### PR TITLE
Send double-click on appicon to WindowMaker

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2019-04-04  Sergii Stoian  <stoyan255@ukr.net>
+
+	* Source/x11/XGServerEvent.m (processEvent:):
+	Send double-click on appicon to the WindowMaker.
+
 2019-04-02  Sergii Stoian  <stoyan255@gmail.com>
 
 	* Source/x11/XGServerWindow.m:

--- a/Source/x11/XGServerEvent.m
+++ b/Source/x11/XGServerEvent.m
@@ -472,10 +472,10 @@ posixFileDescriptor: (NSPosixFileDescriptor*)fileDescriptor
             /*
              * We must hand over control of our icon/miniwindow
              * to Window Maker.
-                 */
+             */
             if ((cWin->win_attrs.window_style
-              & (NSMiniWindowMask | NSIconWindowMask)) != 0
-              && eventType == NSLeftMouseDown && clickCount == 1)
+                 & (NSMiniWindowMask | NSIconWindowMask)) != 0
+                && eventType == NSLeftMouseDown)
               {
                 if (cWin->parent == None)
                   break;
@@ -484,7 +484,8 @@ posixFileDescriptor: (NSPosixFileDescriptor*)fileDescriptor
                 XSendEvent(dpy, cWin->parent, True,
                            ButtonPressMask, &xEvent);
                 XFlush(dpy);
-                break;
+                if (clickCount != 2)
+                  break;
               }
           }
 

--- a/Source/x11/XGServerEvent.m
+++ b/Source/x11/XGServerEvent.m
@@ -484,7 +484,7 @@ posixFileDescriptor: (NSPosixFileDescriptor*)fileDescriptor
                 XSendEvent(dpy, cWin->parent, True,
                            ButtonPressMask, &xEvent);
                 XFlush(dpy);
-                if (clickCount != 2)
+                if (clickCount == 1)
                   break;
               }
           }


### PR DESCRIPTION
 Old code sent to WM only single-click. 
Receiving double-click on GNUstep appicons allows WindowMaker to perform its own focus change related actions.