### PR TITLE
Fix for app icon problem.

### DIFF
--- a/Source/x11/XGServerWindow.m
+++ b/Source/x11/XGServerWindow.m
@@ -89,6 +89,9 @@ static NSMapTable *windowtags = NULL;
 /* Track used window numbers */
 static int		last_win_num = 0;
 
+@interface NSApplication (Private)
+- (void) _appIconInit;
+@end
 
 @interface NSCursor (BackendPrivate)
 - (void *)_cid;
@@ -2692,12 +2695,19 @@ static BOOL didCreatePixmaps;
   GC pixgc;
   RColor pixelRColor;
   RContext *rcontext;
-
+  NSDictionary *infoDict = nil;
+  NSString *appIconFile = nil;
+  
   NSAssert(!didCreatePixmaps, @"called _createAppIconPixmap twice");
 
   didCreatePixmaps = YES;
-
   image = [NSApp applicationIconImage];
+  if(image == nil)
+    {
+      [NSApp _appIconInit];
+      image = [NSApp applicationIconImage];
+    }
+
   rep = getStandardBitmap(image);
   if (rep == nil)
     return 0;


### PR DESCRIPTION
Please review these changes.  The issue was that when we get the icon we also initialize a window which causes an exception since the backend tries to pull all screens before everything is initialized.   Since all we are after is the icon  so it can be stored I have separated these into separate methods.