### PR TITLE
Screens handling with RandR fixes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-2020-01-26  Sergii Stoian  <stoyan255@gmail.com>
+2020-01-30  Sergii Stoian  <stoyan255@gmail.com>
 
 	* Headers/x11/XGServer.h: new structure `MonitorDevice` and ivar
 	`monitors`for holding cache of monitor's parameters (depth, resolution,

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,74 @@
+2020-02-03  Sergii Stoian  <stoyan255@gmail.com>
+
+	* Source/x11/XWindowBuffer.m (windowBufferForWindow:depthInfo:): use
+	renamed	XGServer's `screenVisual` and `screenDepth` methods.
+
+	* Source/x11/XIMInputServer.m (initWithDelegate:name:):
+	use `+xDisplay` instead	of `xCurrentDisplay`. 
+	(clientWindowRect:): ditto.
+
+	* Headers/x11/XGServerWindow.h (_gswindow_device_t):
+	renamed `screen` to `screen_id`. `monitor_id` element was added -
+	this is an index of element in MonitorDevice array.
+	* Source/x11/XGServerWindow.m:
+	Removed `screen` parameter from methods which contains it in name.
+	Methods were renamed to remove `Screen` and `FromScreen`.
+	(_OSFrameToXFrame:for:): use `monitor_id` instead of `screen`.
+	(_OSFrameToXHints:for:): ditto.
+	(_XFrameToOSFrame:for:): ditto.
+	(_checkStyle:): use renamed methods and `screen_id` window structure
+	element.
+	(_rootWindow): renamed from _rootWindowForScreen:, use `defScreen`
+	instead of removed parameter `screen`, set window structure element
+	`monitor_id` to 0.
+	(_createBuffer:): use `screen_id` window structure.
+	(window::::): use renamed methods, `defScreen`, `screen_id` and
+	`monitor_id` window scructure elements.
+	(nativeWindow:::::): ditto.
+	(setbackgroundcolor::): ditto.
+	(miniwindow:): ditto.
+	(_createAppIconPixmaps): removed unused `screen` local variable, use
+	renamed `screenRContext` method.
+	(orderwindow:::): use `screen_id` window structure element.
+	(movewindow::): use `screen_id` window structure element as a parameter
+	to `boundsForScreen`.
+	(windowbounds:): ditto.
+	(windowlist): use renamed `_rootWindow` method.
+	(setMouseLocation:onScreen:): user renamed methods.
+	(_blankCursor): ditto.
+	(imagecursor:::): ditto
+	(recolorcursor:::): ditto.
+	(screenList): change with assumption that Xlib screen is one per application.
+	Failback code to RandR-related always creates arrays with one element (no
+	enumeration needed). Create `monitor` structure in failback (non-RandR) code.
+	Use `screen_id` MonitorDevice structure element to hold	Xlib screen ID.
+	(windowDepthForScreen:): assume that `screen` parameter is a Xlib screen ID,
+	simplify code - `screen` will be used with RandR or not.
+	(availableDepthsForScreen:): changed with assumption that `screen` is a index
+	of element in `monitors` structure.
+
+	* Source/x11/XGServerEvent.m:
+	use renamed methods and `screen_id` window structure element.
+
+	* Headers/x11/XGServer.h
+	Removed `screen` parameter from methods which contains it in name.
+	Methods were renamed to remove `Screen` and `FromScreen`.
+	(MonitorDevice): `screen_id` was added.
+
+	* Source/x11/XGServer.m:
+	use `screen_id` and rename mathods according to XGServer,h.
+	(_initXContext): initialize `monitors` array early here before first
+	use (calls to XGServerWindow methods).
+
+	* Source/x11/XGDragView.m (XDPY): use `monitor_id` in `boundForScreen:`
+	call.
+
+	* Source/cairo/XGCairoSurface.m: use `xDisplayRootWindow` XGServer's method.
+
+	* Source/art/ARTContext.m (setupDrawInfo:): use `xDisplayRootWindow`
+	XGServer's method.
+
+
 2020-01-31  Sergii Stoian  <stoyan255@gmail.com>
 
 	* Source/x11/XGServerWindow.m (screenList): join RandR and non-RandR

