### PR TITLE
placewindow:: fix frame check for multi-monitor layout 

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2020-03-05  Sergii Stoian  <stoyan255@gmail.com>
+
+	* Source/x11/XGServerWindow.m (placewindow::): check window frame
+	in OpenStep and Xlib coordinate systems to decide if it was changed.
+	Rename `xVal` into more meaninful `xFrame` (holds temporary value of
+	window frame in Xlib coordiante system).
+
 2020-03-03  Sergii Stoian  <stoyan255@gmail.com>
 
 	* Headers/x11/XGServer.h,


### PR DESCRIPTION
When monitors layout was changed windows need to update their positions on screen. There are the cases when OpenStep frames is not changed while Xlib did and vise versa. This fix adds checks for OpenStep frame changes as well as Xlib's.