### PR TITLE
try to handle grouping of windows differently

### DIFF
--- a/Source/x11/XGServerWindow.m
+++ b/Source/x11/XGServerWindow.m
@@ -1,3 +1,4 @@
+
 /* XGServerWindows - methods for window/screen handling
 
    Copyright (C) 1999-2020 Free Software Foundation, Inc.
@@ -1933,10 +1934,10 @@ _get_next_prop_new_event(Display *display, XEvent *event, char *arg)
 				&window->xwn_attrs);
 
   /*
-   * Mark this as a GNUstep app with the current application name.
+   * Mark the window as the application with name & class so the WM can group it
    */
   classhint.res_name = generic.rootName;
-  classhint.res_class = "GNUstep";
+  classhint.res_class = generic.rootName;
   XSetClassHint(dpy, window->ident, &classhint);
 
   window->map_state = IsUnmapped;


### PR DESCRIPTION
XFCE windowmanager groups in the task bar windows when there are many for one application. What I found is that with two or more GNUstep applications, everything was put into a "GNUstep" item, different from the expected experience
After some trial-and error using xprops on various apps (internal XFCe,, GTK tools, Firefox...) I found out the issue is the WM_CLASS atoms, which consists of two strings

for most application they were set like this:
"app name", "App Name"

for some others, like this:` "org.gnome.appname", "AppName"`

or even a functional name, e.g Firefox has: "Navigator", "Firefox" which I bet is a heritage of when there was Navigator, Mail, Composer, Chat

we were setting `"AppName", "GNUstep"`

Since in the place I only have NSProcessInfo, (using the domain or a functional name like Firefox).. so now we can set e.g.` "Ink", "Ink"`.
At a first test, it works in XFCE!

I wonder:

- [ ] Is/Was "GNUstep" as class used somewhere or for other WMs?
- [ ] Do other places where res_class is set to GNUstep be also changed?