### PR TITLE
wayland: use GSStandardWindowDecorationView to hit-test cursor clicks

### DIFF
--- a/Source/wayland/WaylandServer+Cursor.m
+++ b/Source/wayland/WaylandServer+Cursor.m
@@ -290,7 +290,7 @@ pointer_handle_button(void *data, struct wl_pointer *pointer, uint32_t serial,
           NSWindow *nswindow = GSWindowWithNumber(window->window_id);
           if (nswindow != nil)
             {
-              id<GSWindowDecorator> wd = [nswindow _windowView];
+              GSStandardWindowDecorationView * wd = [nswindow _windowView];
 
               if ([wd pointInTitleBarRect:eventLocation])
                 {


### PR DESCRIPTION
related to https://github.com/gnustep/libs-gui/commit/b84d8cc3fd4eb198b2021ebed2b03fd942802620