### PR TITLE
Wayland backend pointer events and cursor images

### DIFF
--- a/Headers/cairo/WaylandCairoShmSurface.h
+++ b/Headers/cairo/WaylandCairoShmSurface.h
@@ -30,6 +30,21 @@
 
 #include "cairo/CairoSurface.h"
 
+struct pool_buffer
+{
+  int		      poolfd;
+  struct wl_shm_pool *pool;
+  struct wl_buffer   *buffer;
+  cairo_surface_t	  *surface;
+  uint32_t	      width, height;
+  void	       *data;
+  size_t	      size;
+  bool		      busy;
+};
+
+struct pool_buffer *
+createShmBuffer(int width, int height, struct wl_shm *shm);
+
 @interface WaylandCairoShmSurface : CairoSurface
 {
 }

--- a/Headers/cairo/WaylandCairoShmSurface.h
+++ b/Headers/cairo/WaylandCairoShmSurface.h
@@ -1,5 +1,5 @@
 /*
-   WaylandCairoSurface.h
+   WaylandCairoShmSurface.h
 
    Copyright (C) 2020 Free Software Foundation, Inc.
 
@@ -25,14 +25,15 @@
    Boston, MA 02110-1301, USA.
 */
 
-#ifndef WaylandCairoSurface_h
-#define WaylandCairoSurface_h
+#ifndef WaylandCairoShmSurface_h
+#define WaylandCairoShmSurface_h
 
 #include "cairo/CairoSurface.h"
 
-@interface WaylandCairoSurface : CairoSurface
+@interface WaylandCairoShmSurface : CairoSurface
 {
 }
+- (void)destroySurface;
 @end
 
 #endif

--- a/Headers/wayland/WaylandServer.h
+++ b/Headers/wayland/WaylandServer.h
@@ -37,7 +37,8 @@
 #include <cairo/cairo.h>
 #include <xkbcommon/xkbcommon.h>
 
-#include "cairo/WaylandCairoSurface.h"
+#include "cairo/CairoSurface.h"
+
 #include "wayland/xdg-shell-client-protocol.h"
 #include "wayland/wlr-layer-shell-client-protocol.h"
 
@@ -138,7 +139,7 @@ struct window
   struct xdg_positioner	*positioner;
   struct zwlr_layer_surface_v1 *layer_surface;
   struct output		*output;
-  WaylandCairoSurface	      *wcs;
+  CairoSurface *wcs;
 };
 
 @interface WaylandServer : GSDisplayServer

--- a/Headers/wayland/WaylandServer.h
+++ b/Headers/wayland/WaylandServer.h
@@ -34,6 +34,7 @@
 
 #include <GNUstepGUI/GSDisplayServer.h>
 #include <wayland-client.h>
+#include <wayland-cursor.h>
 #include <cairo/cairo.h>
 #include <xkbcommon/xkbcommon.h>
 
@@ -60,6 +61,15 @@ struct pointer
 
   uint32_t	 serial;
   struct window *focus;
+
+};
+
+struct cursor
+{
+  struct wl_cursor *cursor;
+  struct wl_surface *surface;
+  struct wl_cursor_image *image;
+  struct wl_buffer *buffer;
 };
 
 typedef struct _WaylandConfig
@@ -73,6 +83,7 @@ typedef struct _WaylandConfig
   struct wl_keyboard	     *keyboard;
   struct xdg_wm_base	     *wm_base;
   struct zwlr_layer_shell_v1 *layer_shell;
+  int seat_version;
 
   struct wl_list output_list;
   int		 output_count;
@@ -80,7 +91,20 @@ typedef struct _WaylandConfig
   int		 window_count;
   int		 last_window_id;
 
+// last event serial from pointer or keyboard
+  uint32_t	 event_serial;
+
+
+// cursor
+  struct wl_cursor_theme *cursor_theme;
+  struct cursor *cursor;
+  struct wl_surface *cursor_surface;
+
+// pointer
   struct pointer      pointer;
+  float mouse_scroll_multiplier;
+
+// keyboard
   struct xkb_context *xkb_context;
   struct
   {
@@ -92,9 +116,6 @@ typedef struct _WaylandConfig
   } xkb;
   int modifiers;
 
-  int seat_version;
-
-  float mouse_scroll_multiplier;
 } WaylandConfig;
 
 struct output
@@ -146,6 +167,8 @@ struct window
   struct output		*output;
   CairoSurface		       *wcs;
 };
+
+struct window *get_window_with_id(WaylandConfig *wlconfig, int winid);
 
 @interface WaylandServer : GSDisplayServer
 {

--- a/Headers/wayland/WaylandServer.h
+++ b/Headers/wayland/WaylandServer.h
@@ -52,6 +52,12 @@ struct pointer
   float		     last_click_x;
   float		     last_click_y;
 
+  uint32_t		       button;
+  NSTimeInterval	   last_timestamp;
+  enum wl_pointer_button_state button_state;
+
+  uint32_t axis_source;
+
   uint32_t	 serial;
   struct window *focus;
 };
@@ -147,8 +153,10 @@ struct window
   BOOL _mouseInitialized;
 }
 @end
+
 @interface
 WaylandServer (Cursor)
+- (void)initializeMouseIfRequired;
 @end
 
 #endif /* _WaylandServer_h_INCLUDE */

--- a/Headers/wayland/WaylandServer.h
+++ b/Headers/wayland/WaylandServer.h
@@ -130,8 +130,6 @@ struct window
   int	is_out;
   int	level;
 
-  unsigned char		*data;
-  struct wl_buffer		   *buffer;
   struct wl_surface	    *surface;
   struct xdg_surface	     *xdg_surface;
   struct xdg_toplevel	      *toplevel;
@@ -139,7 +137,7 @@ struct window
   struct xdg_positioner	*positioner;
   struct zwlr_layer_surface_v1 *layer_surface;
   struct output		*output;
-  CairoSurface *wcs;
+  CairoSurface		       *wcs;
 };
 
 @interface WaylandServer : GSDisplayServer

--- a/Headers/wayland/WaylandServer.h
+++ b/Headers/wayland/WaylandServer.h
@@ -126,6 +126,7 @@ struct window
   BOOL terminated;
   BOOL moving;
   BOOL resizing;
+  BOOL ignoreMouse;
 
   float pos_x;
   float pos_y;

--- a/Headers/wayland/WaylandServer.h
+++ b/Headers/wayland/WaylandServer.h
@@ -61,6 +61,7 @@ struct pointer
 
   uint32_t	 serial;
   struct window *focus;
+  struct window *captured;
 
 };
 

--- a/Source/cairo/CairoContext.m
+++ b/Source/cairo/CairoContext.m
@@ -73,9 +73,9 @@
 #elif BUILD_SERVER == SERVER_wayland
 #  include "wayland/WaylandServer.h"
 #  include "cairo/CairoGState.h"
