### PR TITLE
Handle `-autolaunch YES` application argument

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2019-04-02  Sergii Stoian  <stoyan255@gmail.com>
+
+	* Source/x11/XGServerWindow.m:
+	(orderwindow:::) Map application icon window without focus flickering
+	for applications executed with argument `-autolaunch YES` in WindowMaker
+	environment.
+
 2019-03-26 Sergii Stoian <stoyan255@gmail.com>
 	* Source/x11/XGServerWindow.m:
 	(setwindowlevel::) Set `Utility` window type for NSFloatingWindowLevel.

--- a/Headers/x11/XGGeneric.h
+++ b/Headers/x11/XGGeneric.h
@@ -108,7 +108,8 @@ static char *atom_names[] = {
   "_GNUSTEP_WM_MINIATURIZE_WINDOW",
   "_GNUSTEP_WM_ATTR",
   "_GNUSTEP_TITLEBAR_STATE",
-  "_GNUSTEP_FRAME_OFFSETS"
+  "_GNUSTEP_FRAME_OFFSETS",
+  "WM_IGNORE_FOCUS_EVENTS"
  };
 
 /*
@@ -181,6 +182,7 @@ static char *atom_names[] = {
 #define _GNUSTEP_WM_ATTR_ATOM                  atoms[64]
 #define _GNUSTEP_TITLEBAR_STATE_ATOM           atoms[65]
 #define _GNUSTEP_FRAME_OFFSETS_ATOM            atoms[66]
+#define WM_IGNORE_FOCUS_EVENTS_ATOM            atoms[67]
 
 /*
  * Frame offsets for window inside parent decoration window.

--- a/Source/x11/XGServerWindow.m
+++ b/Source/x11/XGServerWindow.m
@@ -2821,15 +2821,15 @@ static BOOL didCreatePixmaps;
  	    {
               XEvent ev;
 
-              // Inform WM to ignore focus events
+              // Inform WindowMaker to ignore focus events
               ev.xclient.type = ClientMessage;
-              ev.xclient.message_type = XInternAtom(dpy,"WM_IGNORE_FOCUS_EVENTS", False);
+              ev.xclient.message_type = generic.WM_IGNORE_FOCUS_EVENTS_ATOM;
               ev.xclient.format = 32;
               ev.xclient.data.l[0] = True;
               XSendEvent(dpy, ROOT, True, EnterWindowMask, &ev);
               // Display application icon
               XMapWindow(dpy, ROOT);
-              // Inform WM to process focus events again
+              // Inform WindowMaker to process focus events again
               ev.xclient.data.l[0] = False;
               XSendEvent(dpy, ROOT, True, EnterWindowMask, &ev);
             }

--- a/Source/x11/XGServerWindow.m
+++ b/Source/x11/XGServerWindow.m
@@ -2815,6 +2815,24 @@ static BOOL didCreatePixmaps;
        */
       if ((window->win_attrs.window_style & NSIconWindowMask) != 0)
 	{
+          NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+          if (op != NSWindowOut && window->map_state == IsUnmapped &&
+              [[defaults objectForKey: @"autolaunch"] isEqualToString:@"YES"])
+ 	    {
+              XEvent ev;
+
+              // Inform WM to ignore focus events
+              ev.xclient.type = ClientMessage;
+              ev.xclient.message_type = XInternAtom(dpy,"WM_IGNORE_FOCUS_EVENTS", False);
+              ev.xclient.format = 32;
+              ev.xclient.data.l[0] = True;
+              XSendEvent(dpy, ROOT, True, EnterWindowMask, &ev);
+              // Display application icon
+              XMapWindow(dpy, ROOT);
+              // Inform WM to process focus events again
+              ev.xclient.data.l[0] = False;
+              XSendEvent(dpy, ROOT, True, EnterWindowMask, &ev);
+            }
 	  return;
 	}
       if ((window->win_attrs.window_style & NSMiniWindowMask) != 0)


### PR DESCRIPTION
Map application icon window without focus switch for applications executed with argument `-autolaunch YES` in WindowMaker environment.