### PR TITLE
Correct application icon images in WM

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,25 @@
+2020-01-13  Sergii Stoian  <stoyan255@gmail.com>
+
+	* Source/x11/XGServerWindow.m (_createNetIcon:result:size:): fixed
+	off-by-one mistake during alpha handling. Enable disabled code and
+	remove temprorary one.
+	(window::::): set NetWM icon to window for all EWMH capable WMs even
+	it's WindowMaker.
+	(image_mask): new function to create alpha mask for image. It's based
+	on xgps_cursor_mask() code with additional argument `alpha_treshold`.
+	This function may be used for images (alpha_treshold == 0) with real
+	alpha mask and for cursors (if no Xcursor library is used - no alpha
+	is used, no shadows in cursors, alpha_treshold == 158 is used to cut
+	transparent pixels).
+	(_createAppIconPixmaps): icon pixmap creation rewritten to support
+	images with alpha channel using wraster functions. Use image_mask().
+	(restrictWindow:toImage:): use image_mask() instead of
+	xgps_cursor_mask().
+	(xgps_cursor_mask): removed as image_mask() replaced it.
+	Guard xgps_cursor_image( with #if - will not be compiled if Xcursor
+	is used.
+	(imagecursor:::): use image_mask() instead of xgps_cursor_mask().
+
 2019-12-24 Fred Kiefer <FredKiefer@gmx.de>
 
 	* Source/cairo/CairoFontInfo.m: Revert to the old defaults for

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,7 @@
 	(_createAppIconPixmaps): use swapColors() and remove unused code.
 	(restrictWindow:toImage:): use alphaMaskForImage().
 	(imagecursor:::): use swapColors() and remove unused code.
+	(ALPHA_THRESHOLD): removed duplicate of definition.
 
 2020-01-13  Sergii Stoian  <stoyan255@gmail.com>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2020-01-14  Sergii Stoian  <stoyan255@gmail.com>
+
+	* Source/x11/XGServerWindow.m (alphaMaskForImage): renamed from
+	image_mask().
+	(swapColors): new function to convert colors from ARGB order into RGBA
+	(big-endian systems) or BGRA (little-endian systems).
+	(_createAppIconPixmaps): use swapColors() and remove unused code.
+	(restrictWindow:toImage:): use alphaMaskForImage().
+	(imagecursor:::): use swapColors() and remove unused code.
+
 2020-01-13  Sergii Stoian  <stoyan255@gmail.com>
 
 	* Source/x11/XGServerWindow.m (_createNetIcon:result:size:): fixed

--- a/Source/x11/XGServerWindow.m
+++ b/Source/x11/XGServerWindow.m
@@ -4297,7 +4297,7 @@ xgps_cursor_image(Display *xdpy, Drawable draw, const unsigned char *data,
       h = maxh;
 
     source = xgps_cursor_image(dpy, ROOT, data, w, h, colors, &fg, &bg);
-    mask = image_mask(dpy, ROOT, data, w, h, colors, ALPHA_TRESHOLD);
+    mask = alphaMaskForImage(dpy, ROOT, data, w, h, colors, ALPHA_TRESHOLD);
     bg = [self xColorFromColor: bg forScreen: defScreen];
     fg = [self xColorFromColor: fg forScreen: defScreen];
 

--- a/Source/x11/XGServerWindow.m
+++ b/Source/x11/XGServerWindow.m
@@ -2742,7 +2742,7 @@ alphaMaskForImage(Display *xdpy, Drawable draw, const unsigned char *data,
 
 // Convert RGBA unpacked to ARGB packed.
 // Packed ARGB values are layed out as ARGB on big endian systems
-// and as BGRA on low endian systems
+// and as BGRA on little endian systems
 void
 swapColors(unsigned char *image_data, int width, int height,
            int samples_per_pixel, int bytes_per_row)
@@ -4076,8 +4076,6 @@ static BOOL   cursor_hidden = NO;
 }
 
 #if !HAVE_XCURSOR
-
-#define ALPHA_THRESHOLD 158
 
 Pixmap
 xgps_cursor_image(Display *xdpy, Drawable draw, const unsigned char *data,


### PR DESCRIPTION
If application icon placed into WM_HINTS properties of window (at least for WindowMaker) alpha channel in image missed and icon in Dock looks weird. For example look into [issue #227](https://github.com/trunkmaster/nextspace/issues/227) in NextSpace.