### PR TITLE
TakeFocus request handling fix

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2020-01-16  Sergii Stoian  <stoyan255@gmail.com>
+
+	* Source/x11/XGServerEvent.m (_handleTakeFocusAtom:forContext:): use
+	lowerCamelCase for objects and underscores for primitive types;
+	Added and used `this_window` variable - represents window that has
+	received TakeFocus event - instead of `cWin` (last used window by
+	backend); do not ignore TakeFocus request if now key window was set
+	and if main application menu received request.
+
 2020-01-14  Sergii Stoian  <stoyan255@gmail.com>
 
 	* Source/x11/XGServerWindow.m (alphaMaskForImage): renamed from

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,10 +2,8 @@
 
 	* Source/x11/XGServerEvent.m (_handleTakeFocusAtom:forContext:): use
 	lowerCamelCase for objects and underscores for primitive types;
-	Added and used `this_window` variable - represents window that has
-	received TakeFocus event - instead of `cWin` (last used window by
-	backend); do not ignore TakeFocus request if now key window was set
-	and if main application menu received request.
+	do not ignore TakeFocus request if no key window was set
+	and main application menu receives request.
 
 2020-01-14  Sergii Stoian  <stoyan255@gmail.com>
 

--- a/Source/x11/XGServerEvent.m
+++ b/Source/x11/XGServerEvent.m
@@ -1911,14 +1911,9 @@ posixFileDescriptor: (NSPosixFileDescriptor*)fileDescriptor
 - (NSEvent *)_handleTakeFocusAtom: (XEvent)xEvent 
                        forContext: (NSGraphicsContext *)gcontext
 {
-  int key_num;
-  NSWindow *keyWindow;
+  NSWindow *keyWindow = [NSApp keyWindow];
+  int key_num = [keyWindow windowNumber];
   NSEvent *e = nil;
-  gswindow_device_t *key_window;
-  
-  keyWindow = [NSApp keyWindow];
-  key_num = [keyWindow windowNumber];
-  key_window = [XGServer _windowWithTag:key_num];
   
   NSDebugLLog(@"Focus",
               @"TakeFocus received by: %li (%lu) (focused = %lu, key = %d)",
@@ -1968,9 +1963,10 @@ posixFileDescriptor: (NSPosixFileDescriptor*)fileDescriptor
       NSDebugLLog(@"Focus", @"Reasserting key window");
       [GSServerForWindow(keyWindow) setinputfocus: key_num];
     }
-  else if (key_num
+  else if (key_num 
            && cWin->number == [[[NSApp mainMenu] window] windowNumber])
     {
+      gswindow_device_t *key_window = [XGServer _windowWithTag:key_num];
       /* This might occur when the window manager just wants someone
          to become key, so it tells the main menu (typically the first
          menu in the list), but since we already have a window that

--- a/Source/x11/XGServerEvent.m
+++ b/Source/x11/XGServerEvent.m
@@ -1912,20 +1912,21 @@ posixFileDescriptor: (NSPosixFileDescriptor*)fileDescriptor
                        forContext: (NSGraphicsContext *)gcontext
 {
   int key_num;
-  NSWindow *key_win;
+  NSWindow *keyWindow;
   NSEvent *e = nil;
-  key_win = [NSApp keyWindow];
-  key_num = [key_win windowNumber];
-  NSDebugLLog(@"Focus", @"take focus:%lu (current=%lu key=%d)",
-              cWin->number, generic.currentFocusWindow, key_num);
-
-  /* Sometimes window managers lose the setinputfocus on the key window
-   * e.g. when ordering out a window with focus then ordering in the key window.   
-   * it might search for a window until one accepts its take focus request.
-   */
-  if (key_num == cWin->number)
-    cWin->ignore_take_focus = NO;
+  gswindow_device_t *this_window;
+  gswindow_device_t *key_window;
   
+  keyWindow = [NSApp keyWindow];
+  key_num = [keyWindow windowNumber];
+  key_window = [XGServer _windowWithTag:key_num];
+  this_window = [XGServer _windowForXWindow:xEvent.xfocus.window];
+  
+  NSDebugLLog(@"Focus",
+              @"TakeFocus received by: %li (%lu) (focused = %lu, key = %d, cWin = %lu)",
+              this_window->number, xEvent.xfocus.window,
+              generic.currentFocusWindow, key_num, cWin->number);
+
   /* Invalidate the previous request. It's possible the app lost focus
      before this request was fufilled and we are being focused again,
      or ??? */
@@ -1933,6 +1934,20 @@ posixFileDescriptor: (NSPosixFileDescriptor*)fileDescriptor
     generic.focusRequestNumber = 0;
     generic.desiredFocusWindow = 0;
   }
+  
+  /* Sometimes window managers lose the setinputfocus on the key window
+   * e.g. when ordering out a window with focus then ordering in the key window.   
+   * it might search for a window until one accepts its take focus request.
+   */
+  if (key_num == 0)
+    {
+      this_window->ignore_take_focus = NO;
+    }
+  else if (this_window->number == [[[NSApp mainMenu] window] windowNumber])
+    {
+      this_window->ignore_take_focus = NO;
+    }
+
   /* We'd like to send this event directly to the front-end to handle,
      but the front-end polls events so slowly compared the speed at
      which X events could potentially come that we could easily get
@@ -1945,31 +1960,38 @@ posixFileDescriptor: (NSPosixFileDescriptor*)fileDescriptor
          window to take focus after each one gets hidden. */
       NSDebugLLog(@"Focus", @"WM take focus while hiding");
     }
-  else if (cWin->ignore_take_focus == YES)
+  else if (this_window->ignore_take_focus == YES)
     {
       NSDebugLLog(@"Focus", @"Ignoring window focus request");
-      cWin->ignore_take_focus = NO;
+      this_window->ignore_take_focus = NO;
     }
-  else if (cWin->number == key_num)
+  else if (this_window->number == key_num)
     {
       NSDebugLLog(@"Focus", @"Reasserting key window");
-      [GSServerForWindow(key_win) setinputfocus: key_num];
+      [GSServerForWindow(keyWindow) setinputfocus: key_num];
     }
-  else if (key_num 
-           && cWin->number == [[[NSApp mainMenu] window] windowNumber])
+  else if (key_num &&
+           this_window->number == [[[NSApp mainMenu] window] windowNumber])
     {
       /* This might occur when the window manager just wants someone
          to become key, so it tells the main menu (typically the first
          menu in the list), but since we already have a window that
          was key before, use that instead */
       NSDebugLLog(@"Focus", @"Key window is already %d", key_num);
-      [GSServerForWindow(key_win) setinputfocus: key_num];
+      if (key_window->map_state == IsUnmapped) {
+        /* `key_window` was unmapped by window manager. 
+           `this_window` and `key_window` are on the different workspace. */
+        [GSServerForWindow(keyWindow) setinputfocus: this_window->number];
+      }
+      else {
+        [GSServerForWindow(keyWindow) setinputfocus: key_num];
+      }
     }
   else
     {
       NSPoint eventLocation;
       /*
-       * Here the app asked for this (if key_win==nil) or there was a
+       * Here the app asked for this (if keyWindow==nil) or there was a
        * click on the title bar or some other reason (window mapped,
        * etc). We don't necessarily want to forward the event for the
        * last reason but we just have to deal with that since we can
@@ -1980,7 +2002,7 @@ posixFileDescriptor: (NSPosixFileDescriptor*)fileDescriptor
                    location: eventLocation
                    modifierFlags: 0
                    timestamp: 0
-                   windowNumber: cWin->number
+                   windowNumber: this_window->number
                    context: gcontext
                    subtype: GSAppKitWindowFocusIn
                    data1: 0

--- a/Source/x11/XGServerEvent.m
+++ b/Source/x11/XGServerEvent.m
@@ -1968,8 +1968,8 @@ posixFileDescriptor: (NSPosixFileDescriptor*)fileDescriptor
       NSDebugLLog(@"Focus", @"Reasserting key window");
       [GSServerForWindow(keyWindow) setinputfocus: key_num];
     }
-  else if (key_num &&
-           cWin->number == [[[NSApp mainMenu] window] windowNumber])
+  else if (key_num
+           && cWin->number == [[[NSApp mainMenu] window] windowNumber])
     {
       /* This might occur when the window manager just wants someone
          to become key, so it tells the main menu (typically the first


### PR DESCRIPTION
This fix primary goal is to manage the following case:
- user opens application on workspace0 with some window (say Terminal);
- user switched to workspace1;
- user activates Terminal by double-clicking on appicon;
- Terminal main menu will be shown, but input focus was left on Terminal window left on workspace0.

Also, I think I've made _handleTakeFocusAtom:forContext: more correct and maintainable due to the usage of window that receives TakeFocus request instead of last window used by application.