### PR TITLE
Mouse cursor images handling fix and cleanup

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2019-04-18  Sergii Stoian  <stoyan255@gmail.com>
+
+	* Source/x11/XGServerWindow.m (standardcursor::): revert resizing
+	cursor names to the old values upon request of project owner.
+
 2019-04-17  Sergii Stoian  <stoyan255@gmail.com>
 
 	* Source/x11/XGServerWindow.m (getStandardBitmap): send `bitmapFormat`

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2019-04-17  Sergii Stoian  <stoyan255@gmail.com>
+
+	* Source/x11/XGServerWindow.m (getStandardBitmap): send `bitmapFormat`
+	to _convertToFormatBitsPerSample::::::::. Fixes display of colored
+	mouse cursor images.
+	(standardcursor::): cleanup in Xlib cursors handling. Additional
+	cursor types were added: GSClosedHandCursor, GSOpenHandCursor.
+	Removed GSDisappearingItemCursor type handling - it loads in NSCursor
+	from image.
+
 2019-04-12  Sergii Stoian  <stoyan255@gmail.com>
 
 	* Source/x11/XGServerEvent.m (mouseOptionsChanged:): change double-click

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2019-04-20  Sergii Stoian  <stoyan255@ukr.net>
+
+	* Source/x11/XGServerWindow.m (standardcursor::): Getting of
+	XC_fleur as GSCloseHandCursor was removed because it loads in
+	NSCursor as image.
+
 2019-04-18  Sergii Stoian  <stoyan255@gmail.com>
 
 	* Source/x11/XGServerWindow.m (standardcursor::): revert resizing

--- a/Source/x11/XGServerWindow.m
+++ b/Source/x11/XGServerWindow.m
@@ -4177,9 +4177,6 @@ xgps_cursor_image(Display *xdpy, Drawable draw, const unsigned char *data,
     case GSIBeamCursor:
       cursor = XCreateFontCursor(dpy, XC_xterm);
       break;
-    case GSClosedHandCursor:
-      cursor = XCreateFontCursor(dpy, XC_fleur);
-      break;
     case GSOpenHandCursor:
       cursor = XCreateFontCursor(dpy, XC_hand1);
       break;

--- a/Source/x11/XGServerWindow.m
+++ b/Source/x11/XGServerWindow.m
@@ -142,7 +142,7 @@ static NSBitmapImageRep *getStandardBitmap(NSImage *image)
                                        hasAlpha: [rep hasAlpha]
                                        isPlanar: NO
                                  colorSpaceName: NSCalibratedRGBColorSpace
-                                   bitmapFormat: 0
+                                   bitmapFormat: [rep bitmapFormat]
                                     bytesPerRow: 0
                                    bitsPerPixel: 0];
     }
@@ -4177,29 +4177,32 @@ xgps_cursor_image(Display *xdpy, Drawable draw, const unsigned char *data,
     case GSIBeamCursor:
       cursor = XCreateFontCursor(dpy, XC_xterm);
       break;
+    case GSClosedHandCursor:
+      cursor = XCreateFontCursor(dpy, XC_fleur);
+      break;
+    case GSOpenHandCursor:
+      cursor = XCreateFontCursor(dpy, XC_hand1);
+      break;
+    case GSPointingHandCursor:
+      cursor = XCreateFontCursor(dpy, XC_hand2);
+      break;
     case GSCrosshairCursor:
       cursor = XCreateFontCursor(dpy, XC_crosshair);
       break;
-    case GSDisappearingItemCursor:
-      cursor = XCreateFontCursor(dpy, XC_shuttle);
-      break;
-    case GSPointingHandCursor:
-      cursor = XCreateFontCursor(dpy, XC_hand1);
-      break;
     case GSResizeDownCursor:
-      cursor = XCreateFontCursor(dpy, XC_bottom_side);
+      cursor = XCreateFontCursor(dpy, XC_sb_down_arrow);
       break;
     case GSResizeLeftCursor:
-      cursor = XCreateFontCursor(dpy, XC_left_side);
+      cursor = XCreateFontCursor(dpy, XC_sb_left_arrow);
       break;
     case GSResizeLeftRightCursor:
       cursor = XCreateFontCursor(dpy, XC_sb_h_double_arrow);
       break;
     case GSResizeRightCursor:
-      cursor = XCreateFontCursor(dpy, XC_right_side);
+      cursor = XCreateFontCursor(dpy, XC_sb_right_arrow);
       break;
     case GSResizeUpCursor:
-      cursor = XCreateFontCursor(dpy, XC_top_side);
+      cursor = XCreateFontCursor(dpy, XC_sb_up_arrow);
       break;
     case GSResizeUpDownCursor:
       cursor = XCreateFontCursor(dpy, XC_sb_v_double_arrow);

--- a/Source/x11/XGServerWindow.m
+++ b/Source/x11/XGServerWindow.m
@@ -4190,19 +4190,19 @@ xgps_cursor_image(Display *xdpy, Drawable draw, const unsigned char *data,
       cursor = XCreateFontCursor(dpy, XC_crosshair);
       break;
     case GSResizeDownCursor:
-      cursor = XCreateFontCursor(dpy, XC_sb_down_arrow);
+      cursor = XCreateFontCursor(dpy, XC_bottom_side);
       break;
     case GSResizeLeftCursor:
-      cursor = XCreateFontCursor(dpy, XC_sb_left_arrow);
+      cursor = XCreateFontCursor(dpy, XC_left_side);
       break;
     case GSResizeLeftRightCursor:
       cursor = XCreateFontCursor(dpy, XC_sb_h_double_arrow);
       break;
     case GSResizeRightCursor:
-      cursor = XCreateFontCursor(dpy, XC_sb_right_arrow);
+      cursor = XCreateFontCursor(dpy, XC_right_side);
       break;
     case GSResizeUpCursor:
-      cursor = XCreateFontCursor(dpy, XC_sb_up_arrow);
+      cursor = XCreateFontCursor(dpy, XC_top_side);
       break;
     case GSResizeUpDownCursor:
       cursor = XCreateFontCursor(dpy, XC_sb_v_double_arrow);


### PR DESCRIPTION
Fix for displaying of colored mouse cursor images.
Cleanup in Xlib cursor images loading - do not load cursors which handled by NSCursor.
Complementary to https://github.com/gnustep/libs-gui/pull/30.