### PR TITLE
x11/XGServerWindow.m: removed WindowMaker appicon hack

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,21 @@
+2020-09-18  Sergii Stoian  <stoyan255@gmail.com>
+
+	* Source/x11/XGServerWindow.m
+	(_setupRootWindow, window::::): removed WindowMaker appicon hack and
+	- now unused - _wmAppIcon variable.
+
+	Description: The removed code removed creates and maps zero-sized
+	window in hope that WindowMaker will recognize app by this event and
+	create app icon window. Although when application requests window
+	for appicon through the `-window::::` method call, it returns newly
+	created and mapped window. This actually happens but application icon
+	flickers between WM icon creation and application icon window appearance.
+
+	This fix based on the fact that root application window (ROOT) is mapped
+	in `-orderwindow:::` and this is the event of application recognition
+	by WindowMaker because it is a first application window that is
+	mapped.
+
 2020-09-17  Sergii Stoian  <stoyan255@gmail.com>
 
 	* Source/x11/XGServerEvent.m

--- a/Source/x11/XGServerWindow.m
+++ b/Source/x11/XGServerWindow.m
@@ -77,8 +77,6 @@
 
 
 static BOOL handlesWindowDecorations = YES;
-// static int _wmAppIcon = -1;
-
 
 #define WINDOW_WITH_TAG(windowNumber) (gswindow_device_t *)NSMapGet(windowtags, (void *)(uintptr_t)windowNumber)
 
@@ -1599,24 +1597,6 @@ _get_next_prop_new_event(Display *display, XEvent *event, char *arg)
       // FIXME: Need to set WM_CLIENT_MACHINE as well.
     }
 
-  /* WindowMaker hack: We want to display our own app icon window in the
-   * icon window provided by WindowMaker. However, this only works when
-   * the icon window is the first window being mapped. For that reason,
-   * we create an empty icon window here before the code below eventually
-   * generates some temporary windows to determine the window frame offsets
-   * and reuse the icon window once the real app icon window is allocated.
-   */
-  // if ((generic.wm & XGWM_WINDOWMAKER) == XGWM_WINDOWMAKER
-  //     && generic.flags.useWindowMakerIcons == 1)
-  //   {
-  //     NSDebugLLog(@"XGTrace", @"WindowMaker hack: Preparing app icon window");
-  //     _wmAppIcon =
-  //       [self window: NSZeroRect : NSBackingStoreBuffered
-  //       	    : NSIconWindowMask : defScreen];
-  //     [self orderwindow: NSWindowAbove : -1 : _wmAppIcon];
-  //     NSDebugLLog(@"XGTrace", @"WindowMaker hack: icon window = %d", _wmAppIcon);
-  //   }
-
   /* We need to determine the offsets between the actual decorated window
    * and the window we draw into.
    */
@@ -1881,19 +1861,6 @@ _get_next_prop_new_event(Display *display, XEvent *event, char *arg)
   RContext              *context;
 
   NSDebugLLog(@"XGTrace", @"DPSwindow: %@ %d", NSStringFromRect(frame), (int)type);
-  /* WindowMaker hack: Reuse the empty app icon allocated in _setupRootWindow
-   * for the real app icon.
-   */
-  // if ((generic.wm & XGWM_WINDOWMAKER) == XGWM_WINDOWMAKER
-  //     && generic.flags.useWindowMakerIcons == 1
-  //     && (style & NSIconWindowMask) == NSIconWindowMask
-  //     && _wmAppIcon != -1)
-  //   {
-  //     int win = _wmAppIcon;
-  //     NSDebugLLog(@"XGTrace", @"WindowMaker hack: Returning window %d as app icon window", win);
-  //     _wmAppIcon = -1;
-  //     return win;
-  //   }
   root = [self _rootWindow];
   context = [self screenRContext];
 

--- a/Source/x11/XGServerWindow.m
+++ b/Source/x11/XGServerWindow.m
@@ -77,7 +77,7 @@
 
 
 static BOOL handlesWindowDecorations = YES;