-#  include "cairo/WaylandCairoSurface.h"
+#  include "cairo/WaylandCairoShmSurface.h"
 #  define _CAIRO_GSTATE_CLASSNAME CairoGState
-#  define _CAIRO_SURFACE_CLASSNAME WaylandCairoSurface
+#  define _CAIRO_SURFACE_CLASSNAME WaylandCairoShmSurface
 #else
 #  error Invalid server for Cairo backend : non implemented
 #endif /* BUILD_SERVER */

--- a/Source/cairo/GNUmakefile
+++ b/Source/cairo/GNUmakefile
@@ -50,7 +50,7 @@ ifeq ($(BUILD_SERVER),x11)
   endif
 else
   ifeq ($(BUILD_SERVER),wayland)
-    cairo_OBJC_FILES += WaylandCairoSurface.m
+    cairo_OBJC_FILES += WaylandCairoShmSurface.m
   else
     ifeq ($(BUILD_GRAPHICS),cairo)
       ifeq ($(WITH_GLITZ),yes)

--- a/Source/cairo/WaylandCairoShmSurface.m
+++ b/Source/cairo/WaylandCairoShmSurface.m
@@ -1,7 +1,7 @@
 /* WaylandCairoSurface
 
-   WaylandCairoSurface - Draw with Cairo onto Wayland surfaces
-   
+   WaylandCairoShmSurface - Draw with Cairo onto Wayland surfaces
+
 
    Copyright (C) 2020 Free Software Foundation, Inc.
 
@@ -31,7 +31,7 @@
 #define _GNU_SOURCE
 
 #include "wayland/WaylandServer.h"
-#include "cairo/WaylandCairoSurface.h"
+#include "cairo/WaylandCairoShmSurface.h"
 #include <cairo/cairo.h>
 
 #include <stdlib.h>
@@ -135,7 +135,7 @@ create_shm_buffer(struct window *window)
   return surface;
 }
 
-@implementation WaylandCairoSurface
+@implementation WaylandCairoShmSurface
 
 - (id)initWithDevice:(void *)device
 {
@@ -178,7 +178,6 @@ create_shm_buffer(struct window *window)
   // the counterpart to create_shm_buffer.
   //
   // For instance, this is the wrong place to destroy the cairo surface:
-  //  cairo_surface_destroy(window->surface);
   //  window->surface = NULL;
   // and likely to unmap the data, and destroy/release the buffer.
   //  "Destroying the wl_buffer after wl_buffer.release does not change
@@ -188,6 +187,8 @@ create_shm_buffer(struct window *window)
   // Hence also skipping:
   //  munmap(window->data, shm_buffer_size(window));
 
+  cairo_surface_destroy(_surface);
+  _surface = NULL;
   [super dealloc];
 }
 
@@ -233,4 +234,9 @@ create_shm_buffer(struct window *window)
   // NSDebugLog(@"[CairoSurface handleExposeRect end]");
 }
 
+- (void)destroySurface
+{
+  // noop this is an offscreen surface
+  // no need to destroy it when not visible
+}
 @end

--- a/Source/wayland/WaylandServer+Cursor.m
+++ b/Source/wayland/WaylandServer+Cursor.m
@@ -51,17 +51,17 @@ pointer_handle_enter(void *data, struct wl_pointer *pointer, uint32_t serial,
 
   struct window *window = wl_surface_get_user_data(surface);
 
-  if(window->ignoreMouse)
-  {
-    return;
-  }
+  if (window->ignoreMouse)
+    {
+      return;
+    }
 
   wlconfig->pointer.focus = window;
 
-  if(wlconfig->pointer.captured)
-  {
-    return;
-  }
+  if (wlconfig->pointer.captured)
+    {
+      return;
+    }
 
   [(WaylandServer *)GSCurrentServer() initializeMouseIfRequired];
 
@@ -115,7 +115,7 @@ pointer_handle_leave(void *data, struct wl_pointer *pointer, uint32_t serial,
 
   struct window *window = wl_surface_get_user_data(surface);
 
-  if(window->ignoreMouse)
+  if (window->ignoreMouse)
     {
       return;
     }
@@ -130,31 +130,31 @@ pointer_handle_leave(void *data, struct wl_pointer *pointer, uint32_t serial,
   if (wlconfig->pointer.focus->window_id == window->window_id
       && wlconfig->pointer.serial)
     {
-      if(wlconfig->pointer.captured == NULL)
+      if (wlconfig->pointer.captured == NULL)
         {
-            window = wlconfig->pointer.focus;
-            NSEvent	      *event;
-            NSPoint		 eventLocation;
-            NSGraphicsContext *gcontext;
+          window = wlconfig->pointer.focus;
+          NSEvent		  *event;
+          NSPoint	     eventLocation;
+          NSGraphicsContext *gcontext;
 
-            gcontext = GSCurrentContext();
+          gcontext = GSCurrentContext();
 
-            eventLocation = NSMakePoint(wlconfig->pointer.x, wlconfig->pointer.y);
-            event = [NSEvent mouseEventWithType:NSMouseExited
-                      location:eventLocation
+          eventLocation = NSMakePoint(wlconfig->pointer.x, wlconfig->pointer.y);
+          event = [NSEvent mouseEventWithType:NSMouseExited
+                          location:eventLocation
                       modifierFlags:0
-                      timestamp:wlconfig->pointer.last_timestamp
+                          timestamp:wlconfig->pointer.last_timestamp
                       windowNumber:window->window_id
-                        context:gcontext
-                        eventNumber:serial
-                        clickCount:0
-                      pressure:0.0
+                          context:gcontext
+                      eventNumber:serial
+                      clickCount:0
+                          pressure:0.0
                       buttonNumber:0
-                        deltaX:0
-                        deltaY:0
-                        deltaZ:0.];
+                          deltaX:0
+                          deltaY:0
+                          deltaZ:0.];
 
-            [GSCurrentServer() postEvent:event atStart:NO];
+          [GSCurrentServer() postEvent:event atStart:NO];
         }
       wlconfig->pointer.focus = NULL;
       wlconfig->pointer.serial = serial;
@@ -170,14 +170,14 @@ pointer_handle_motion(void *data, struct wl_pointer *pointer, uint32_t time,
   WaylandConfig *wlconfig = data;
   struct window *focused_window = wlconfig->pointer.focus;
 
-  if(wlconfig->pointer.captured)
-  {
-    focused_window = wlconfig->pointer.captured;
-  }
-  if(focused_window == NULL || focused_window->ignoreMouse)
-  {
-    return;
-  }
+  if (wlconfig->pointer.captured)
+    {
+      focused_window = wlconfig->pointer.captured;
+    }
+  if (focused_window == NULL || focused_window->ignoreMouse)
+    {
+      return;
+    }
   float sx = wl_fixed_to_double(sx_w);
   float sy = wl_fixed_to_double(sy_w);
 
@@ -261,15 +261,15 @@ pointer_handle_button(void *data, struct wl_pointer *pointer, uint32_t serial,
 
   struct window		*window = wlconfig->pointer.focus;
 
-  if(wlconfig->pointer.captured)
-  {
-    window = wlconfig->pointer.captured;
-  }
+  if (wlconfig->pointer.captured)
+    {
+      window = wlconfig->pointer.captured;
+    }
 
-  if(window == NULL || window->ignoreMouse)
-  {
-    return;
-  }
+  if (window == NULL || window->ignoreMouse)
+    {
+      return;
+    }
   [(WaylandServer *)GSCurrentServer() initializeMouseIfRequired];
 
   gcontext = GSCurrentContext();
@@ -364,12 +364,12 @@ pointer_handle_button(void *data, struct wl_pointer *pointer, uint32_t serial,
     {
       wlconfig->pointer.serial = 0;
       wlconfig->pointer.button = 0;
-      if(window->moving)
+      if (window->moving)
         {
           window->moving = NO;
           return;
         }
-      if(window->resizing)
+      if (window->resizing)
         {
           window->resizing = NO;
           return;
@@ -473,10 +473,10 @@ pointer_handle_axis(void *data, struct wl_pointer *pointer, uint32_t time,
   int		     buttonNumber;
 
   struct window *window = wlconfig->pointer.focus;
-  if(window->ignoreMouse)
-  {
-    return;
-  }
+  if (window->ignoreMouse)
+    {
+      return;
+    }
 
   [(WaylandServer *)GSCurrentServer() initializeMouseIfRequired];
 
@@ -757,24 +757,24 @@ WaylandServer (Cursor)
 - (void)setcursor:(void *)cid
 {
   struct cursor *wayland_cursor = cid;
-  if(wayland_cursor == NULL)
+  if (wayland_cursor == NULL)
     {
       return;
     }
-  if(wayland_cursor->cursor == NULL)
+  if (wayland_cursor->cursor == NULL)
     {
       return;
     }
-  if(wayland_cursor->image == NULL)
+  if (wayland_cursor->image == NULL)
     {
       return;
     }
-  if(wayland_cursor->buffer == NULL)
+  if (wayland_cursor->buffer == NULL)
     {
       return;
     }
 
-  if(wayland_cursor->surface)
+  if (wayland_cursor->surface)
     {
       wl_surface_destroy(wayland_cursor->surface);
     }

--- a/Source/wayland/WaylandServer+Cursor.m
+++ b/Source/wayland/WaylandServer+Cursor.m
@@ -49,7 +49,10 @@ pointer_handle_enter(void *data, struct wl_pointer *pointer, uint32_t serial,
 
   WaylandConfig *wlconfig = data;
   struct window *window = wl_surface_get_user_data(surface);
-
+  if(window->ignoreMouse)
+  {
+    return;
+  }
   NSDebugLog(@"[%d] pointer_handle_enter",window->window_id);
 
   float		 sx = wl_fixed_to_double(sx_w);
@@ -103,6 +106,10 @@ pointer_handle_leave(void *data, struct wl_pointer *pointer, uint32_t serial,
 
   WaylandConfig *wlconfig = data;
   struct window *window = wl_surface_get_user_data(surface);
+  if(window->ignoreMouse)
+  {
+    return;
+  }
   [(WaylandServer *)GSCurrentServer() initializeMouseIfRequired];
 
   if (wlconfig->pointer.focus->window_id == window->window_id
@@ -145,7 +152,10 @@ pointer_handle_motion(void *data, struct wl_pointer *pointer, uint32_t time,
 {
   WaylandConfig *wlconfig = data;
   struct window *focused_window = wlconfig->pointer.focus;
-
+  if(window->ignoreMouse)
+  {
+    return;
+  }
   float sx = wl_fixed_to_double(sx_w);
   float sy = wl_fixed_to_double(sy_w);
 
@@ -226,7 +236,10 @@ pointer_handle_button(void *data, struct wl_pointer *pointer, uint32_t serial,
   int			       buttonNumber;
   enum wl_pointer_button_state state = state_w;
   struct window		*window = wlconfig->pointer.focus;
-
+  if(window->ignoreMouse)
+  {
+    return;
+  }
   [(WaylandServer *)GSCurrentServer() initializeMouseIfRequired];
 
   gcontext = GSCurrentContext();
@@ -432,6 +445,10 @@ pointer_handle_axis(void *data, struct wl_pointer *pointer, uint32_t time,
   int		     buttonNumber;
 
   struct window *window = wlconfig->pointer.focus;
+  if(window->ignoreMouse)
+  {
+    return;
+  }
 
   [(WaylandServer *)GSCurrentServer() initializeMouseIfRequired];
 
@@ -610,7 +627,12 @@ WaylandServer (Cursor)
 }
 - (void)setIgnoreMouse:(BOOL)ignoreMouse :(int)win
 {
-  NSDebugLog(@"setIgnoreMouse");
+  struct window *window = get_window_with_id(wlconfig, win);
+  if(window)
+  {
+    window->ignoreMouse = ignoreMouse;
+  }
+
 }
 
 - (void)initializeMouseIfRequired

--- a/Source/wayland/WaylandServer+Cursor.m
+++ b/Source/wayland/WaylandServer+Cursor.m
@@ -596,10 +596,8 @@ WaylandServer (Cursor)
 
 - (BOOL)capturemouse:(int)win
 {
-
   struct window *window = get_window_with_id(wlconfig, win);
   wlconfig->pointer.captured = window;
-  wlconfig->pointer.focus = window;
   return YES;
 }
 

--- a/Source/wayland/WaylandServer+Cursor.m
+++ b/Source/wayland/WaylandServer+Cursor.m
@@ -1,4 +1,4 @@
-/* 
+/*
    WaylandServer - Cursor Handling
 
    Copyright (C) 2020 Free Software Foundation, Inc.
@@ -26,13 +26,16 @@
 */
 
 #include "wayland/WaylandServer.h"
