### PR TITLE
Align screens origin to OpenStep coordinate system.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2020-02-11  Sergii Stoian  <stoyan255@gmail.com>
+
+	* Source/x11/XGServerWindow.m (screenList): Transform screen
+	origin into unflipped (OpenStep) coordinate system for XRandR capable
+	systems. After this change windows and screen will use the same start
+	of coordinate system for their origins.
+
 2020-02-07  Sergii Stoian  <stoyan255@gmail.com>
 
 	* Source/x11/XGServerWindow.m (_XFrameToOSFrame:for:): use Xlib

--- a/Source/x11/XGServerWindow.m
+++ b/Source/x11/XGServerWindow.m
@@ -4465,6 +4465,7 @@ _computeDepth(int class, int bpp)
       NSMutableArray *tmpScreens;
       int             i;
       int             mi;
+      int             xScreenHeight = DisplayHeight(dpy, defScreen);
 
       monitorsCount = screen_res->noutput;
       tmpScreens = [NSMutableArray arrayWithCapacity: monitorsCount];
@@ -4487,11 +4488,10 @@ _computeDepth(int class, int bpp)
               monitors[mi].resolution = [self resolutionForScreen: defScreen];
               /* Transform coordinates from Xlib (flipped) to OpenStep (unflippped). 
                  Windows and screens should have the same coordinate system. */
-              frame = NSMakeRect(crtc_info->x,
-                                 xScreenHeight - crtc_info->height - crtc_info->y,
-                                 crtc_info->width,
-                                 crtc_info->height);
-              monitors[mi].frame = frame;
+              monitors[mi].frame = NSMakeRect(crtc_info->x,
+                                              xScreenHeight - crtc_info->height - crtc_info->y,
+                                              crtc_info->width,
+                                              crtc_info->height);
               /* Add monitor ID (index in monitors array).
                  Put primary monitor ID at index 0 since NSScreen get this as main 
                  screen if application has no key window. */

--- a/Source/x11/XGServerWindow.m
+++ b/Source/x11/XGServerWindow.m
@@ -4464,6 +4464,8 @@ _computeDepth(int class, int bpp)
   XRROutputInfo       *output_info;
   XRRCrtcInfo         *crtc_info;
   int                 mi;
+  NSRect              frame;
+  int                 xScreenHeight = DisplayHeight(dpy, defScreen);
 
   screen_res = XRRGetScreenResources(dpy, RootWindow(dpy, defScreen));
   if (screen_res != NULL)
@@ -4483,8 +4485,13 @@ _computeDepth(int class, int bpp)
               monitors[mi].screen_id = defScreen;
               monitors[mi].depth = [self windowDepthForScreen: mi];
               monitors[mi].resolution = [self resolutionForScreen: defScreen];
-              monitors[mi].frame = NSMakeRect(crtc_info->x, crtc_info->y,
-                                              crtc_info->width, crtc_info->height);
+              /* Transform coordinates from Xlib (flipped) to OpenStep (unflippped). 
+                 Windows and screens should have the same coordinate system. */
+              frame = NSMakeRect(crtc_info->x,
+                                 xScreenHeight - crtc_info->height - crtc_info->y,
+                                 crtc_info->width,
+                                 crtc_info->height);
+              monitors[mi].frame = frame;
               /* Add monitor ID (index in monitors array).
                  Put primary monitor ID index 0 since NSScreen get this as main 
                  screen if application has no key window. */


### PR DESCRIPTION
Transform screen origin into unflipped (OpenStep) coordinate system for XRandR capable systems. After this change windows and screen will use the same start of coordinate system for their origins.