### PR TITLE
Font system revamp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ config.cache
 config.make
 back.make
 Source/config.h
+Source/libgnustep*Info.plist
+Tools/XGCommonFont.m
+Tools/xdnd.c

--- a/Headers/fontconfig/FCFaceInfo.h
+++ b/Headers/fontconfig/FCFaceInfo.h
@@ -63,6 +63,8 @@
 - (NSString *) familyName;
 - (void) setFamilyName: (NSString *)name;
 
+- (NSString *) displayName;
+
 - (void *) fontFace;
 - (FcPattern *) matchedPattern;
 

--- a/Source/art/FTFontEnumerator.m
+++ b/Source/art/FTFontEnumerator.m
@@ -245,8 +245,7 @@ static void add_face(NSString *family, int family_weight,
       return;
     }
 
-  fi->displayName = [[family stringByAppendingString: @" "]
-			     stringByAppendingString: faceName];
+  fi->displayName = [[NSString stringWithFormat: @"%@ %@", family, faceName] retain];
 
 
   weight = family_weight;

--- a/Source/art/ftfont.m
+++ b/Source/art/ftfont.m
@@ -352,6 +352,11 @@ static FT_Error ft_get_face(FTC_FaceID fid, FT_Library lib,
   return self;
 }
 
+- (NSString*) displayName
+{
+  return face_info->displayName;
+}
+
 - (void) set
 {
   NSLog(@"ignore -set method of font '%@'", fontName);

--- a/Source/cairo/CairoFontInfo.m
+++ b/Source/cairo/CairoFontInfo.m
@@ -241,6 +241,12 @@ BOOL _cairo_extents_for_NSGlyph(cairo_scaled_font_t *scaled_font, NSGlyph glyph,
   return NSZeroRect;
 }
 
+- (NSString *) displayName
+{
+	return [_faceInfo displayName];
+}
+
+
 - (CGFloat) widthOfString: (NSString *)string
 {
   cairo_text_extents_t ctext;

--- a/Source/fontconfig/FCFaceInfo.m
+++ b/Source/fontconfig/FCFaceInfo.m
@@ -69,13 +69,35 @@
 
 - (NSString *) displayName
 {
-	char	*fcstyle;
+  char *fcname;
 
-	if (FcPatternGetString(_pattern, FC_STYLE, 0, (FcChar8 **)&fcstyle) == FcResultMatch) {
-		return [NSString stringWithFormat: @"%@ %@", _familyName, 
-				[NSString stringWithUTF8String: fcstyle]];
-	}
-	return _familyName;
+#ifdef FC_POSTSCRIPT_NAME
+  char  *fcpsname;
+#endif
+
+  /*
+    If fullname && fullname != psname, use fullname as displayname.
+    This works around some weird Adobe OpenType fonts which contain their
+    PostScript name in their "human-readable name" field.
+
+    So, set the fullname as displayName (now AKA VisibleName) only
+    if it's not the same as whatever the postscript name is.
+  */
+  if (FcPatternGetString(_pattern, FC_FULLNAME, 0, (FcChar8 **)&fcname) == FcResultMatch
+#ifdef FC_POSTSCRIPT_NAME
+      && FcPatternGetString(_pattern, FC_POSTSCRIPT_NAME, 0, (FcChar8 **)&fcpsname) == FcResultMatch
+      && strcmp (fcpsname, fcname)
+#endif
+     )
+    {
+      return [NSString stringWithUTF8String: fcname];
+    }
+  else if (FcPatternGetString(_pattern, FC_STYLE, 0, (FcChar8 **)&fcname) == FcResultMatch)
+    {
+      return [NSString stringWithFormat: @"%@ %@", _familyName,
+              [NSString stringWithUTF8String: fcname]];
+    }
+  return _familyName;
 }
 
 - (int) weight

--- a/Source/fontconfig/FCFaceInfo.m
+++ b/Source/fontconfig/FCFaceInfo.m
@@ -67,6 +67,17 @@
   return _familyName;
 }
 
+- (NSString *) displayName
+{
+	char	*fcstyle;
+
+	if (FcPatternGetString(_pattern, FC_STYLE, 0, (FcChar8 **)&fcstyle) == FcResultMatch) {
+		return [NSString stringWithFormat: @"%@ %@", _familyName, 
+				[NSString stringWithUTF8String: fcstyle]];
+	}
+	return _familyName;
+}
+
 - (int) weight
 {
   return _weight;

--- a/Source/fontconfig/FCFontEnumerator.m
+++ b/Source/fontconfig/FCFontEnumerator.m
@@ -496,7 +496,6 @@ static NSArray *faFromFc(FcPattern *pat)
 @end
 
 
-
 @implementation FontconfigPatternGenerator
 
 - (void)addName: (NSString*)name
@@ -880,7 +879,7 @@ static NSArray *faFromFc(FcPattern *pat)
   int value;
   if (FcResultMatch == FcPatternGetInteger(pat, FC_SLANT, 0, &value))
     {
-      if (value == FC_SLANT_ITALIC)
+      if (value > FC_SLANT_ROMAN)
 	{
 	  symTraits |= NSFontItalicTrait;
 	}

--- a/Source/fontconfig/FCFontEnumerator.m
+++ b/Source/fontconfig/FCFontEnumerator.m
@@ -94,13 +94,26 @@ sortFontFacesArray(id fontArr1, id fontArr2, void *context)
   unsigned int traits2 = [[fontArr2 objectAtIndex: 3] unsignedIntValue];
 
   // order first by weight
-  if (weight1 > weight2)
-    return NSOrderedDescending;
   if (weight1 < weight2)
     return NSOrderedAscending;
-  if (traits1 < traits2)
+  if (weight1 > weight2)
+    return NSOrderedDescending;
+
+  // Italic next
+  if ((traits1 & NSItalicFontMask) < (traits2 & NSItalicFontMask))
     return NSOrderedAscending;
-  if (traits1 > traits2)
+  if ((traits1 & NSItalicFontMask) > (traits2 & NSItalicFontMask))
+    return NSOrderedDescending;
+
+  // now do condensed
+  if ((traits1 & NSCondensedFontMask) < (traits2 & NSCondensedFontMask))
+    return NSOrderedAscending;
+  if ((traits1 & NSCondensedFontMask) > (traits2 & NSCondensedFontMask))
+    return NSOrderedDescending;
+  // ...and expanded
+  if ((traits1 & NSExpandedFontMask) < (traits2 & NSExpandedFontMask))
+    return NSOrderedAscending;
+  if ((traits1 & NSExpandedFontMask) > (traits2 & NSExpandedFontMask))
     return NSOrderedDescending;
 
   // Special case: "Regular" sorts before non-Regular, for many reasons.

--- a/Source/fontconfig/FCFontEnumerator.m
+++ b/Source/fontconfig/FCFontEnumerator.m
@@ -167,6 +167,9 @@ static NSArray *faFromFc(FcPattern *pat)
 #ifdef FC_POSTSCRIPT_NAME
   char *fcname;
 #endif
+#if 0
+  FT_Face ftface = NULL;
+#endif
 
   if (FcPatternGetInteger(pat, FC_WEIGHT, 0, &weight) != FcResultMatch
     || FcPatternGetInteger(pat, FC_SLANT,  0, &slant) != FcResultMatch
@@ -177,6 +180,26 @@ static NSArray *faFromFc(FcPattern *pat)
   if (FcPatternGetInteger(pat, FC_SPACING, 0, &spacing) == FcResultMatch)
     if (spacing==FC_MONO || spacing==FC_CHARCELL)
       nstraits |= NSFixedPitchFontMask;
+
+  /*
+     This code will allow us to access TrueType/OpenType font tables from
+     fontconfig. If we want to implement features like the so-called "OS/2"
+     table which contains typographic family info ("give me a list of 'script'
+     fonts with slab serifs") and stuff like the font's correct typographic
+     line height and its xHeight, this is where we get that info.
+
+     For more information, see http://www.microsoft.com/typography/otspec/
+  */
+#if 0
+  if (FcPatternGetFTFace (pat, FC_FT_FACE, 0, &ftface) == FcResultMatch)
+    {
+      // we got a FreeType face now, mwahaha.
+      TT_Header *head = FT_Get_Sfnt_Table (ftface, FT_SFNT_HEAD);
+      TT_OS2 *os2 = FT_Get_Sfnt_Table (ftface, FT_SFNT_OS2);
+      TT_HoriHeader *hhea = FT_Get_Sfnt_Table (ftface, FT_SFNT_HHEA);
+      TT_Postscript *post = FT_Get_Sfnt_Table (ftface, FT_SFNT_POST);
+    }
+#endif
 
   name = [NSMutableString stringWithCapacity: 100];
 #ifdef FC_POSTSCRIPT_NAME

--- a/Source/fontconfig/FCFontEnumerator.m
+++ b/Source/fontconfig/FCFontEnumerator.m
@@ -619,7 +619,7 @@ static NSArray *faFromFc(FcPattern *pat)
 	}
       if (symTraits & NSFontVerticalTrait)
 	{
-	  // FIXME: What is this supposed to mean?
+	  // Fontconfig can't express this (it means sideways letters)
 	}
       if (symTraits & NSFontUIOptimizedTrait)
 	{
@@ -835,20 +835,27 @@ static NSArray *faFromFc(FcPattern *pat)
 
 - (NSString*)readNameFromPattern: (FcPattern*)pat
 {
-  // FIXME: Hack which generates a PostScript-style name from the
-  // family name and style
-
+#ifdef FC_POSTSCRIPT_NAME
+  NSString *name = [self readFontconfigString: FC_POSTSCRIPT_NAME fromPattern: pat];
+#endif
   NSString *family = [self readFontconfigString: FC_FAMILY fromPattern: pat];
   NSString *style = [self readFontconfigString: FC_STYLE fromPattern: pat];
-  if (style)
-    {
-      return [NSString stringWithFormat: @"%@-%@", family, style];
-    }
+
+#ifdef FC_POSTSCRIPT_NAME
+  if (name)
+    return name;
   else
-    {
-      return family;
-    }
+#endif
+    if (style)
+      {
+        return [NSString stringWithFormat: @"%@-%@", family, style];
+      }
+    else
+      {
+        return family;
+      }
 }
+
 - (NSString*)readVisibleNameFromPattern: (FcPattern*)pat
 {
   // FIXME: try to get the localized one

--- a/Source/fontconfig/FCFontInfo.m
+++ b/Source/fontconfig/FCFontInfo.m
@@ -149,6 +149,11 @@
   return NSZeroRect;
 }
 
+- (NSString *) displayName
+{
+  return [_faceInfo displayName];
+}
+
 - (CGFloat) widthOfString: (NSString *)string
 {
   [self subclassResponsibility: _cmd];


### PR DESCRIPTION
This is a semi-comprehensive revamp of the font system in use with the Cairo backend.

I have implemented support for Fontconfig 2.11's unique PostScript font descriptors, which prevents synthesized font names from causing fonts to "shadow" each other. For people with very old versions of fontconfig, I have added many new rules for synthesizing new font descriptors, which should limit that shadowing effect drastically, as well as made use of each font's human-readable name to improve the user interface (and make shadowing even less likely).

I have also introduced sorting for the font list, which causes the faces within a font to become sorted by weight and traits, so that the user-visible list now has a discernible pattern to it that it lacked before.

I have used Cairo's and Fontconfig's support for the FreeType library to access encoding information and PostScript glyph tables to enable -glyphIsEncoded: and -glyphWithName: to finally work, which enables things like ligatures and (eventually) complex glyph substitutions.

I have also included some stubbed-out code which enables the fetching of TrueType SFNT tables, which are the things that actually provide glyph substitution as well as all of the basic typographic metric data we can use to find any font's true typographic baseline, xHeight, and glyph extents.

And finally, for my own purposes, I turned on subpixel rendering and hinting in a user-controllable way.

Fred asked me to put this together some time ago, but I have been busy and hadn't gotten around to it. Sorry. :)