--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,14 @@
 	indices to get access to monitors` items.
 	(boundsForScreen:): use cached `frame` parameter of specified monitor.
 	Use `monitorsCount` instead of ScreenCount().
+	(windowDepthForScreen:): renamed method parameter; append `x_` prefix to
+	`Screen *` internal variable; validate `screen` parameter value; use
+	`defScreen` for RandR enabled code.
+	(availableDepthsForScreen:): ditto.
+	(resolutionForScreen:): renamed method parameter; validate `screen`
+	parameter value.
+	(boundsForScreen:): renamed method parameter.
+
 	* Source/x11/XGServer.m (dealloc): free `monitors` if it was used.
 
 2020-01-26  Sergii Stoian  <stoyan255@gmail.com>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2020-01-31  Sergii Stoian  <stoyan255@gmail.com>
+
+	* Source/x11/XGServerWindow.m (screenList): join RandR and non-RandR
+	code. Failback to Xlib generic method if any no RandR available or
+	RandR function call was unsuccessful. In Xlib generic method fill in
+	monitors array with values.
+	(boundsForScreen:): use values from cached `monitors` array since
+	-screenList fills it on both cases with or without RandR available.
+
 2020-01-30  Sergii Stoian  <stoyan255@gmail.com>
 
 	* Headers/x11/XGServer.h: new structure `MonitorDevice` and ivar

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,16 @@
+2020-02-07  Sergii Stoian  <stoyan255@gmail.com>
+
+	* Source/x11/XGServerWindow.m (_XFrameToOSFrame:for:): use Xlib
+	screen height instead of monitor's because we convert coordinates
+	from Xlib area.
+	(movewindow::): use Xlib screen height because we're operating in
+	Xlib coordinate system.
+	(screenList): fill monitor depth with value returned by
+	windowPathForScreen with monitor at index 0 (screen_id already set so
+	method will get correct screen_id).
+
+	* Source/x11/XGServerEvent.m (processEvent:): fixed indentaion.
+
 2020-02-07 Fred Kiefer <FredKiefer@gmx.de>
 
 	* Source/x11/XGServerWindow.m (swapColors): Made code more

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,18 @@
 2020-01-26  Sergii Stoian  <stoyan255@gmail.com>
 
+	* Headers/x11/XGServer.h: new structure `MonitorDevice` and ivar
+	`monitors`for holding cache of monitor's parameters (depth, resolution,
+	frame). New ivar `monitorsCount` - holds number of items in `monitors` for
+	RandR or X11 screen count otherwise.
+	* Source/x11/XGServerWindow.m (screenList): new method for RandR mode -
+	enumerates monitors and caches their parameters. Returns array of monitors'
+	indices to get access to monitors` items.
+	(boundsForScreen:): use cached `frame` parameter of specified monitor.
+	Use `monitorsCount` instead of ScreenCount().
+	* Source/x11/XGServer.m (dealloc): free `monitors` if it was used.
+
+2020-01-26  Sergii Stoian  <stoyan255@gmail.com>
+
 	* Source/x11/XGServerWindow.m (boundsForScreen:): use `screen` variable
 	to identify output in RandR screen resources. Use `boundsRect` local
 	variable as return vaalue storage. Cleanup.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,15 @@
+2020-02-07  Sergii Stoian  <stoyan255@gmail.com>
+
+	* Source/x11/XGServerWindow.m (_OSFrameToXFrame:for:):,
+	(_OSFrameToXHints:for:): use Xlib screen height instead of monitor's
+	because we convert coordinates to Xlib area.
+
+	* Source/x11/XGServerEvent.m (processEvent:): update monitor_id from
+	NSWindow's screen number (it could change after event processing).
+	(mouseLocationOnScreen:window:): use Xlib screen height instead of
+	monitor's. Added comment to code that should be probably removed
+	later.
+
 2020-02-03  Sergii Stoian  <stoyan255@gmail.com>
 
 	* Source/x11/XWindowBuffer.m (windowBufferForWindow:depthInfo:): use

--- a/Headers/x11/XGServer.h
+++ b/Headers/x11/XGServer.h
@@ -52,6 +52,12 @@ typedef enum {
   XGDM_PORTABLE
 } XGDrawMechanism;
 
