### PR TITLE
Avoid AV in Win32FontInfo setupAttributes

### DIFF
--- a/Source/winlib/WIN32FontInfo.m
+++ b/Source/winlib/WIN32FontInfo.m
@@ -453,9 +453,14 @@ NSLog(@"No glyph for U%d", c);
     logfont.lfItalic = 1; 
 
   logfont.lfQuality = DEFAULT_QUALITY;
-  wcsncpy(logfont.lfFaceName,
-    (const unichar*)[familyName cStringUsingEncoding: NSUnicodeStringEncoding],
-    LF_FACESIZE);
+
+  if (familyName)
+  {
+    wcsncpy(logfont.lfFaceName,
+      (const unichar*)[familyName cStringUsingEncoding: NSUnicodeStringEncoding],
+      LF_FACESIZE);
+  }
+
   hFont = CreateFontIndirectW(&logfont);
   if (!hFont)
     {


### PR DESCRIPTION
I've seen `[Win32FontInfo setupAttributes]` being called when `familyName` is `nil`, which will cause a call to `wcsncpy` with the second argument being `NULL`, resulting in an AV.

This PR works around that.  In this implementation, when familyName` is `nil`:
- `logfont.lfFaceName` will not be set
-  `CreateFontIndirectW` will fail 
- [Win32FontInfo setupAttributes] will now return `NO` instead of failing with an AV