### PR TITLE
Support for configurable mouse properties

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2019-04-12  Sergii Stoian  <stoyan255@gmail.com>
+
+	* Source/x11/XGServerEvent.m (mouseOptionsChanged:): change double-click
+	minimum value to 200 and default to 300.
+
 2019-04-11  Sergii Stoian  <stoyan255@gmail.com>
 
 	* Source/x11/XGServerEvent.m (processEvent:): do not send event if

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2019-04-11  Sergii Stoian  <stoyan255@ukr.net>
+
+	* Source/x11/XGServerEvent.m (initializeMouse): new method. Calls -mouseOptionsChanged:
+	and setups observer for defaults changes.
+	(mouseOptionsChanged:): new method. Read mouse properties from user defaults.
+	(processEvent:): respect mouse options on ButtonPress and ButtonRelease events.
+
+	* Source/x11/XGServer.m (dealloc): remove notification observer.
+
 2019-04-06  Sergii Stoian  <stoyan255@ukr.net>
 
 	* Source/x11/XGServerWindow.m (hideApplication:): new method name for

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,9 +1,16 @@
+2019-04-11  Sergii Stoian  <stoyan255@gmail.com>
+
+	* Source/x11/XGServerEvent.m (processEvent:): do not send event if
+	disabled menu mouse button was released.
+
 2019-04-11  Sergii Stoian  <stoyan255@ukr.net>
 
-	* Source/x11/XGServerEvent.m (initializeMouse): new method. Calls -mouseOptionsChanged:
-	and setups observer for defaults changes.
-	(mouseOptionsChanged:): new method. Read mouse properties from user defaults.
-	(processEvent:): respect mouse options on ButtonPress and ButtonRelease events.
+	* Source/x11/XGServerEvent.m (initializeMouse): new method. Calls
+	-mouseOptionsChanged: and setups observer for defaults changes.
+	(mouseOptionsChanged:): new method. Read mouse properties from user
+	defaults.
+	(processEvent:): respect mouse options on ButtonPress and
+	ButtonRelease events.
 
 	* Source/x11/XGServer.m (dealloc): remove notification observer.
 

--- a/Source/x11/XGServer.m
+++ b/Source/x11/XGServer.m
@@ -40,6 +40,7 @@
 #include <Foundation/NSString.h>
 #include <Foundation/NSUserDefaults.h>
 #include <Foundation/NSDebug.h>
+#include <Foundation/NSDistributedNotificationCenter.h>
 
 #include <signal.h>
 /* Terminate cleanly if we get a signal to do so */
@@ -489,6 +490,7 @@ _parse_display_name(NSString *name, int *dn, int *sn)
 - (void) dealloc
 {
   NSDebugLog(@"Destroying X11 Server");
+  [[NSDistributedNotificationCenter defaultCenter] removeObserver:self];
   DESTROY(inputServer);
   [self _destroyServerWindows];
   NSFreeMapTable(screenList);

--- a/Source/x11/XGServerEvent.m
+++ b/Source/x11/XGServerEvent.m
@@ -354,8 +354,8 @@ posixFileDescriptor: (NSPosixFileDescriptor*)fileDescriptor
   NSUserDefaults *defs = [NSUserDefaults standardUserDefaults];
 
   clickTime = [defs integerForKey:@"GSDoubleClickTime"];
-  if (clickTime < 250)
-    clickTime = 250;
+  if (clickTime < 200)
+    clickTime = 300;
   
   clickMove = [defs integerForKey:@"GSMouseMoveThreshold"];
   if (clickMove < 3)

--- a/Source/x11/XGServerEvent.m
+++ b/Source/x11/XGServerEvent.m
@@ -476,7 +476,7 @@ posixFileDescriptor: (NSPosixFileDescriptor*)fileDescriptor
               }
           }
         else if (xEvent.xbutton.button == generic.rMouse
-          && generic.rMouse != 0)
+                 && generic.rMouse != 0)
           {
             if (swapMouseButtons)
               {
@@ -490,34 +490,34 @@ posixFileDescriptor: (NSPosixFileDescriptor*)fileDescriptor
               }
           }
         else if (xEvent.xbutton.button == generic.mMouse
-          && generic.mMouse != 0)
+                 && generic.mMouse != 0)
           {
             eventType = NSOtherMouseDown;
             buttonNumber = generic.mMouse;
           }
         else if (xEvent.xbutton.button == generic.upMouse
-          && generic.upMouse != 0)
+                 && generic.upMouse != 0)
           {
             deltaY = 1. * mouseScrollMultiplier;
             eventType = NSScrollWheel;
             buttonNumber = generic.upMouse;
           }
         else if (xEvent.xbutton.button == generic.downMouse
-          && generic.downMouse != 0)
+                 && generic.downMouse != 0)
           {
             deltaY = -1. * mouseScrollMultiplier;
             eventType = NSScrollWheel;
             buttonNumber = generic.downMouse;
           }
         else if (xEvent.xbutton.button == generic.scrollLeftMouse
-          && generic.scrollLeftMouse != 0)
+                 && generic.scrollLeftMouse != 0)
           {
             deltaX = -1. * mouseScrollMultiplier;
             eventType = NSScrollWheel;
             buttonNumber = generic.scrollLeftMouse;
           }
         else if (xEvent.xbutton.button == generic.scrollRightMouse
-          && generic.scrollRightMouse != 0)
+                 && generic.scrollRightMouse != 0)
           {
             deltaX = 1. * mouseScrollMultiplier;
             eventType = NSScrollWheel;
@@ -599,7 +599,7 @@ posixFileDescriptor: (NSPosixFileDescriptor*)fileDescriptor
               }
           }
         else if (xEvent.xbutton.button == generic.rMouse
-          && generic.rMouse != 0)
+                 && generic.rMouse != 0)
           {
             if (swapMouseButtons)
               {
@@ -613,7 +613,7 @@ posixFileDescriptor: (NSPosixFileDescriptor*)fileDescriptor
               }
           }
         else if (xEvent.xbutton.button == generic.mMouse
-          && generic.mMouse != 0)
+                 && generic.mMouse != 0)
           {
             eventType = NSOtherMouseUp;
             buttonNumber = generic.mMouse;
@@ -623,6 +623,9 @@ posixFileDescriptor: (NSPosixFileDescriptor*)fileDescriptor
             // we ignore release of scrollUp or scrollDown
             break;                /* Unknown button */
           }
+        
+        if (menuButtonEnabled == NO && eventType == menuMouseButton)
+          break; // disabled menu button was released
 
         eventFlags = process_modifier_flags(xEvent.xbutton.state);
         // if pointer is grabbed use grab window


### PR DESCRIPTION
Double-click time, move threshold, scroll wheel multiplier, menu button configuration: enable/disable, left/right.

Things which are need to be done in GUI:
- NSUserDefaults should send notification to NSDistributedNotificationCenter on defaults change. This will allow all running applications adjust mouse properties on the fly.
- NSScrollView (NSScroller) should respect "GSMouseScrollMultiplier" value.