### PR TITLE
Wayland shm surface

### DIFF
--- a/Headers/cairo/WaylandCairoShmSurface.h
+++ b/Headers/cairo/WaylandCairoShmSurface.h
@@ -1,5 +1,5 @@
 /*
-   WaylandCairoSurface.h
+   WaylandCairoShmSurface.h
 
    Copyright (C) 2020 Free Software Foundation, Inc.
 
@@ -25,14 +25,15 @@
    Boston, MA 02110-1301, USA.
 */
 
-#ifndef WaylandCairoSurface_h
-#define WaylandCairoSurface_h
+#ifndef WaylandCairoShmSurface_h
+#define WaylandCairoShmSurface_h
 
 #include "cairo/CairoSurface.h"
 
-@interface WaylandCairoSurface : CairoSurface
+@interface WaylandCairoShmSurface : CairoSurface
 {
 }
+- (void)destroySurface;
 @end
 
 #endif

--- a/Headers/wayland/WaylandServer.h
+++ b/Headers/wayland/WaylandServer.h
@@ -37,7 +37,8 @@
 #include <cairo/cairo.h>
 #include <xkbcommon/xkbcommon.h>
 
-#include "cairo/WaylandCairoSurface.h"
+#include "cairo/CairoSurface.h"
+
 #include "wayland/xdg-shell-client-protocol.h"
 #include "wayland/wlr-layer-shell-client-protocol.h"
 
@@ -138,7 +139,7 @@ struct window
   struct xdg_positioner	*positioner;
   struct zwlr_layer_surface_v1 *layer_surface;
   struct output		*output;
-  WaylandCairoSurface	      *wcs;
+  CairoSurface *wcs;
 };
 
 @interface WaylandServer : GSDisplayServer

--- a/Headers/wayland/WaylandServer.h
+++ b/Headers/wayland/WaylandServer.h
@@ -130,8 +130,6 @@ struct window
   int	is_out;
   int	level;
 
-  unsigned char		*data;
-  struct wl_buffer		   *buffer;
   struct wl_surface	    *surface;
   struct xdg_surface	     *xdg_surface;
   struct xdg_toplevel	      *toplevel;
@@ -139,7 +137,7 @@ struct window
   struct xdg_positioner	*positioner;
   struct zwlr_layer_surface_v1 *layer_surface;
   struct output		*output;
-  CairoSurface *wcs;
+  CairoSurface		       *wcs;
 };
 
 @interface WaylandServer : GSDisplayServer

--- a/Source/cairo/CairoContext.m
+++ b/Source/cairo/CairoContext.m
@@ -73,9 +73,9 @@
 #elif BUILD_SERVER == SERVER_wayland
 #  include "wayland/WaylandServer.h"
 #  include "cairo/CairoGState.h"
-#  include "cairo/WaylandCairoSurface.h"
+#  include "cairo/WaylandCairoShmSurface.h"
 #  define _CAIRO_GSTATE_CLASSNAME CairoGState
-#  define _CAIRO_SURFACE_CLASSNAME WaylandCairoSurface
+#  define _CAIRO_SURFACE_CLASSNAME WaylandCairoShmSurface
 #else
 #  error Invalid server for Cairo backend : non implemented
 #endif /* BUILD_SERVER */

--- a/Source/cairo/GNUmakefile
+++ b/Source/cairo/GNUmakefile
@@ -50,7 +50,7 @@ ifeq ($(BUILD_SERVER),x11)
   endif
 else
   ifeq ($(BUILD_SERVER),wayland)
-    cairo_OBJC_FILES += WaylandCairoSurface.m
+    cairo_OBJC_FILES += WaylandCairoShmSurface.m
   else
     ifeq ($(BUILD_GRAPHICS),cairo)
       ifeq ($(WITH_GLITZ),yes)