-#include <AppKit/NSEvent.h>
-#include <AppKit/NSView.h>
-#include <AppKit/NSWindow.h>
-#include <AppKit/GSWindowDecorationView.h>
-#include <AppKit/GSTheme.h>
-#include <AppKit/NSApplication.h>
+#import <AppKit/NSEvent.h>
+#import <AppKit/NSView.h>
+#import <AppKit/NSWindow.h>
+#import <GNUstepGUI/GSWindowDecorationView.h>
+#import <GNUstepGUI/GSTheme.h>
 #include <linux/input.h>
+
+// XXX should this be configurable by the user?
+#define DOUBLECLICK_DELAY 300
+#define DOUBLECLICK_MOVE_THREASHOLD 3
 
 static void
 pointer_handle_enter(void *data, struct wl_pointer *pointer, uint32_t serial,
@@ -41,21 +44,52 @@ pointer_handle_enter(void *data, struct wl_pointer *pointer, uint32_t serial,
 {
   if (!surface)
     {
-      NSDebugLog(@"no surface");
       return;
     }
 
   WaylandConfig *wlconfig = data;
   struct window *window = wl_surface_get_user_data(surface);
+
+  NSDebugLog(@"[%d] pointer_handle_enter",window->window_id);
+
   float		 sx = wl_fixed_to_double(sx_w);
   float		 sy = wl_fixed_to_double(sy_w);
-  [GSCurrentServer() initializeMouseIfRequired];
+  [(WaylandServer *)GSCurrentServer() initializeMouseIfRequired];
+
+  wlconfig->pointer.focus = window;
+
+  if (wlconfig->pointer.focus && wlconfig->pointer.serial)
+    {
+      window = wlconfig->pointer.focus;
+      NSEvent	      *event;
+      NSPoint		 eventLocation;
+      NSGraphicsContext *gcontext;
+
+      float		 deltaX = sx - wlconfig->pointer.x;
+      float		 deltaY = sy - wlconfig->pointer.y;
+
+      gcontext = GSCurrentContext();
+      eventLocation = NSMakePoint(sx, window->height - sy);
+
+      event = [NSEvent mouseEventWithType:NSMouseEntered
+				 location:eventLocation
+			    modifierFlags:wlconfig->modifiers
+				timestamp:wlconfig->pointer.last_timestamp
+			     windowNumber:window->window_id
+				  context:gcontext
+			      eventNumber:serial
+			       clickCount:0
+				 pressure:0.0
+			     buttonNumber:0
+				   deltaX:deltaX
+				   deltaY:deltaY
+				   deltaZ:0.];
+
+      [GSCurrentServer() postEvent:event atStart:NO];
+    }
 
   wlconfig->pointer.x = sx;
   wlconfig->pointer.y = sy;
-  wlconfig->pointer.focus = window;
-
-  // FIXME: Send NSMouseEntered event.
 }
 
 static void
@@ -64,21 +98,44 @@ pointer_handle_leave(void *data, struct wl_pointer *pointer, uint32_t serial,
 {
   if (!surface)
     {
-      NSDebugLog(@"no surface");
       return;
     }
 
   WaylandConfig *wlconfig = data;
   struct window *window = wl_surface_get_user_data(surface);
-  [GSCurrentServer() initializeMouseIfRequired];
+  [(WaylandServer *)GSCurrentServer() initializeMouseIfRequired];
 
-  if (wlconfig->pointer.focus->window_id == window->window_id)
+  if (wlconfig->pointer.focus->window_id == window->window_id
+      && wlconfig->pointer.serial)
     {
+      window = wlconfig->pointer.focus;
+      NSEvent	      *event;
+      NSPoint		 eventLocation;
+      NSGraphicsContext *gcontext;
+
+      gcontext = GSCurrentContext();
+
+      eventLocation = NSMakePoint(wlconfig->pointer.x, wlconfig->pointer.y);
+
+      event = [NSEvent mouseEventWithType:NSMouseExited
+                location:eventLocation
+                modifierFlags:wlconfig->modifiers
+                timestamp:wlconfig->pointer.last_timestamp
+                windowNumber:window->window_id
+                  context:gcontext
+                  eventNumber:serial
+                  clickCount:0
+                pressure:0.0
+                buttonNumber:0
+                  deltaX:0
+                  deltaY:0
+                  deltaZ:0.];
+
+      [GSCurrentServer() postEvent:event atStart:NO];
+
       wlconfig->pointer.focus = NULL;
       wlconfig->pointer.serial = 0;
     }
-
-  // FIXME: Send NSMouseExited event.
 }
 
 // triggered when the cursor is over a surface
@@ -87,50 +144,60 @@ pointer_handle_motion(void *data, struct wl_pointer *pointer, uint32_t time,
 		      wl_fixed_t sx_w, wl_fixed_t sy_w)
 {
   WaylandConfig *wlconfig = data;
-  struct window *window;
-  if (window->moving || window->resizing)
-    {
-      return;
-    }
+  struct window *focused_window = wlconfig->pointer.focus;
+
   float sx = wl_fixed_to_double(sx_w);
   float sy = wl_fixed_to_double(sy_w);
 
-  [GSCurrentServer() initializeMouseIfRequired];
+  wlconfig->pointer.last_timestamp = (NSTimeInterval) time / 1000.0;
 
-  if (wlconfig->pointer.focus && wlconfig->pointer.serial)
+  [(WaylandServer *)GSCurrentServer() initializeMouseIfRequired];
+
+  if (focused_window && wlconfig->pointer.serial)
     {
-      window = wlconfig->pointer.focus;
       NSEvent	      *event;
       NSEventType	 eventType;
       NSPoint		 eventLocation;
       NSGraphicsContext *gcontext;
       unsigned int	 eventFlags;
-      float		 deltaX = sx - window->wlconfig->pointer.x;
-      float		 deltaY = sy - window->wlconfig->pointer.y;
 
-      //	NSDebugLog(@"obtaining locations: wayland=%fx%f pointer=%fx%f",
-      //		   sx, sy, window->wlconfig->pointer.x,
-      //window->wlconfig->pointer.y);
+      float		 deltaX = sx - wlconfig->pointer.x;
+      float		 deltaY = sy - wlconfig->pointer.y;
 
       gcontext = GSCurrentContext();
-      eventLocation = NSMakePoint(sx, window->height - sy);
+      eventLocation = NSMakePoint(sx, focused_window->height - sy);
 
-      eventFlags = 0;
-      eventType = NSLeftMouseDragged;
+      eventFlags = wlconfig->modifiers;
 
-      //	NSDebugLog(@"sending pointer delta: %fx%f, window=%d", deltaX,
-      //deltaY, window->window_id);
+      eventType = NSMouseMoved;
+
+      if (wlconfig->pointer.button_state == WL_POINTER_BUTTON_STATE_PRESSED)
+        {
+
+          switch (wlconfig->pointer.button)
+            {
+              case BTN_LEFT:
+                eventType = NSLeftMouseDragged;
+                break;
+              case BTN_RIGHT:
+                eventType = NSRightMouseDragged;
+                break;
+              case BTN_MIDDLE:
+                eventType = NSOtherMouseDragged;
+                break;
+            }
+        }
 
       event = [NSEvent mouseEventWithType:eventType
 				 location:eventLocation
 			    modifierFlags:eventFlags
-				timestamp:(NSTimeInterval) time / 1000.0
-			     windowNumber:(int) window->window_id
+				timestamp:wlconfig->pointer.last_timestamp
+			     windowNumber:(int) focused_window->window_id
 				  context:gcontext
 			      eventNumber:time
-			       clickCount:1
-				 pressure:1.0
-			     buttonNumber:0 /* FIXME */
+			       clickCount:0
+				 pressure:1.0 // XXX should this be 0 when no button is pressed?
+			     buttonNumber:wlconfig->pointer.button
 				   deltaX:deltaX
 				   deltaY:deltaY
 				   deltaZ:0.];
@@ -160,231 +227,132 @@ pointer_handle_button(void *data, struct wl_pointer *pointer, uint32_t serial,
   enum wl_pointer_button_state state = state_w;
   struct window		*window = wlconfig->pointer.focus;
 
-  [GSCurrentServer() initializeMouseIfRequired];
+  [(WaylandServer *)GSCurrentServer() initializeMouseIfRequired];
 
   gcontext = GSCurrentContext();
   eventLocation
     = NSMakePoint(wlconfig->pointer.x, window->height - wlconfig->pointer.y);
-  eventFlags = 0;
+  eventFlags = wlconfig->modifiers;
+  NSTimeInterval timestamp = (NSTimeInterval) time / 1000.0;
 
-  if (window->toplevel)
-    {
-      // if the window is a toplevel we check if the event is for resizing or
-      // moving the window these actions are delegated to the compositor and
-      // therefore we skip forwarding the events to the NSWindow / NSView
-
-      NSWindow *nswindow = GSWindowWithNumber(window->window_id);
-      if (nswindow != nil)
-	{
-	  GSWindowDecorationView *wd = [GSWindowDecorationView windowDecorator];
-	  //            NSPoint p = [[nswindow contentView] convertPoint:
-	  //            eventLocation fromView: nil];
-	  GSTheme *theme = [GSTheme theme];
-	  CGFloat  titleHeight = [theme titlebarHeight];
-	  CGFloat  resizebarHeight = [theme resizebarHeight];
-	  NSRect   windowframe = [nswindow frame];
-	  NSDebugLog(@"[%d] titleHeight: %f", window->window_id, titleHeight);
-	  NSDebugLog(@"[%d] resizebarHeight: %f", window->window_id,
-		     resizebarHeight);
-	  NSDebugLog(@"[%d] windowframe: %f,%f %fx%f", windowframe.origin.x,
-		     windowframe.origin.y, windowframe.size.width,
-		     windowframe.size.height);
-	  NSDebugLog(@"[%d] eventLocation: %f,%f", window->window_id,
-		     eventLocation.x, eventLocation.y);
-
-	  NSRect     titleBarRect = NSZeroRect;
-	  NSRect     resizeBarRect = NSZeroRect;
-	  NSRect     closeButtonRect = NSZeroRect;
-	  NSRect     miniaturizeButtonRect = NSZeroRect;
-	  NSUInteger styleMask = [nswindow styleMask];
-	  bool	     hasTitleBar = NO;
-	  bool	     hasResizeBar = NO;
-	  bool	     hasCloseButton = NO;
-	  bool	     hasMiniaturizeButton = NO;
-
-	  // wayland controls the window move / resize
-
-	  if (styleMask
-	      & (NSTitledWindowMask | NSClosableWindowMask
-		 | NSMiniaturizableWindowMask))
-	    {
-	      hasTitleBar = YES;
-	      titleBarRect
-		= NSMakeRect(0.0, windowframe.size.height - titleHeight,
-			     windowframe.size.width, titleHeight);
-
-	      NSDebugLog(@"[%d] titleBarRect: %f,%f %fx%f",
-			 titleBarRect.origin.x, titleBarRect.origin.y,
-			 titleBarRect.size.width, titleBarRect.size.height);
-	    }
-
-	  if (styleMask & NSResizableWindowMask)
-	    {
-	      hasResizeBar = YES;
-	      float padding = 10.0;
-	      resizeBarRect = NSMakeRect(-padding, -padding,
-					 windowframe.size.width + padding * 2,
-					 resizebarHeight + padding * 2);
-
-	      NSDebugLog(@"[%d] resizeBarRect: %f,%f %fx%f",
-			 resizeBarRect.origin.x, resizeBarRect.origin.y,
-			 resizeBarRect.size.width, resizeBarRect.size.height);
-	    }
-
-	  if (styleMask & NSClosableWindowMask)
-	    {
-	      hasCloseButton = YES;
-
-	      closeButtonRect
-		= NSMakeRect(windowframe.size.width - [theme titlebarButtonSize]
-			       - [theme titlebarPaddingRight],
-			     windowframe.size.height -
-			       [theme titlebarButtonSize] -
-			       [theme titlebarPaddingTop],
-			     [theme titlebarButtonSize],
-			     [theme titlebarButtonSize]);
-	    }
-
-	  if (styleMask & NSMiniaturizableWindowMask)
-	    {
-	      hasMiniaturizeButton = YES;
-	      miniaturizeButtonRect = NSMakeRect([theme titlebarPaddingLeft],
-						 windowframe.size.height -
-						   [theme titlebarButtonSize] -
-						   [theme titlebarPaddingTop],
-						 [theme titlebarButtonSize],
-						 [theme titlebarButtonSize]);
-	    }
-
-	  if (hasTitleBar && !NSPointInRect(eventLocation, closeButtonRect)
-	      && !NSPointInRect(eventLocation, miniaturizeButtonRect)
-	      && NSPointInRect(eventLocation, titleBarRect))
-	    {
-	      NSDebugLog(@"[%d] point in titleBarRect [%f,%f] [%f,%f %fx%f]",
-			 window->window_id, eventLocation.x, eventLocation.y,
-			 titleBarRect.origin.x, titleBarRect.origin.y,
-			 titleBarRect.size.width, titleBarRect.size.height);
-
-	      if (state == WL_POINTER_BUTTON_STATE_PRESSED)
-		{
-		  xdg_toplevel_move(window->toplevel, wlconfig->seat, serial);
-		  window->moving = YES;
-		  return;
-		}
-	      else
-		{
-		  window->moving = NO;
-		}
-	    }
-	  if (hasResizeBar && NSPointInRect(eventLocation, resizeBarRect))
-	    {
-	      uint32_t edges = XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_RIGHT;
-	      NSDebugLog(@"[%d] point in resizeBarRect [%f,%f] [%f,%f %fx%f]",
-			 window->window_id, eventLocation.x, eventLocation.y,
-			 resizeBarRect.origin.x, resizeBarRect.origin.y,
-			 resizeBarRect.size.width, resizeBarRect.size.height);
-
-	      if (resizeBarRect.size.width < 30 * 2
-		  && eventLocation.x < resizeBarRect.size.width / 2)
-		{
-		  edges = XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_LEFT;
-		}
-	      else if (eventLocation.x > resizeBarRect.size.width - 30)
-		{
-		  edges = XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_RIGHT;
-		}
-	      else if (eventLocation.x < 29)
-		{
-		  edges = XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_LEFT;
-		}
-	      else
-		{
-		  edges = XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM;
-		}
-
-	      if (state == WL_POINTER_BUTTON_STATE_PRESSED)
-		{
-		  xdg_toplevel_resize(window->toplevel, wlconfig->seat, serial,
-				      edges);
-		  window->resizing = YES;
-		  return;
-		}
-	      else
-		{
-		  window->resizing = NO;
-		}
-	    }
-	}
-    } // endif window->toplevel
 
   if (state == WL_POINTER_BUTTON_STATE_PRESSED)
     {
-      if (button == wlconfig->pointer.last_click_button
-	  && time - wlconfig->pointer.last_click_time < 300
-	  && abs(wlconfig->pointer.x - wlconfig->pointer.last_click_x) < 3
-	  && abs(wlconfig->pointer.y - wlconfig->pointer.last_click_y) < 3)
-	{
-	  wlconfig->pointer.last_click_time = 0;
-	  clickCount++;
-	}
-      else
-	{
-	  NSDebugLog(@"handle_button MISS: b=%d t=%d x=%f y=%f", button, time,
-		     wlconfig->pointer.x, wlconfig->pointer.y);
-	  wlconfig->pointer.last_click_button = button;
-	  wlconfig->pointer.last_click_time = time;
-	  wlconfig->pointer.last_click_x = wlconfig->pointer.x;
-	  wlconfig->pointer.last_click_y = wlconfig->pointer.y;
-	}
+      if (window->toplevel)
+        {
+          // if the window is a toplevel we check if the event is for resizing or
+          // moving the window these actions are delegated to the compositor and
+          // therefore we skip forwarding the events to the NSWindow / NSView
 
-      switch (button)
+          NSWindow *nswindow = GSWindowWithNumber(window->window_id);
+          if (nswindow != nil)
+            {
+              id<GSWindowDecorator> *wd = [nswindow _windowView];
+
+              if ([wd pointInTitleBarRect:eventLocation])
+                {
+                  xdg_toplevel_move(window->toplevel, wlconfig->seat, serial);
+                  window->moving = YES;
+                  return;
+                }
+              if ([wd pointInResizeBarRect:eventLocation])
+                {
+                  GSResizeEdgeMode mode = [wd resizeModeForPoint:eventLocation];
+
+                  uint32_t edges = XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_RIGHT;
+
+                  if (mode == GSResizeEdgeBottomLeftMode)
+                    {
+                      edges = XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_LEFT;
+                    }
+                  else if (mode == GSResizeEdgeBottomRightMode)
+                    {
+                      edges = XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_RIGHT;
+                    }
+                  else if (mode == GSResizeEdgeBottomMode)
+                    {
+                      edges = XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM;
+                    }
+
+                    xdg_toplevel_resize(window->toplevel, wlconfig->seat, serial,
+                                edges);
+                    window->resizing = YES;
+                    return;
+                }
+            } // endif nswindow != nil
+        } // endif window->toplevel
+
+      if (button == wlconfig->pointer.last_click_button
+	  && time - wlconfig->pointer.last_click_time < DOUBLECLICK_DELAY
+	  && fabsf(wlconfig->pointer.x - wlconfig->pointer.last_click_x)
+	       < DOUBLECLICK_MOVE_THREASHOLD
+	  && fabsf(wlconfig->pointer.y - wlconfig->pointer.last_click_y)
+	       < DOUBLECLICK_MOVE_THREASHOLD)
 	{
-	case BTN_LEFT:
-	  eventType = NSLeftMouseDown;
-	  break;
-	case BTN_RIGHT:
-	  eventType = NSRightMouseDown;
-	  break;
-	case BTN_MIDDLE:
-	  eventType = NSOtherMouseDown;
-	  break;
-	  // TODO: handle BTN_SIDE, BTN_EXTRA, BTN_FORWARD, BTN_BACK and other
-	  // constants in libinput.
-	  // We may just want to send NSOtherMouseDown and populate buttonNumber
-	  // with the libinput constant?
-	}
+          wlconfig->pointer.last_click_time = 0;
+          clickCount++;
+        }
+      else
+        {
+          wlconfig->pointer.last_click_button = button;
+          wlconfig->pointer.last_click_time = time;
+          wlconfig->pointer.last_click_x = wlconfig->pointer.x;
+          wlconfig->pointer.last_click_y = wlconfig->pointer.y;
+        }
       wlconfig->pointer.serial = serial;
+      switch (button)
+        {
+          case BTN_LEFT:
+            eventType = NSLeftMouseDown;
+            break;
+          case BTN_RIGHT:
+            eventType = NSRightMouseDown;
+            break;
+          case BTN_MIDDLE:
+            eventType = NSOtherMouseDown;
+            break;
+          // TODO: handle BTN_SIDE, BTN_EXTRA, BTN_FORWARD, BTN_BACK and other
+          // constants in libinput.
+          // We may just want to send NSOtherMouseDown and populate buttonNumber
+          // with the libinput constant?
+        }
     }
   else if (state == WL_POINTER_BUTTON_STATE_RELEASED)
     {
-      switch (button)
-	{
-	case BTN_LEFT:
-	  eventType = NSLeftMouseUp;
-	  break;
-	case BTN_RIGHT:
-	  eventType = NSRightMouseUp;
-	  break;
-	case BTN_MIDDLE:
-	  eventType = NSOtherMouseUp;
-	  break;
-	}
       wlconfig->pointer.serial = 0;
+      if(window->moving)
+        {
+          window->moving = NO;
+          return;
+        }
+      if(window->resizing)
+        {
+          window->resizing = NO;
+          return;
+        }
+      switch (button)
+        {
+          case BTN_LEFT:
+            eventType = NSLeftMouseUp;
+            break;
+          case BTN_RIGHT:
+            eventType = NSRightMouseUp;
+            break;
+          case BTN_MIDDLE:
+            eventType = NSOtherMouseUp;
+            break;
+        }
     }
   else
     {
       return;
     }
-
   /* FIXME: unlike in _motion and _axis handlers, the argument used in _button
      is the "serial" of the event, not passed and unavailable in _motion and
      _axis handlers. Is it allowed to pass "serial" as the eventNumber: in
      _button handler, but "time" as the eventNumber: in the _motion and _axis
      handlers? */
   tick = serial;
-
-  NSDebugLog(@"sending pointer event at: %fx%f, window=%d", wlconfig->pointer.x,
-	     wlconfig->pointer.y, window->window_id);
 
   /* FIXME: X11 backend uses the XGetPointerMapping()-returned values from
      its map_return argument as constants for buttonNumber. As the variant
@@ -397,7 +365,7 @@ pointer_handle_button(void *data, struct wl_pointer *pointer, uint32_t serial,
   event = [NSEvent mouseEventWithType:eventType
 			     location:eventLocation
 			modifierFlags:eventFlags
-			    timestamp:(NSTimeInterval) time / 1000.0
+			    timestamp:timestamp
 			 windowNumber:(int) window->window_id
 			      context:gcontext
 			  eventNumber:tick
@@ -409,14 +377,49 @@ pointer_handle_button(void *data, struct wl_pointer *pointer, uint32_t serial,
 			       deltaZ:0.];
 
   [GSCurrentServer() postEvent:event atStart:NO];
+
+  // store button state for mouse move handlers
+  wlconfig->pointer.button = button;
+  wlconfig->pointer.button_state = state;
+  wlconfig->pointer.last_timestamp = timestamp;
+
 }
 
+// Discrete step information for scroll and other axes.
+static void
+pointer_handle_frame(void *data, struct wl_pointer *pointer)
+{
+
+}
+
+// Source information for scroll and other axes.
+static void
+pointer_handle_axis_source(void *data, struct wl_pointer *pointer,
+			   uint32_t axis_source)
+{
+  WaylandConfig		*wlconfig = data;
+  wlconfig->pointer.axis_source = axis_source;
+}
+
+// Stop notification for scroll and other axes.
+static void
+pointer_handle_axis_stop(void *data, struct wl_pointer *pointer, uint32_t time,
+			 uint32_t axis)
+{}
+
+// Discrete step information for scroll and other axes.
+static void
+pointer_handle_axis_discrete(void *data, struct wl_pointer *pointer,
+		    uint32_t axis, int discrete)
+{
+
+}
+
+// Scroll and other axis notifications.
 static void
 pointer_handle_axis(void *data, struct wl_pointer *pointer, uint32_t time,
 		    uint32_t axis, wl_fixed_t value)
 {
-  NSDebugLog(@"pointer_handle_axis: axis=%d value=%g", axis,
-	     wl_fixed_to_double(value));
   WaylandConfig	*wlconfig = data;
   NSEvent		  *event;
   NSEventType	     eventType;
@@ -430,22 +433,23 @@ pointer_handle_axis(void *data, struct wl_pointer *pointer, uint32_t time,
 
   struct window *window = wlconfig->pointer.focus;
 
-  [GSCurrentServer() initializeMouseIfRequired];
+  [(WaylandServer *)GSCurrentServer() initializeMouseIfRequired];
 
   gcontext = GSCurrentContext();
   eventLocation
     = NSMakePoint(wlconfig->pointer.x, window->height - wlconfig->pointer.y);
-  eventFlags = 0;
+  eventFlags = wlconfig->modifiers;
 
-  /* FIXME: we should get axis_source out of wl_pointer; however, the wl_pointer
-     is not defined in wayland-client.h. How does one get the axis_source out of
-     it to confirm the source is the physical mouse wheel? */
-#if 0
-  if (pointer->axis_source != WL_POINTER_AXIS_SOURCE_WHEEL)
-    return;
-#endif
+  if (wlconfig->pointer.axis_source != WL_POINTER_AXIS_SOURCE_WHEEL)
+  {
+    //axis_source == WL POINTER AXIS SOURCE FINGER
+    //axis_source == WL POINTER AXIS SOURCE CONTINUOUS
+    // XXX the scroll is from trackpad we should calculate
+    // the momentumPhase
+    NSDebugLog(@"touch scroll");
+  }
 
-  float mouse_scroll_multiplier = wlconfig->mouse_scroll_multiplier;
+  //float mouse_scroll_multiplier = wlconfig->mouse_scroll_multiplier;
   /* For smooth-scroll events, we're not doing any cross-event or delta
      calculations, as is done in button event handling. */
   switch (axis)
@@ -458,9 +462,6 @@ pointer_handle_axis(void *data, struct wl_pointer *pointer, uint32_t time,
       deltaX = wl_fixed_to_double(value) * wlconfig->mouse_scroll_multiplier;
     }
 
-  NSDebugLog(@"sending pointer scroll at: %fx%f, value %fx%f, window=%d",
-	     wlconfig->pointer.x, wlconfig->pointer.y, deltaX, deltaY,
-	     window->window_id);
 
   /* FIXME: X11 backend uses the XGetPointerMapping()-returned values from
      its map_return argument as constants for buttonNumber. As the variant
@@ -487,29 +488,31 @@ pointer_handle_axis(void *data, struct wl_pointer *pointer, uint32_t time,
   [GSCurrentServer() postEvent:event atStart:NO];
 }
 
+// the Seat category uses this listener
 const struct wl_pointer_listener pointer_listener = {
   pointer_handle_enter,	 pointer_handle_leave, pointer_handle_motion,
-  pointer_handle_button, pointer_handle_axis,
+  pointer_handle_button, pointer_handle_axis, pointer_handle_frame, pointer_handle_axis_source,
+  pointer_handle_axis_stop, pointer_handle_axis_discrete
 };
 
 @implementation
 WaylandServer (Cursor)
 - (NSPoint)mouselocation
 {
-  int		 aScreen = -1;
-  struct output *output;
+  int aScreen = -1;
 
-  NSDebugLog(@"mouselocation");
+  if (wl_list_length(&wlconfig->output_list) == 0)
+    {
+      return NSZeroPoint;
+    }
+  struct output *output = (struct output *)wlconfig->output_list.next;
+  aScreen = output->server_output_id;
 
-  // FIXME: find a cleaner way to get the first element of a wl_list
-  wl_list_for_each(output, &wlconfig->output_list, link)
-  {
-    aScreen = output->server_output_id;
-    break;
-  }
   if (aScreen < 0)
-    // No outputs in the wl_list.
-    return NSZeroPoint;
+    {
+      // No outputs in the wl_list.
+      return NSZeroPoint;
+    }
 
   return [self mouseLocationOnScreen:aScreen window:NULL];
 }
@@ -523,37 +526,27 @@ WaylandServer (Cursor)
   float		 x;
   float		 y;
 
-  /*if (wlconfig->pointer.serial) {
-      NSDebugLog(@"captured");
-      x = wlconfig->pointer.captured_x;
-      y = wlconfig->pointer.captured_y;
-      } else*/
-  {
-    // NSDebugLog(@"NOT captured");
-    x = wlconfig->pointer.x;
-    y = wlconfig->pointer.y;
+  x = wlconfig->pointer.x;
+  y = wlconfig->pointer.y;
 
-    if (window)
-      {
-	x += window->pos_x;
-	y += window->pos_y;
-	if (win)
-	  {
-	    *win = &window->window_id;
-	  }
-      }
-  }
+  if (window)
+    {
+      x += window->pos_x;
+      y += window->pos_y;
+      if (win)
+        {
+          *win = window->window_id;
+        }
+    }
 
   wl_list_for_each(output, &wlconfig->output_list, link)
   {
     if (output->server_output_id == aScreen)
       {
-	y = output->height - y;
-	break;
+        y = output->height - y;
+        break;
       }
   }
-
-  //    NSDebugLog(@"mouseLocationOnScreen: returning %fx%f", x, y);
 
   return NSMakePoint(x, y);
 }
@@ -571,7 +564,7 @@ WaylandServer (Cursor)
 
 - (void)setMouseLocation:(NSPoint)mouseLocation onScreen:(int)aScreen
 {
-  NSDebugLog(@"setMouseLocation");
+  NSDebugLog(@"setMouseLocation: not supported");
 }
 
 - (void)hidecursor
@@ -584,24 +577,24 @@ WaylandServer (Cursor)
   NSDebugLog(@"showcursor");
 }
 
-- (void)standardcursor:(int)style:(void **)cid
+- (void)standardcursor:(int)style :(void **)cid
 {
   NSDebugLog(@"standardcursor");
 }
 
-- (void)imagecursor:(NSPoint)hotp:(NSImage *)image:(void **)cid
+- (void)imagecursor:(NSPoint)hotp :(NSImage *)image :(void **)cid
 {
   NSDebugLog(@"imagecursor");
 }
 
-- (void)setcursorcolor:(NSColor *)fg:(NSColor *)bg:(void *)cid
+- (void)setcursorcolor:(NSColor *)fg :(NSColor *)bg :(void *)cid
 {
   NSLog(@"Call to obsolete method -setcursorcolor:::");
   [self recolorcursor:fg:bg:cid];
   [self setcursor:cid];
 }
 
-- (void)recolorcursor:(NSColor *)fg:(NSColor *)bg:(void *)cid
+- (void) recolorcursor:(NSColor *)fg :(NSColor *)bg :(void*) cid
 {
   NSDebugLog(@"recolorcursor");
 }
@@ -615,7 +608,7 @@ WaylandServer (Cursor)
 {
   NSDebugLog(@"freecursor");
 }
-- (void)setIgnoreMouse:(BOOL)ignoreMouse:(int)win
+- (void)setIgnoreMouse:(BOOL)ignoreMouse :(int)win
 {
   NSDebugLog(@"setIgnoreMouse");
 }

--- a/Source/wayland/WaylandServer+Keyboard.m
+++ b/Source/wayland/WaylandServer+Keyboard.m
@@ -105,12 +105,16 @@ keyboard_handle_enter(void *data, struct wl_keyboard *keyboard, uint32_t serial,
 		      struct wl_surface *surface, struct wl_array *keys)
 {
   // NSDebugLog(@"keyboard_handle_enter");
+  WaylandConfig	*wlconfig = data;
+  wlconfig->event_serial = serial;
 }
 
 static void
 keyboard_handle_leave(void *data, struct wl_keyboard *keyboard, uint32_t serial,
 		      struct wl_surface *surface)
 {
+  WaylandConfig	*wlconfig = data;
+  wlconfig->event_serial = serial;
   // NSDebugLog(@"keyboard_handle_leave");
 }
 
@@ -122,6 +126,7 @@ keyboard_handle_modifiers(void *data, struct wl_keyboard *keyboard,
 {
   // NSDebugLog(@"keyboard_handle_modifiers");
   WaylandConfig *wlconfig = data;
+  wlconfig->event_serial = serial;
   xkb_mod_mask_t mask;
 
   /* If we're not using a keymap, then we don't handle PC-style modifiers */
@@ -148,6 +153,7 @@ keyboard_handle_key(void *data, struct wl_keyboard *keyboard, uint32_t serial,
 {
   // NSDebugLog(@"keyboard_handle_key: %d", key);
   WaylandConfig		*wlconfig = data;
+  wlconfig->event_serial = serial;
   uint32_t		     code, num_syms;
   enum wl_keyboard_key_state state = state_w;
   const xkb_keysym_t	     *syms;

--- a/Source/wayland/WaylandServer+Layershell.m
+++ b/Source/wayland/WaylandServer+Layershell.m
@@ -40,9 +40,9 @@ layer_surface_configure(void *data, struct zwlr_layer_surface_v1 *surface,
   window->configured = YES;
   if (window->buffer_needs_attach)
     {
-      NSDebugLog(@"attach: win=%d layer", window->window_id);
-      wl_surface_attach(window->surface, window->buffer, 0, 0);
-      wl_surface_commit(window->surface);
+      [window->instance flushwindowrect:NSMakeRect(window->pos_x, window->pos_y,
+						   window->width, window->height
+						   ):window->window_id];
     }
 }
 

--- a/Source/wayland/WaylandServer+Xdgshell.m
+++ b/Source/wayland/WaylandServer+Xdgshell.m
@@ -56,9 +56,9 @@ xdg_surface_on_configure(void *data, struct xdg_surface *xdg_surface,
 
   if (window->buffer_needs_attach)
     {
-      NSDebugLog(@"attach: win=%d toplevel", window->window_id);
-      wl_surface_attach(window->surface, window->buffer, 0, 0);
-      wl_surface_commit(window->surface);
+      [window->instance flushwindowrect:NSMakeRect(window->pos_x, window->pos_y,
+						   window->width, window->height
+						   ):window->window_id];
     }
 
   if (wlconfig->pointer.focus
@@ -129,7 +129,8 @@ xdg_popup_configure(void *data, struct xdg_popup *xdg_popup, int32_t x,
   struct window *window = data;
   WaylandConfig *wlconfig = window->wlconfig;
 
-  NSDebugLog(@"xdg_popup_configure");
+  NSDebugLog(@"[%d] xdg_popup_configure [%d,%d %dx%d]", window->window_id, x, y,
+	     width, height);
 }
 
 static void

--- a/Source/wayland/WaylandServer.m
+++ b/Source/wayland/WaylandServer.m
@@ -401,6 +401,7 @@ WaylandServer (WindowOps)
 
   window->moving = NO;
   window->resizing = NO;
+  window->ignoreMouse = NO;
 
   // FIXME is this needed?
   if (window->pos_x < 0)

--- a/configure
+++ b/configure
@@ -7373,7 +7373,7 @@ fi
 
       CAIRO_LIBS="$CAIRO_LIBS $XFT_LIBS"
       CAIRO_CFLAGS="$CAIRO_CFLAGS"
-      LIBS="-lwayland-client -lxkbcommon $LIBS"
+      LIBS="-lwayland-client -lwayland-cursor -lxkbcommon $LIBS"
     else
       as_fn_error $? "Invalid Cairo installation" "$LINENO" 5
     fi

--- a/configure.ac
+++ b/configure.ac
@@ -657,7 +657,7 @@ if test x"$BUILD_GRAPHICS" = "xcairo"; then
         [AC_MSG_ERROR([**** No xkb_context_new in libxkbcommon. Install correct version of libxkbcommon-dev or equivalent.])])
       CAIRO_LIBS="$CAIRO_LIBS $XFT_LIBS"
       CAIRO_CFLAGS="$CAIRO_CFLAGS"
-      LIBS="-lwayland-client -lxkbcommon $LIBS"
+      LIBS="-lwayland-client -lwayland-cursor -lxkbcommon $LIBS"
     else
       AC_MSG_ERROR([Invalid Cairo installation])
     fi


### PR DESCRIPTION
This PR depends on the following PRs:
- https://github.com/gnustep/libs-back/pull/34
- https://github.com/gnustep/libs-gui/pull/124

It is a refactor of the current cursor handling for the wayland backend and it includes:
- warnings cleanup
- new library dependency on `wayland-cursor` to load cursor images from the X theme
- mouse dragging
- window move/resize refactor depends on: https://github.com/gnustep/libs-gui/pull/124
- pointer axis source to distinguish between mouse scroll and touch scroll
- hide/show cursor
- set image cursor
- mapping between gnustep cursor styles and X themes icons