### PR TITLE
Normalize annoucement file between core libraries

### DIFF
--- a/ANNOUNCE
+++ b/ANNOUNCE
@@ -1,5 +1,5 @@
-1 ANNOUNCE
-**********
+1 Announcement
+**************
 
 This is version 0.28.0 of the GNUstep GUI Backend ('gnustep-back').
 
@@ -56,10 +56,12 @@ instructions.
 1.4 Where do I send bug reports?
 ================================
 
-Bug reports can be sent to the GNUstep bug list <bug-gnustep@gnu.org>
+Please log bug reports on the GNUstep project page
+<http://savannah.gnu.org/bugs/?group=gnustep> or send bug reports to
+<bug-gnustep@gnu.org>.
 
-1.5 Obtaining GNU Software
-==========================
+1.5 Obtaining GNUstep Software
+==============================
 
 Check out the GNUstep web site.  (<http://www.gnustep.org/>) and the GNU
 web site.  (<http://www.gnu.org/>)

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2020-04-13  Ivan Vucica <ivan@vucica.net>
+
+	* Documentation/announce.texi:
+	* ANNOUNCE:
+	Normalize the accompanying text for the release announcement across
+	core packages: standardize chapter name and GPG information.
+
 2020-04-05  Ivan Vucica  <ivan@vucica.net>
 
 	* ANNOUNCE:

--- a/Documentation/announce.texi
+++ b/Documentation/announce.texi
@@ -1,10 +1,10 @@
 @c -*- texinfo -*-
-@chapter ANNOUNCE
+@chapter Announcement
 @ifset TEXT-ONLY
 @include version.texi
 @end ifset
 
-This is version @value{GNUSTEP-BACK-VERSION} of the GNUstep GUI Backend 
+This is version @value{GNUSTEP-BACK-VERSION} of the GNUstep GUI Backend
 (@samp{gnustep-back}).
 
 @section What is the GNUstep GUI Backend?
@@ -32,9 +32,10 @@ emulate the DPS functions required by the front-end system.
 @ifset GNUSTEP-BACK-FTP-MACHINE
 The gnustep-back-@value{GNUSTEP-BACK-VERSION}.tar.gz distribution
 file has been placed at @url{ftp://@value{GNUSTEP-BACK-FTP-MACHINE}/@value{GNUSTEP-BACK-FTP-DIRECTORY}}.
-@end ifset
 
-It is accompanied by gnustep-back-@value{GNUSTEP-BACK-VERSION}.tar.gz.sig, a PGP signature which you can validate by putting both files in the same directory and using:
+It is accompanied by gnustep-back-@value{GNUSTEP-BACK-VERSION}.tar.gz.sig, a
+PGP signature which you can validate by putting both files in the same
+directory and using:
 
 @example
 gpg --verify gnustep-back-@value{GNUSTEP-BACK-VERSION}.tar.gz.sig
@@ -45,15 +46,18 @@ Signature has been created using the key with the following fingerprint:
 @example
 83AA E47C E829 A414 6EF8  3420 CA86 8D4C 9914 9679
 @end example
+@end ifset
 
 Read the INSTALL file or the GNUstep-HOWTO for installation instructions.
 
 @section Where do I send bug reports?
 
-Bug reports can be sent to the GNUstep bug list
-@email{bug-gnustep@@gnu.org}
+Please log bug reports on the GNUstep project page
+@url{http://savannah.gnu.org/bugs/?group=gnustep} or send
+bug reports to @email{bug-gnustep@@gnu.org}.
 
-@section Obtaining GNU Software
+
+@section Obtaining GNUstep Software
 
 Check out the GNUstep web site. (@url{http://www.gnustep.org/}) and the
 GNU web site. (@url{http://www.gnu.org/})


### PR DESCRIPTION
While preparing the email, I noticed the ANNOUNCE file for `-make` doesn't mention the GPG key, and there are other subtle differences.

I'm creating this pull request across `make`, `base`, `gui` and `back`.