-static int _wmAppIcon = -1;
+// static int _wmAppIcon = -1;
 
 
 #define WINDOW_WITH_TAG(windowNumber) (gswindow_device_t *)NSMapGet(windowtags, (void *)(uintptr_t)windowNumber)
@@ -1606,16 +1606,16 @@ _get_next_prop_new_event(Display *display, XEvent *event, char *arg)
    * generates some temporary windows to determine the window frame offsets
    * and reuse the icon window once the real app icon window is allocated.
    */
-  if ((generic.wm & XGWM_WINDOWMAKER) == XGWM_WINDOWMAKER
-      && generic.flags.useWindowMakerIcons == 1)
-    {
-      NSDebugLLog(@"XGTrace", @"WindowMaker hack: Preparing app icon window");
-      _wmAppIcon =
-	[self window: NSZeroRect : NSBackingStoreBuffered
-		    : NSIconWindowMask : defScreen];
-      [self orderwindow: NSWindowAbove : -1 : _wmAppIcon];
-      NSDebugLLog(@"XGTrace", @"WindowMaker hack: icon window = %d", _wmAppIcon);
-    }
+  // if ((generic.wm & XGWM_WINDOWMAKER) == XGWM_WINDOWMAKER
+  //     && generic.flags.useWindowMakerIcons == 1)
+  //   {
+  //     NSDebugLLog(@"XGTrace", @"WindowMaker hack: Preparing app icon window");
+  //     _wmAppIcon =
+  //       [self window: NSZeroRect : NSBackingStoreBuffered
+  //       	    : NSIconWindowMask : defScreen];
+  //     [self orderwindow: NSWindowAbove : -1 : _wmAppIcon];
+  //     NSDebugLLog(@"XGTrace", @"WindowMaker hack: icon window = %d", _wmAppIcon);
+  //   }
 
   /* We need to determine the offsets between the actual decorated window
    * and the window we draw into.
@@ -1884,16 +1884,16 @@ _get_next_prop_new_event(Display *display, XEvent *event, char *arg)
   /* WindowMaker hack: Reuse the empty app icon allocated in _setupRootWindow
    * for the real app icon.
    */
-  if ((generic.wm & XGWM_WINDOWMAKER) == XGWM_WINDOWMAKER
-      && generic.flags.useWindowMakerIcons == 1
-      && (style & NSIconWindowMask) == NSIconWindowMask
-      && _wmAppIcon != -1)
-    {
-      int win = _wmAppIcon;
-      NSDebugLLog(@"XGTrace", @"WindowMaker hack: Returning window %d as app icon window", win);
-      _wmAppIcon = -1;
-      return win;
-    }
+  // if ((generic.wm & XGWM_WINDOWMAKER) == XGWM_WINDOWMAKER
+  //     && generic.flags.useWindowMakerIcons == 1
+  //     && (style & NSIconWindowMask) == NSIconWindowMask
+  //     && _wmAppIcon != -1)
+  //   {
+  //     int win = _wmAppIcon;
+  //     NSDebugLLog(@"XGTrace", @"WindowMaker hack: Returning window %d as app icon window", win);
+  //     _wmAppIcon = -1;
+  //     return win;
+  //   }
   root = [self _rootWindow];
   context = [self screenRContext];
 


### PR DESCRIPTION
The removed code removed creates and maps zero-sized window in hope that WindowMaker will recognize app by this event and  create app icon window. Although when application requests window for appicon through the `-window::::` method call, it returns newly created and mapped window. This actually happens but application icon flickers between WM icon creation and application icon window appearance.

This fix based on the fact that root application window (ROOT) is mapped in `-orderwindow:::` and this is the event of application recognition by WindowMaker because it is a first application window that is mapped.

I've made tests on WindowMaker and NextSpace Workspace WM with ART and Cairo backends. Applications started with double-click is started with 'highlighted' icon and then normal icon without interim state - empty tile background with little white square at the center. It looks as more smooth application startup.