### PR TITLE
Window positionning: rely on internal variable not the GUI's one

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2020-02-24  Sergii Stoian  <stoyan255@gmail.com>
+
+	* Source/x11/XGServerWindow.m (placewindow::): use window->xframe
+	as current window frame instead of NSWindow's frame because
+	`_frame` ivar may be already changed to desired value.
+
 2020-02-11  Sergii Stoian  <stoyan255@gmail.com>
 
 	* Source/x11/XGServerWindow.m (screenList): Transform screen

--- a/Source/x11/XGServerWindow.m
+++ b/Source/x11/XGServerWindow.m
@@ -3219,7 +3219,7 @@ swapColors(unsigned char *image_data, NSBitmapImageRep *rep)
   NSDebugLLog(@"XGTrace", @"DPSplacewindow: %@ : %d", NSStringFromRect(rect),
 	      win);
   nswin  = GSWindowWithNumber(win);
-  frame = [nswin frame];
+  frame = [self _XFrameToOSFrame: window->xframe for: window];
   if (NSEqualRects(rect, frame) == YES)
     return;
   if (NSEqualSizes(rect.size, frame.size) == NO)

--- a/Source/x11/XGServerWindow.m
+++ b/Source/x11/XGServerWindow.m
@@ -3234,7 +3234,6 @@ swapColors(unsigned char *image_data, NSBitmapImageRep *rep)
 
   NSDebugLLog(@"XGTrace", @"DPSplacewindow: %@ : %d", NSStringFromRect(rect),
 	      win);
-  nswin  = GSWindowWithNumber(win);
   frame = [self _XFrameToOSFrame: window->xframe for: window];
   if (NSEqualRects(rect, frame) == YES)
     return;
@@ -3285,6 +3284,7 @@ swapColors(unsigned char *image_data, NSBitmapImageRep *rep)
      with min/max sizes and resizability in some window managers.  */
   setNormalHints(dpy, window);
 
+  nswin = GSWindowWithNumber(win);
   if (resize == YES)
     {
       NSDebugLLog(@"Moving", @"Fake size %lu - %@", window->number,


### PR DESCRIPTION
Using `window->xframe` for making decisions provides ability to alter NSWindow's _frame variable before `placewindow:for:` call without affecting actual Xlib window placement.