### PR TITLE
Fix: right-click app menu steals focus from active application

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2020-01-30  Sergii Stoian  <stoyan255@gmail.com>
+
+	* Source/x11/XGServerEvent.m (_handleTakeFocusAtom:forContext:):
+	do not grab focus of active applicaion if right-click app menu requests
+	focus.
+
 2020-01-26  Sergii Stoian  <stoyan255@gmail.com>
 
 	* Source/x11/XGServerWindow.m (boundsForScreen:): use `screen` variable

--- a/Source/x11/XGServerEvent.m
+++ b/Source/x11/XGServerEvent.m
@@ -1981,6 +1981,13 @@ posixFileDescriptor: (NSPosixFileDescriptor*)fileDescriptor
       NSDebugLLog(@"Focus", @"Ignoring window focus request");
       cWin->ignore_take_focus = NO;
     }
+  else if ([[NSApp mainMenu] isTransient] != NO)
+    {
+      /* Do not grab focus from active application if right-click on our
+         application icon was performed. */
+      NSDebugLLog(@"Focus",
+                  @"Ignore transient application menu focus request.");
+    }
   else if (cWin->number == key_num)
     {
       NSDebugLLog(@"Focus", @"Reasserting key window");


### PR DESCRIPTION
This change fixes focus stealing from active application on right-click menu appearance.
How to reproduce:
1. Start two applications (app1 and app2).
2. Activate app1 by double-click on its appicon.
3. Right-click on app2 appicon without activating it.

App2 becomes active, right click main menu shows. After right mouse button release app2 stays active.

Should be: app2 right-click application menu shows without app2 activation. After right mouse release app1 stays active.