+typedef struct MonitorDevice {
+  NSWindowDepth depth;
+  NSSize resolution;
+  NSRect frame;
+} MonitorDevice;
+
 @interface XGServer : GSDisplayServer
 {
   Display           *dpy;
@@ -62,6 +68,7 @@ typedef enum {
   id                inputServer;
   int               randrEventBase;
   int               randrErrorBase;
+  MonitorDevice     *monitors;
 }
 
 + (Display*) currentXDisplay;

--- a/Headers/x11/XGServer.h
+++ b/Headers/x11/XGServer.h
@@ -53,6 +53,7 @@ typedef enum {
 } XGDrawMechanism;
 
 typedef struct MonitorDevice {
+  int screen_id;
   NSWindowDepth depth;
   NSSize resolution;
   NSRect frame;
@@ -72,19 +73,19 @@ typedef struct MonitorDevice {
   unsigned          monitorsCount;
 }
 
-+ (Display*) currentXDisplay;
-- (Display*) xDisplay;
++ (Display *) xDisplay;
+- (Display *) xDisplay;
+- (Window) xDisplayRootWindow;
 - (Window) xAppRootWindow;
 
-- (void *) xrContextForScreen: (int)screen_number;
-- (Visual *) visualForScreen: (int)screen_number;
-- (int) depthForScreen: (int)screen_number;
+- (void *) screenRContext;
+- (Visual *) screenVisual;
+- (int) screenDepth;
+- (XGDrawMechanism) screenDrawMechanism;
 
-- (XGDrawMechanism) drawMechanismForScreen: (int)screen_number;
 - (void) getForScreen: (int)screen_number pixelFormat: (int *)bpp_number 
                 masks: (int *)red_mask : (int *)green_mask : (int *)blue_mask;
-- (Window) xDisplayRootWindowForScreen: (int)screen_number;
-- (XColor) xColorFromColor: (XColor)color forScreen: (int)screen_number;
+- (XColor) xColorFromColor: (XColor)color;
 
 + (void) waitAllContexts;
 @end

--- a/Headers/x11/XGServer.h
+++ b/Headers/x11/XGServer.h
@@ -69,6 +69,7 @@ typedef struct MonitorDevice {
   int               randrEventBase;
   int               randrErrorBase;
   MonitorDevice     *monitors;
+  unsigned          monitorsCount;
 }
 
 + (Display*) currentXDisplay;

--- a/Headers/x11/XGServerWindow.h
+++ b/Headers/x11/XGServerWindow.h
@@ -84,8 +84,9 @@ typedef struct _gswindow_device_t {
   Display               *display;      /* Display this window is on */
   Window                ident;         /* Window handle */
   Window                root;          /* Handle of root window */
-  Window		parent;        /* Handle of parent window */
-  int                   screen;        /* Screeen this window is on */
+  Window                parent;        /* Handle of parent window */
+  int                   screen_id;     /* Screeen this window is on */
+  int                   monitor_id;    /* Physical monitor this window is on */
   GC                    gc;            /* GC for drawing */
   long                  number;        /* Globally unique identifier */
   unsigned int          depth;         /* Window depth */

--- a/Source/art/ARTContext.m
+++ b/Source/art/ARTContext.m
@@ -70,7 +70,7 @@
   gswindow_device_t *gs_win;
 
   gs_win = device;
-  [(XGServer *)server getForScreen: gs_win->screen pixelFormat: &bpp 
+  [(XGServer *)server getForScreen: gs_win->screen_id pixelFormat: &bpp 
                 masks: &red_mask : &green_mask : &blue_mask];
 #endif
   artcontext_setup_draw_info(&DI, red_mask, green_mask, blue_mask, bpp);

--- a/Source/cairo/XGCairoSurface.m
+++ b/Source/cairo/XGCairoSurface.m
@@ -95,7 +95,7 @@
   Window win;
   XWindowAttributes attrs;
 
-  win = [self xDisplayRootWindowForScreen: screen];
+  win = [self xDisplayRootWindow];
  
   if (XGetWindowAttributes(dpy, win, &attrs))
     {

--- a/Source/x11/XGDragView.m
+++ b/Source/x11/XGDragView.m
@@ -47,14 +47,14 @@
 /* Size of the dragged window */
 #define	DWZ	48
 
-#define XDPY  [XGServer currentXDisplay]
+#define XDPY  [XGServer xDisplay]
 
 #define SLIDE_TIME_STEP   .02   /* in seconds */
 #define SLIDE_NR_OF_STEPS 20  
 
 #define	DRAGWINDEV [XGServer _windowWithTag: [_window windowNumber]]
 #define	XX(P)	(P.x)
-#define	XY(P)	([GSCurrentServer() boundsForScreen: DRAGWINDEV->screen].size.height - P.y)
+#define	XY(P)	([GSCurrentServer() boundsForScreen: DRAGWINDEV->monitor_id].size.height - P.y)
 
 @interface XGRawWindow : NSWindow
 @end

--- a/Source/x11/XGServer.m
+++ b/Source/x11/XGServer.m
@@ -503,6 +503,10 @@ _parse_display_name(NSString *name, int *dn, int *sn)
   DESTROY(inputServer);
   [self _destroyServerWindows];
   NSFreeMapTable(screenList);
+  if (monitors != NULL)
+    {
+      NSZoneFree([self zone], monitors);
+    }
   XCloseDisplay(dpy);
   [super dealloc];
 }

--- a/Source/x11/XGServer.m
+++ b/Source/x11/XGServer.m
@@ -141,7 +141,7 @@ _parse_display_name(NSString *name, int *dn, int *sn)
   XGDrawMechanism drawMechanism;
 }
 
-- initForDisplay: (Display *)dpy screen: (int)screen_number;
+- initForDisplay: (Display *)dpy screen: (int)screen_id;
 - (XGDrawMechanism) drawMechanism;
 - (RContext *) context;
 @end
@@ -173,7 +173,7 @@ _parse_display_name(NSString *name, int *dn, int *sn)
   return attribs;
 }
 
-- initForDisplay: (Display *)dpy screen: (int)screen_number
+- initForDisplay: (Display *)dpy screen: (int)screen_id
 {
   RContextAttributes *attribs;
   XColor testColor;
@@ -182,7 +182,7 @@ _parse_display_name(NSString *name, int *dn, int *sn)
    /* Get the visual information */
   attribs = NULL;
   //attribs = [self _getXDefaults];
-  rcontext = RCreateContext(dpy, screen_number, attribs);
+  rcontext = RCreateContext(dpy, screen_id, attribs);
 
   /*
    * If we have shared memory available, only use it when the XGPS-Shm
@@ -291,7 +291,7 @@ _parse_display_name(NSString *name, int *dn, int *sn)
       drawMechanism = XGDM_PORTABLE;
     }
   NSDebugLLog(@"XGTrace", @"Draw mech %d for screen %d", drawMechanism,
-        screen_number);
+        screen_id);
   return self;
 }
 
@@ -377,14 +377,14 @@ _parse_display_name(NSString *name, int *dn, int *sn)
    Returns a pointer to the current X-Windows display variable for
    the current context.
 */
-+ (Display*) currentXDisplay
++ (Display *) xDisplay
 {
   return [(XGServer*)GSCurrentServer() xDisplay];
 }
 
 - (id) _initXContext
 {
-  int screen_number, display_number;
+  int screen_id, display_id;
   NSString *display_name;
 
   display_name = [server_info objectForKey: GSDisplayName];
@@ -436,13 +436,13 @@ _parse_display_name(NSString *name, int *dn, int *sn)
     }
 
   /* Parse display information */
-  _parse_display_name(display_name, &display_number, &screen_number);
+  _parse_display_name(display_name, &display_id, &screen_id);
   NSDebugLog(@"Opened display %@, display %d screen %d", 
-             display_name, display_number, screen_number);
+             display_name, display_id, screen_id);
   [server_info setObject: display_name forKey: GSDisplayName];
-  [server_info setObject: [NSNumber numberWithInt: display_number]
+  [server_info setObject: [NSNumber numberWithInt: display_id]
                   forKey: GSDisplayNumber];
-  [server_info setObject: [NSNumber numberWithInt: screen_number] 
+  [server_info setObject: [NSNumber numberWithInt: screen_id] 
                   forKey: GSScreenNumber];
 
   /* Setup screen*/
@@ -450,7 +450,11 @@ _parse_display_name(NSString *name, int *dn, int *sn)
     screenList = NSCreateMapTable(NSIntMapKeyCallBacks,
                                  NSObjectMapValueCallBacks, 20);
 
-  defScreen = screen_number;
+  defScreen = screen_id;
+
+  /* Enumerate monitors */
+  if (monitors == NULL)
+    [self screenList];
 
   XSetErrorHandler(XGErrorHandler);
 
@@ -519,46 +523,57 @@ _parse_display_name(NSString *name, int *dn, int *sn)
   return dpy;
 }
 
-- (XGScreenContext *) _screenContextForScreen: (int)screen_number
+/**
+   Returns the root window of the display 
+*/
+- (Window) xDisplayRootWindow;
 {
-  int count = ScreenCount(dpy);
-  XGScreenContext *screen;
-
-  if (screen_number >= count)
-    {
-      [NSException raise: NSInvalidArgumentException
-                   format: @"Request for invalid screen"];
-    }
-
-  screen = NSMapGet(screenList, (void *)(uintptr_t)screen_number);
-  if (screen == NULL)
-    {
-      screen = [[XGScreenContext alloc] 
-                   initForDisplay: dpy screen: screen_number];
-      NSMapInsert(screenList, (void *)(uintptr_t)screen_number, (void *)screen);
-      RELEASE(screen);
-    }
-
-  return screen;
+  return RootWindow(dpy, defScreen);
 }
+
+/**
+   Returns the application root window, which is used for many things
+   such as window hints 
+*/
+- (Window) xAppRootWindow
+{
+  return generic.appRootWindow;
+}
+
+- (XGScreenContext *) _defaultScreenContext
+{
+  XGScreenContext *screenCtxt;
+
+  screenCtxt = NSMapGet(screenList, (void *)(uintptr_t)defScreen);
+  if (screenCtxt == NULL)
+    {
+      screenCtxt = [[XGScreenContext alloc] initForDisplay: dpy
+                                                    screen: defScreen];
+      NSMapInsert(screenList, (void *)(uintptr_t)defScreen, (void *)screenCtxt);
+      RELEASE(screenCtxt);
+    }
+
+  return screenCtxt;
+}
+
 
 /**
    Returns a pointer to a structure which describes aspects of the
    X windows display 
 */
-- (void *) xrContextForScreen: (int)screen_number
+- (void *) screenRContext
 {
-  return [[self _screenContextForScreen: screen_number] context];
+  return [[self _defaultScreenContext] context];
 }
 
-- (Visual *) visualForScreen: (int)screen_number
+- (Visual *) screenVisual
 {
-    return [[self _screenContextForScreen: screen_number] context]->visual;
+  return [[self _defaultScreenContext] context]->visual;
 }
 
-- (int) depthForScreen: (int)screen_number
+- (int) screenDepth
 {
-    return [[self _screenContextForScreen: screen_number] context]->depth;
+  return [[self _defaultScreenContext] context]->depth;
 }
 
 /**
@@ -566,9 +581,9 @@ _parse_display_name(NSString *name, int *dn, int *sn)
    the screen and how pixels should be drawn to the screen for maximum
    speed.
 */
-- (XGDrawMechanism) drawMechanismForScreen: (int)screen_number
+- (XGDrawMechanism) screenDrawMechanism
 {
- return [[self _screenContextForScreen: screen_number] drawMechanism];
+ return [[self _defaultScreenContext] drawMechanism];
 }
 
 // Could use NSSwapInt() instead
@@ -600,48 +615,48 @@ static int byte_order(void)
 /**
  * Used by the art backend to determine the drawing mechanism.
  */
-- (void) getForScreen: (int)screen_number pixelFormat: (int *)bpp_number 
+- (void) getForScreen: (int)screen_id pixelFormat: (int *)bpp_number 
                 masks: (int *)red_mask : (int *)green_mask : (int *)blue_mask
 {
   Visual *visual;
   XImage *i;
   int bpp;
-#if 0
-  XVisualInfo template;
-  XVisualInfo *visualInfo;
-  int numMatches;
+// #if 0
+//   XVisualInfo template;
+//   XVisualInfo *visualInfo;
+//   int numMatches;
   
-  /*
-    We need a visual that we can generate pixel values for by ourselves.
-    Thus, we try to find a DirectColor or TrueColor visual. If that fails,
-    we use the default visual and hope that it's usable.
-  */
-  template.class = DirectColor;
-  visualInfo = XGetVisualInfo(dpy, VisualClassMask, &template, &numMatches);
-  if (!visualInfo)
-    {
-      template.class = TrueColor;
-      visualInfo = XGetVisualInfo(dpy, VisualClassMask, &template, &numMatches);
-    }
-  if (visualInfo)
-    {
-      visual = visualInfo->visual;
-      bpp = visualInfo->depth;
-      XFree(visualInfo);
-    }
-  else
-    {
-      visual = DefaultVisual(dpy, DefaultScreen(dpy));
-      bpp = DefaultDepth(dpy, DefaultScreen(dpy));
-    }
-#else
+//   /*
+//     We need a visual that we can generate pixel values for by ourselves.
+//     Thus, we try to find a DirectColor or TrueColor visual. If that fails,
+//     we use the default visual and hope that it's usable.
+//   */
+//   template.class = DirectColor;
+//   visualInfo = XGetVisualInfo(dpy, VisualClassMask, &template, &numMatches);
+//   if (!visualInfo)
+//     {
+//       template.class = TrueColor;
+//       visualInfo = XGetVisualInfo(dpy, VisualClassMask, &template, &numMatches);
+//     }
+//   if (visualInfo)
+//     {
+//       visual = visualInfo->visual;
+//       bpp = visualInfo->depth;
+//       XFree(visualInfo);
+//     }
+//   else
+//     {
+//       visual = DefaultVisual(dpy, DefaultScreen(dpy));
+//       bpp = DefaultDepth(dpy, DefaultScreen(dpy));
+//     }
+// #else
   RContext *context;
 
   // Better to get the used visual from the context.
-  context = [self xrContextForScreen: screen_number];
+  context = [self screenRContext];
   visual = context->visual;
   bpp = context->depth;
-#endif 
+// #endif 
 
   i = XCreateImage(dpy, visual, bpp, ZPixmap, 0, NULL, 8, 8, 8, 0);
   bpp = i->bits_per_pixel;
@@ -678,42 +693,26 @@ static int byte_order(void)
 }
 
 /**
-   Returns the root window of the display 
-*/
-- (Window) xDisplayRootWindowForScreen: (int)screen_number;
-{
-  return RootWindow(dpy, screen_number);
-}
-
-/**
    Returns the closest color in the current colormap to the indicated
    X color
 */
-- (XColor) xColorFromColor: (XColor)color forScreen: (int)screen_number
+- (XColor) xColorFromColor: (XColor)color
 {
   Status ret;
   RColor rcolor;
-  RContext *context = [self xrContextForScreen: screen_number];
+  RContext *context = [self screenRContext];
   XAllocColor(dpy, context->cmap, &color);
   rcolor.red   = color.red / 256;
   rcolor.green = color.green / 256;
   rcolor.blue  = color.blue / 256;
   ret = RGetClosestXColor(context, &rcolor, &color);
   if (ret == False)
-    NSLog(@"Failed to alloc color (%d,%d,%d)\n",
-          (int)rcolor.red, (int)rcolor.green, (int)rcolor.blue);
+    {
+      NSLog(@"Failed to alloc color (%d,%d,%d)\n",
+            (int)rcolor.red, (int)rcolor.green, (int)rcolor.blue);
+    }
   return color;
 }
-
-/**
-   Returns the application root window, which is used for many things
-   such as window hints 
-*/
-- (Window) xAppRootWindow
-{
-  return generic.appRootWindow;
-}
-
 
 /**
   Wait for all contexts to finish processing. Only used with XDPS graphics.
@@ -805,7 +804,6 @@ static int byte_order(void)
 
 @end // XGServer (InputMethod)
 
-
 //==== Additional code for NSTextView =========================================
 //
 //  WARNING  This section is not genuine part of the XGServer implementation.
@@ -822,6 +820,9 @@ static int byte_order(void)
 
 #include <AppKit/NSClipView.h>
 #include <AppKit/NSTextView.h>
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wobjc-protocol-method-implementation"
 
 @implementation NSTextView (InputMethod)
 
@@ -935,4 +936,6 @@ static int byte_order(void)
 }
 
 @end // NSTextView
+
+#pragma clang diagnostic pop
 //==== End: Additional Code for NSTextView ====================================

--- a/Source/x11/XGServer.m
+++ b/Source/x11/XGServer.m
@@ -791,8 +791,10 @@ static int byte_order(void)
 #include <AppKit/NSClipView.h>
 #include <AppKit/NSTextView.h>
 
+#if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wobjc-protocol-method-implementation"
+#endif
 
 @implementation NSTextView (InputMethod)
 
@@ -907,5 +909,7 @@ static int byte_order(void)
 
 @end // NSTextView
 
+#if defined(__clang__)
 #pragma clang diagnostic pop
+#endif
 //==== End: Additional Code for NSTextView ====================================

--- a/Source/x11/XGServer.m
+++ b/Source/x11/XGServer.m
@@ -621,42 +621,12 @@ static int byte_order(void)
   Visual *visual;
   XImage *i;
   int bpp;
-// #if 0
-//   XVisualInfo template;
-//   XVisualInfo *visualInfo;
-//   int numMatches;
-  
-//   /*
-//     We need a visual that we can generate pixel values for by ourselves.
-//     Thus, we try to find a DirectColor or TrueColor visual. If that fails,
-//     we use the default visual and hope that it's usable.
-//   */
-//   template.class = DirectColor;
-//   visualInfo = XGetVisualInfo(dpy, VisualClassMask, &template, &numMatches);
-//   if (!visualInfo)
-//     {
-//       template.class = TrueColor;
-//       visualInfo = XGetVisualInfo(dpy, VisualClassMask, &template, &numMatches);
-//     }
-//   if (visualInfo)
-//     {
-//       visual = visualInfo->visual;
-//       bpp = visualInfo->depth;
-//       XFree(visualInfo);
-//     }
-//   else
-//     {
-//       visual = DefaultVisual(dpy, DefaultScreen(dpy));
-//       bpp = DefaultDepth(dpy, DefaultScreen(dpy));
-//     }
-// #else
   RContext *context;
 
   // Better to get the used visual from the context.
   context = [self screenRContext];
   visual = context->visual;
   bpp = context->depth;
-// #endif 
 
   i = XCreateImage(dpy, visual, bpp, ZPixmap, 0, NULL, 8, 8, 8, 0);
   bpp = i->bits_per_pixel;

--- a/Source/x11/XGServerEvent.m
+++ b/Source/x11/XGServerEvent.m
@@ -1047,7 +1047,7 @@ posixFileDescriptor: (NSPosixFileDescriptor*)fileDescriptor
 		 * this event, causing a confusion.
 		 */
                 window = [NSApp windowWithWindowNumber: cWin->number];
-		[window sendEvent: r];
+                [window sendEvent: r];
                 /* Update monitor_id of the backend window.
                    NSWindow may change screen pointer while processing
                    the event. */

--- a/Source/x11/XGServerEvent.m
+++ b/Source/x11/XGServerEvent.m
@@ -744,7 +744,7 @@ posixFileDescriptor: (NSPosixFileDescriptor*)fileDescriptor
               else if ((Atom)xEvent.xclient.data.l[0]
                 == generic._NET_WM_PING_ATOM)
                 {
-                  xEvent.xclient.window = RootWindow(dpy, cWin->screen);
+                  xEvent.xclient.window = RootWindow(dpy, cWin->screen_id);
                   XSendEvent(dpy, xEvent.xclient.window, False, 
                     (SubstructureRedirectMask | SubstructureNotifyMask), 
                     &xEvent);
@@ -796,7 +796,7 @@ posixFileDescriptor: (NSPosixFileDescriptor*)fileDescriptor
                 send ConfigureNotify events for app icons.
               */
               XTranslateCoordinates(dpy, xEvent.xclient.window,
-                                    RootWindow(dpy, cWin->screen),
+                                    RootWindow(dpy, cWin->screen_id),
                                     0, 0,
                                     &root_x, &root_y,
                                     &root_child);
@@ -965,7 +965,7 @@ posixFileDescriptor: (NSPosixFileDescriptor*)fileDescriptor
                 int root_x, root_y;
                 Window root_child;
                 XTranslateCoordinates(dpy, xEvent.xconfigure.window,
-                                      RootWindow(dpy, cWin->screen),
+                                      RootWindow(dpy, cWin->screen_id),
                                       0, 0,
                                       &root_x, &root_y,
                                       &root_child);
@@ -2066,7 +2066,7 @@ static void
 initialize_keyboard (void)
 {
   NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-  Display *display = [XGServer currentXDisplay];
+  Display *display = [XGServer xDisplay];
 
   // Below must be stored and checked as keysyms, not keycodes, since
   // more than one keycode may be mapped t the same keysym
@@ -2140,7 +2140,7 @@ set_up_num_lock (void)
     ShiftMask, LockMask, ControlMask, Mod1Mask, 
     Mod2Mask, Mod3Mask, Mod4Mask, Mod5Mask
   };
-  Display *display = [XGServer currentXDisplay];
+  Display *display = [XGServer xDisplay];
   KeyCode _num_lock_keycode;
   
   // Get NumLock keycode
@@ -2668,10 +2668,9 @@ process_modifier_flags(unsigned int state)
   BOOL ok;
   NSPoint p;
   int height;
-  int screen_number;
-  
-  screen_number = (screen >= 0) ? screen : defScreen;
-  ok = XQueryPointer (dpy, [self xDisplayRootWindowForScreen: screen_number],
+  int screen_id;
+
+  ok = XQueryPointer (dpy, [self xDisplayRootWindow],
     &rootWin, &childWin, &currentX, &currentY, &winX, &winY, &mask);
   p = NSMakePoint(-1,-1);
   if (ok == False)
@@ -2683,8 +2682,8 @@ process_modifier_flags(unsigned int state)
         {
           return p;
         }
-      screen_number = XScreenNumberOfScreen(attribs.screen);
-      if (screen >= 0 && screen != screen_number)
+      screen_id = XScreenNumberOfScreen(attribs.screen);
+      if (screen >= 0 && screen != screen_id)
         {
           /* Mouse not on the requred screen, return an invalid point */
           return p;
@@ -2692,7 +2691,7 @@ process_modifier_flags(unsigned int state)
       height = attribs.height;
     }
   else
-    height = [self boundsForScreen: screen_number].size.height;
+    height = [self boundsForScreen: screen].size.height;
   p = NSMakePoint(currentX, height - currentY);
   if (win)
     {

--- a/Source/x11/XGServerWindow.m
+++ b/Source/x11/XGServerWindow.m
@@ -4583,7 +4583,7 @@ _computeDepth(int class, int bpp)
   return depths;
 }
 
-// `screen` is a Xlib screen number.
+// `screen_num` is a Xlib screen number.
 - (NSSize) resolutionForScreen: (int)screen_num
 {
   // NOTE:

--- a/Source/x11/XGServerWindow.m
+++ b/Source/x11/XGServerWindow.m
@@ -4457,7 +4457,7 @@ _computeDepth(int class, int bpp)
               crtc_info = XRRGetCrtcInfo(dpy, screen_res, output_info->crtc);
 
               // Fill the cache of device parameters
-              monitors[i].depth = [self windowDepthForScreen: defScreen];
+              monitors[i].depth = [self windowDepthForScreen: i];
               monitors[i].resolution = [self resolutionForScreen: defScreen];
               monitors[i].frame = NSMakeRect(crtc_info->x, crtc_info->y,
                                              crtc_info->width, crtc_info->height);
@@ -4489,7 +4489,7 @@ _computeDepth(int class, int bpp)
   return screens;
 }
 
-// `screen` is a Xlib screen number.
+// `screen` is a monitor index not X11 screen
 - (NSWindowDepth) windowDepthForScreen: (int)screen
 {
   Screen	*x_screen;
@@ -4500,7 +4500,7 @@ _computeDepth(int class, int bpp)
       return 0;
     }
   
-  x_screen = XScreenOfDisplay(dpy, screen);
+  x_screen = XScreenOfDisplay(dpy, monitors[screen].screen_id);
   
   if (x_screen == NULL)
     {

--- a/Source/x11/XGServerWindow.m
+++ b/Source/x11/XGServerWindow.m
@@ -576,7 +576,7 @@ BOOL AtomPresentAndPointsToItself(Display *dpy, Atom atom, Atom type)
 
   [self styleoffsets: &l : &r : &t : &b : style : win->ident];
   o = x;
-  o.origin.y = [self boundsForScreen: win->monitor_id].size.height - x.origin.y;
+  o.origin.y = DisplayHeight(dpy, defScreen) - x.origin.y;
   o.origin.y = o.origin.y - x.size.height - b;
   o.origin.x -= l;
   o.size.width += l + r;
@@ -3192,7 +3192,7 @@ swapColors(unsigned char *image_data, NSBitmapImageRep *rep)
     }
 
   window->siz_hints.x = (int)loc.x;
-  window->siz_hints.y = (int)([self boundsForScreen: window->monitor_id].size.height -
+  window->siz_hints.y = (int)(DisplayHeight(dpy, defScreen) -
 			      loc.y - window->siz_hints.height);
   XMoveWindow (dpy, window->ident, window->siz_hints.x, window->siz_hints.y);
   setNormalHints(dpy, window);
@@ -4512,7 +4512,7 @@ _computeDepth(int class, int bpp)
       monitorsCount = 1;
       monitors = NSZoneMalloc([self zone], sizeof(MonitorDevice));
       monitors[0].screen_id = defScreen;
-      monitors[0].depth = [self windowDepthForScreen: defScreen];
+      monitors[0].depth = [self windowDepthForScreen: 0];
       monitors[0].resolution = [self resolutionForScreen: defScreen];
       monitors[0].frame = NSMakeRect(0, 0,
                                      DisplayWidth(dpy, defScreen),

--- a/Source/x11/XGServerWindow.m
+++ b/Source/x11/XGServerWindow.m
@@ -4482,8 +4482,8 @@ _computeDepth(int class, int bpp)
 
   if (monitorsCount == 0)
     {
-      /* Assumed that it's always available 1 screen per application. We only
-         need to know it's number and it was saved in _initXContext as
+      /* It is assumed that there is always only one screen per application. 
+         We only need to know its number and it was saved in _initXContext as
          `defScreen`. */
       monitorsCount = 1;
       monitors = NSZoneMalloc([self zone], sizeof(MonitorDevice));
@@ -4560,7 +4560,7 @@ _computeDepth(int class, int bpp)
 }
 
 // `screen` is a Xlib screen number.
-- (NSSize) resolutionForScreen: (int)screen
+- (NSSize) resolutionForScreen: (int)screen_num
 {
   // NOTE:
   // -gui now trusts the return value of resolutionForScreen:,

--- a/Source/x11/XGServerWindow.m
+++ b/Source/x11/XGServerWindow.m
@@ -2106,8 +2106,8 @@ _get_next_prop_new_event(Display *display, XEvent *event, char *arg)
   window = NSAllocateCollectable(sizeof(gswindow_device_t), NSScannedOption);
   memset(window, '\0', sizeof(gswindow_device_t));
   window->display = dpy;
-  window->screen_id = defScreen;
-  window->monitor_id = *screen;
+  window->screen_id = *screen;
+  window->monitor_id = 0;
   window->ident = windowRef;
   window->root = root->ident;
   window->parent = root->ident;
@@ -4417,6 +4417,8 @@ _computeDepth(int class, int bpp)
 
 /* This method assumes that we deal with one X11 screen - `defScreen`.
    Basically it means that we have DISPLAY variable set to `:0.0`.
+   Where both digits have artbitrary values, but it defines once on
+   every application run.
    AppKit and X11 use the same term "screen" with different meaning:
    AppKit Screen - single monitor/display device.
    X11 Screen - it's a plane where X Server can draw on.

--- a/Source/x11/XGServerWindow.m
+++ b/Source/x11/XGServerWindow.m
@@ -4473,7 +4473,7 @@ _computeDepth(int class, int bpp)
          put the main screen first */
       [screens addObject: [NSNumber numberWithInt: defScreen]];
     }
-  for (i = 0; i < count; i++)
+  for (i = 0; i < monitorsCount; i++)
     {
       if (i != defScreen)
         [screens addObject: [NSNumber numberWithInt: i]];

--- a/Source/x11/XGServerWindow.m
+++ b/Source/x11/XGServerWindow.m
@@ -509,7 +509,7 @@ BOOL AtomPresentAndPointsToItself(Display *dpy, Atom atom, Atom type)
   x.size.height = o.size.height - t - b;
   x.origin.x = o.origin.x + l;
   x.origin.y = o.origin.y + o.size.height - t;
-  x.origin.y = [self boundsForScreen: win->monitor_id].size.height - x.origin.y;
+  x.origin.y = DisplayHeight(dpy, defScreen) - x.origin.y;
   NSDebugLLog(@"Frame", @"O2X %lu, %x, %@, %@", win->number, style,
     NSStringFromRect(o), NSStringFromRect(x));
   return x;
@@ -534,7 +534,7 @@ BOOL AtomPresentAndPointsToItself(Display *dpy, Atom atom, Atom type)
   x.size.height = o.size.height - t - b;
   x.origin.x = o.origin.x;
   x.origin.y = o.origin.y + o.size.height;
-  x.origin.y = [self boundsForScreen: win->monitor_id].size.height - x.origin.y;
+  x.origin.y = DisplayHeight(dpy, defScreen) - x.origin.y;
   NSDebugLLog(@"Frame", @"O2H %lu, %x, %@, %@", win->number, style,
     NSStringFromRect(o), NSStringFromRect(x));
   return x;

--- a/Source/x11/XIMInputServer.m
+++ b/Source/x11/XIMInputServer.m
@@ -61,7 +61,7 @@
 - (id) initWithDelegate: (id)aDelegate
 		   name: (NSString *)name
 {
-  Display *dpy = [XGServer currentXDisplay];
+  Display *dpy = [XGServer xDisplay];
   return [self initWithDelegate: aDelegate display: dpy name: name];
 }
 
@@ -380,7 +380,7 @@ betterStyle(XIMStyle a, XIMStyle b, XIMStyle xim_requested_style)
     }
   else if (xim_style == OffTheSpotStyle || xim_style == OverTheSpotStyle)
     {
-      Display	    *dpy = [XGServer currentXDisplay];
+      Display	    *dpy = [XGServer xDisplay];
       XFontSet	    font_set;
       char	    **missing_charset;
       int	    num_missing_charset;
@@ -556,7 +556,7 @@ finish:
 
   if (XGetICValues(xics[num_xics - 1], XNClientWindow, &win, NULL))
     return NO;
-  dpy = [XGServer currentXDisplay];
+  dpy = [XGServer xDisplay];
   if (XTranslateCoordinates(dpy, win, DefaultRootWindow(dpy), 0, 0,
 			    &abs_x, &abs_y, &dummy) == 0)
     return NO;

--- a/Source/x11/XWindowBuffer.m
+++ b/Source/x11/XWindowBuffer.m
@@ -222,8 +222,8 @@ no_xshm:
   visual = DefaultVisual(wi->display, DefaultScreen(wi->display));
 #else
   // Better to get the used visual from the XGServer.
-  visual = [(XGServer*)GSCurrentServer() visualForScreen: awindow->screen];
-  drawing_depth = [(XGServer*)GSCurrentServer() depthForScreen: awindow->screen];
+  visual = [(XGServer*)GSCurrentServer() screenVisual];
+  drawing_depth = [(XGServer*)GSCurrentServer() screenDepth];
 #endif
 
   /* TODO: resolve properly.


### PR DESCRIPTION
In addition to the previous PR I've made some optiomizations and fixes:
- implemented caching of monitors parameters;
- fixed monitors enumeration - NSScreen receives correct array with indices to monitors parameters cache;
- fixed/unified handling count of monitors/screens with RandR and without it.
- boundsForScreen now should run much faster because of cached parameters use.