### PR TITLE
XGServerEvent.m: unhide app if WindowMaker sends WM_TAKE_FOCUS to window

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,24 @@
+2020-09-17  Sergii Stoian  <stoyan255@gmail.com>
+
+	* Source/x11/XGServerEvent.m
+	(_handleTakeFocusAtom:forContext:): if application (window) receives
+	WM_TAKE_FOCUS in hidden state it means WindowMaker wants us to be
+	unhidden.
+
+	Description: There are 2 protocols defined in XGServerWindow.h:
+	WMFHideApplication and WMFHideOtherApplications. These protocols exist
+	to help GNUstep application and WindowMaker notify each other
+	about "Hide" and "Hide Others" actions. There are no protocols for
+	"unhide" action.
+
+	Test case steps:
+	1. Open application with window opened.
+	2. Hide application with "Hide" menu item.
+	3. Open WindowMaker's "Windows" menu (middle-click on desktop).
+	4. Select hidden application window.
+	Application unhides, activates, restored window is focused (receives) input
+	and "Hide" menu item unselected.
+
 2020-09-16  Sergii Stoian  <stoyan255@gmail.com>
 
 	* Source/x11/XGServerWindow.m

--- a/Source/x11/XGServerEvent.m
+++ b/Source/x11/XGServerEvent.m
@@ -1983,7 +1983,7 @@ posixFileDescriptor: (NSPosixFileDescriptor*)fileDescriptor
              state - it's time to unhide. There's no other method to
              tell us to unhide. */
           NSDebugLLog(@"Focus", @"WM take focus while hidden - unhiding.");
-          [NSApp unhide:nil];
+          [NSApp unhide: nil];
         }
       else
         {

--- a/Source/x11/XGServerEvent.m
+++ b/Source/x11/XGServerEvent.m
@@ -1977,10 +1977,21 @@ posixFileDescriptor: (NSPosixFileDescriptor*)fileDescriptor
      events */
   if ([NSApp isHidden])
     {
-      /* This often occurs when hidding an app, since a bunch of
-         windows get hidden at once, and the WM is searching for a
-         window to take focus after each one gets hidden. */
-      NSDebugLLog(@"Focus", @"WM take focus while hiding");
+      if (generic.wm & XGWM_WINDOWMAKER)
+        {
+          /* If window receives WM_TAKE_FOCUS and application is in hidden
+             state - it's time to unhide. There's no other method to
+             tell us to unhide. */
+          NSDebugLLog(@"Focus", @"WM take focus while hidden - unhiding.");
+          [NSApp unhide:nil];
+        }
+      else
+        {
+          /* This often occurs when hidding an app, since a bunch of
+             windows get hidden at once, and the WM is searching for a
+             window to take focus after each one gets hidden. */
+          NSDebugLLog(@"Focus", @"WM take focus while hiding");
+        }
     }
   else if (cWin->ignore_take_focus == YES)
     {


### PR DESCRIPTION
If application (window) receives WM_TAKE_FOCUS in hidden state it means WindowMaker wants us to be unhidden.

Description: There are 2 protocols defined in XGServerWindow.h - WMFHideApplication and WMFHideOtherApplications. These protocols exist to help GNUstep application and WindowMaker notify each other about "Hide" and "Hide Others" actions. There are no protocols for "unhide" action.

Test case steps:
  1. Open application with window opened.
  2. Hide application with "Hide" menu item.
  3. Open WindowMaker's "Windows" menu (middle-click on desktop).
  4. Select hidden application window.
 Application unhides, activates, restored window is focused (receives) input and "Hide" menu item unselected.