--- a/Source/cairo/WaylandCairoShmSurface.m
+++ b/Source/cairo/WaylandCairoShmSurface.m
@@ -1,7 +1,7 @@
 /* WaylandCairoSurface
 
-   WaylandCairoSurface - Draw with Cairo onto Wayland surfaces
-   
+   WaylandCairoShmSurface - Draw with Cairo onto Wayland surfaces
+
 
    Copyright (C) 2020 Free Software Foundation, Inc.
 
@@ -31,7 +31,7 @@
 #define _GNU_SOURCE
 
 #include "wayland/WaylandServer.h"
-#include "cairo/WaylandCairoSurface.h"
+#include "cairo/WaylandCairoShmSurface.h"
 #include <cairo/cairo.h>
 
 #include <stdlib.h>
@@ -135,7 +135,7 @@ create_shm_buffer(struct window *window)
   return surface;
 }
 
-@implementation WaylandCairoSurface
+@implementation WaylandCairoShmSurface
 
 - (id)initWithDevice:(void *)device
 {
@@ -178,7 +178,6 @@ create_shm_buffer(struct window *window)
   // the counterpart to create_shm_buffer.
   //
   // For instance, this is the wrong place to destroy the cairo surface:
-  //  cairo_surface_destroy(window->surface);
   //  window->surface = NULL;
   // and likely to unmap the data, and destroy/release the buffer.
   //  "Destroying the wl_buffer after wl_buffer.release does not change
@@ -188,6 +187,8 @@ create_shm_buffer(struct window *window)
   // Hence also skipping:
   //  munmap(window->data, shm_buffer_size(window));
 
+  cairo_surface_destroy(_surface);
+  _surface = NULL;
   [super dealloc];
 }
 
@@ -233,4 +234,9 @@ create_shm_buffer(struct window *window)
   // NSDebugLog(@"[CairoSurface handleExposeRect end]");
 }
 
+- (void)destroySurface
+{
+  // noop this is an offscreen surface
+  // no need to destroy it when not visible
+}
 @end

--- a/Source/wayland/WaylandServer+Layershell.m
+++ b/Source/wayland/WaylandServer+Layershell.m
@@ -40,9 +40,9 @@ layer_surface_configure(void *data, struct zwlr_layer_surface_v1 *surface,
   window->configured = YES;
   if (window->buffer_needs_attach)
     {
-      NSDebugLog(@"attach: win=%d layer", window->window_id);
-      wl_surface_attach(window->surface, window->buffer, 0, 0);
-      wl_surface_commit(window->surface);
+      [window->instance flushwindowrect:NSMakeRect(window->pos_x, window->pos_y,
+						   window->width, window->height
+						   ):window->window_id];
     }
 }
 

--- a/Source/wayland/WaylandServer+Xdgshell.m
+++ b/Source/wayland/WaylandServer+Xdgshell.m
@@ -56,9 +56,9 @@ xdg_surface_on_configure(void *data, struct xdg_surface *xdg_surface,
 
   if (window->buffer_needs_attach)
     {
-      NSDebugLog(@"attach: win=%d toplevel", window->window_id);
-      wl_surface_attach(window->surface, window->buffer, 0, 0);
-      wl_surface_commit(window->surface);
+      [window->instance flushwindowrect:NSMakeRect(window->pos_x, window->pos_y,
+						   window->width, window->height
+						   ):window->window_id];
     }
 
   if (wlconfig->pointer.focus
@@ -129,7 +129,8 @@ xdg_popup_configure(void *data, struct xdg_popup *xdg_popup, int32_t x,
   struct window *window = data;
   WaylandConfig *wlconfig = window->wlconfig;
 
-  NSDebugLog(@"xdg_popup_configure");
+  NSDebugLog(@"[%d] xdg_popup_configure [%d,%d %dx%d]", window->window_id, x, y,
+	     width, height);
 }
 
 static void


### PR DESCRIPTION
This PR is a refactor of the WaylandCairoSurface, which is an implementation of a Wayland shared memory surface. It includes:
- some documentation on how it works
- a buffer release listener to fix the memory leak present before
- rename to a more specific name as more Wayland surface implementations are possible
- move `wl_surface_attach` calls from the server into the surface class