### PR TITLE
Fix build errors with Wayland on Debian 13 (trixie) using Clang 16

### DIFF
--- a/Source/wayland/WaylandServer+Cursor.m
+++ b/Source/wayland/WaylandServer+Cursor.m
@@ -38,6 +38,9 @@
 #include <linux/input.h>
 #include "wayland-cursor.h"
 
+// Added extern declaration to resolve implicit function declaration error
+extern void wl_cursor_destroy(struct wl_cursor *cursor);
+
 // XXX should this be configurable by the user?
 #define DOUBLECLICK_DELAY 300
 #define DOUBLECLICK_MOVE_THREASHOLD 3
@@ -290,19 +293,17 @@ pointer_handle_button(void *data, struct wl_pointer *pointer, uint32_t serial,
           NSWindow *nswindow = GSWindowWithNumber(window->window_id);
           if (nswindow != nil)
             {
-              // Removed the usage of _windowView as it is not declared
-              // GSStandardWindowDecorationView * wd = [nswindow _windowView];
+              GSStandardWindowDecorationView * wd = [nswindow _windowView];
 
-              // Assuming some alternative logic instead
-              if ([nswindow pointInTitleBarRect:eventLocation])
+              if ([wd pointInTitleBarRect:eventLocation])
                 {
                   xdg_toplevel_move(window->toplevel, wlconfig->seat, serial);
                   window->moving = YES;
                   return;
                 }
-              if ([nswindow pointInResizeBarRect:eventLocation])
+              if ([wd pointInResizeBarRect:eventLocation])
                 {
-                  GSResizeEdgeMode mode = [nswindow resizeModeForPoint:eventLocation];
+                  GSResizeEdgeMode mode = [wd resizeModeForPoint:eventLocation];
 
                   uint32_t edges = XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_RIGHT;
 
@@ -798,11 +799,7 @@ WaylandServer (Cursor)
 {
   // the cursor should be deallocated
   struct cursor * c = cid;
-
-  // Fix the missing declaration error by manually declaring wl_cursor_destroy
-  extern void wl_cursor_destroy(struct wl_cursor *);
-
-  wl_cursor_destroy(c->cursor);
+  wl_cursor_destroy(c->cursor); // Ensure wl_cursor_destroy is declared and defined
   wl_buffer_destroy(c->buffer);
   free(cid);
 }

--- a/Source/wayland/WaylandServer+Cursor.m
+++ b/Source/wayland/WaylandServer+Cursor.m
@@ -290,17 +290,19 @@ pointer_handle_button(void *data, struct wl_pointer *pointer, uint32_t serial,
           NSWindow *nswindow = GSWindowWithNumber(window->window_id);
           if (nswindow != nil)
             {
-              GSStandardWindowDecorationView * wd = [nswindow _windowView];
+              // Removed the usage of _windowView as it is not declared
+              // GSStandardWindowDecorationView * wd = [nswindow _windowView];
 
-              if ([wd pointInTitleBarRect:eventLocation])
+              // Assuming some alternative logic instead
+              if ([nswindow pointInTitleBarRect:eventLocation])
                 {
                   xdg_toplevel_move(window->toplevel, wlconfig->seat, serial);
                   window->moving = YES;
                   return;
                 }
-              if ([wd pointInResizeBarRect:eventLocation])
+              if ([nswindow pointInResizeBarRect:eventLocation])
                 {
-                  GSResizeEdgeMode mode = [wd resizeModeForPoint:eventLocation];
+                  GSResizeEdgeMode mode = [nswindow resizeModeForPoint:eventLocation];
 
                   uint32_t edges = XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_RIGHT;
 
@@ -796,6 +798,10 @@ WaylandServer (Cursor)
 {
   // the cursor should be deallocated
   struct cursor * c = cid;
+
+  // Fix the missing declaration error by manually declaring wl_cursor_destroy
+  extern void wl_cursor_destroy(struct wl_cursor *);
+
   wl_cursor_destroy(c->cursor);
   wl_buffer_destroy(c->buffer);
   free(cid);

--- a/Source/wayland/WaylandServer+Cursor.m
+++ b/Source/wayland/WaylandServer+Cursor.m
@@ -38,7 +38,6 @@
 #include <linux/input.h>
 #include "wayland-cursor.h"
 
-// Added extern declaration to resolve implicit function declaration error
 extern void wl_cursor_destroy(struct wl_cursor *cursor);
 
 // XXX should this be configurable by the user?
@@ -799,7 +798,7 @@ WaylandServer (Cursor)
 {
   // the cursor should be deallocated
   struct cursor * c = cid;
-  wl_cursor_destroy(c->cursor); // Ensure wl_cursor_destroy is declared and defined
+  wl_cursor_destroy(c->cursor);
   wl_buffer_destroy(c->buffer);
   free(cid);
 }

--- a/Source/wayland/WaylandServer+Keyboard.m
+++ b/Source/wayland/WaylandServer+Keyboard.m
@@ -31,6 +31,7 @@
 #include <linux/input.h>
 #include <AppKit/NSText.h>
 #include <sys/mman.h>
+#include <unistd.h>
 
 static void
 keyboard_handle_keymap(void *data, struct wl_keyboard *keyboard,

--- a/Source/wayland/WaylandServer+Xdgshell.m
+++ b/Source/wayland/WaylandServer+Xdgshell.m
@@ -29,9 +29,7 @@
 #include <AppKit/NSEvent.h>
 #include <AppKit/NSApplication.h>
 #include <AppKit/NSWindow.h>
-
-// Ensure the function GSWindowWithNumber is declared or included from the appropriate header
-NSWindow *GSWindowWithNumber(int window_id);
+#include <AppKit/NSGraphics.h>
 
 static void
 xdg_surface_on_configure(void *data, struct xdg_surface *xdg_surface,

--- a/Source/wayland/WaylandServer+Xdgshell.m
+++ b/Source/wayland/WaylandServer+Xdgshell.m
@@ -28,10 +28,14 @@
 #include "wayland/WaylandServer.h"
 #include <AppKit/NSEvent.h>
 #include <AppKit/NSApplication.h>
+#include <AppKit/NSWindow.h>
+
+// Ensure the function GSWindowWithNumber is declared or included from the appropriate header
+NSWindow *GSWindowWithNumber(int window_id);
 
 static void
 xdg_surface_on_configure(void *data, struct xdg_surface *xdg_surface,
-			 uint32_t serial)
+                         uint32_t serial)
 {
   struct window *window = data;
 
@@ -43,7 +47,6 @@ xdg_surface_on_configure(void *data, struct xdg_surface *xdg_surface,
       free(window);
       return;
     }
-  WaylandConfig *wlconfig = window->wlconfig;
 
   NSEvent  *ev = nil;
   NSWindow *nswindow = GSWindowWithNumber(window->window_id);
@@ -57,22 +60,22 @@ xdg_surface_on_configure(void *data, struct xdg_surface *xdg_surface,
   if (window->buffer_needs_attach)
     {
       [window->instance flushwindowrect:NSMakeRect(window->pos_x, window->pos_y,
-						   window->width, window->height
-						   ):window->window_id];
+                                                   window->width, window->height)
+                                      :window->window_id];
     }
 
-  if (wlconfig->pointer.focus
-      && wlconfig->pointer.focus->window_id == window->window_id)
+  if (window->wlconfig->pointer.focus
+      && window->wlconfig->pointer.focus->window_id == window->window_id)
     {
       ev = [NSEvent otherEventWithType:NSAppKitDefined
-			      location:NSZeroPoint
-			 modifierFlags:0
-			     timestamp:0
-			  windowNumber:(int) window->window_id
-			       context:GSCurrentContext()
-			       subtype:GSAppKitWindowFocusIn
-				 data1:0
-				 data2:0];
+                              location:NSZeroPoint
+                         modifierFlags:0
+                             timestamp:0
+                          windowNumber:(int) window->window_id
+                               context:GSCurrentContext()
+                               subtype:GSAppKitWindowFocusIn
+                                 data1:0
+                                 data2:0];
 
       [nswindow sendEvent:ev];
     }
@@ -80,15 +83,14 @@ xdg_surface_on_configure(void *data, struct xdg_surface *xdg_surface,
 
 static void
 xdg_toplevel_configure(void *data, struct xdg_toplevel *xdg_toplevel,
-		       int32_t width, int32_t height, struct wl_array *states)
+                       int32_t width, int32_t height, struct wl_array *states)
 {
   struct window *window = data;
-  WaylandConfig *wlconfig = window->wlconfig;
 
-  NSDebugLog(@"[%d] xdg_toplevel_configure %ldx%ld", window->window_id, width,
-	     height);
+  NSDebugLog(@"[%d] xdg_toplevel_configure %dx%d", window->window_id, width,
+             height);
 
-  // the compositor can send 0.0x0.0
+  // The compositor can send 0x0
   if (width == 0 || height == 0)
     {
       return;
@@ -99,45 +101,43 @@ xdg_toplevel_configure(void *data, struct xdg_toplevel *xdg_toplevel,
       window->height = height;
 
       xdg_surface_set_window_geometry(window->xdg_surface, 0, 0, window->width,
-				      window->height);
+                                      window->height);
 
       NSEvent *ev = [NSEvent otherEventWithType:NSAppKitDefined
-				       location:NSMakePoint(0.0, 0.0)
-				  modifierFlags:0
-				      timestamp:0
-				   windowNumber:window->window_id
-					context:GSCurrentContext()
-					subtype:GSAppKitWindowResized
-					  data1:window->width
-					  data2:window->height];
+                                       location:NSMakePoint(0.0, 0.0)
+                                  modifierFlags:0
+                                      timestamp:0
+                                   windowNumber:window->window_id
+                                        context:GSCurrentContext()
+                                        subtype:GSAppKitWindowResized
+                                          data1:window->width
+                                          data2:window->height];
       [(GSWindowWithNumber(window->window_id)) sendEvent:ev];
     }
-  NSDebugLog(@"[%d] notify resize from backend=%ldx%ld", window->window_id,
-	     width, height);
+  NSDebugLog(@"[%d] notify resize from backend=%dx%d", window->window_id,
+             width, height);
 }
 
 static void
-xdg_toplevel_close_handler(void *data, struct zxdg_toplevel_v6 *xdg_toplevel)
+xdg_toplevel_close_handler(void *data, struct xdg_toplevel *xdg_toplevel)
 {
   NSDebugLog(@"xdg_toplevel_close_handler");
 }
 
 static void
 xdg_popup_configure(void *data, struct xdg_popup *xdg_popup, int32_t x,
-		    int32_t y, int32_t width, int32_t height)
+                    int32_t y, int32_t width, int32_t height)
 {
   struct window *window = data;
-  WaylandConfig *wlconfig = window->wlconfig;
 
   NSDebugLog(@"[%d] xdg_popup_configure [%d,%d %dx%d]", window->window_id, x, y,
-	     width, height);
+             width, height);
 }
 
 static void
 xdg_popup_done(void *data, struct xdg_popup *xdg_popup)
 {
   struct window *window = data;
-  WaylandConfig *wlconfig = window->wlconfig;
   window->terminated = YES;
   xdg_popup_destroy(xdg_popup);
   wl_surface_destroy(window->surface);
@@ -145,7 +145,7 @@ xdg_popup_done(void *data, struct xdg_popup *xdg_popup)
 
 static void
 wm_base_handle_ping(void *data, struct xdg_wm_base *xdg_wm_base,
-		    uint32_t serial)
+                    uint32_t serial)
 {
   NSDebugLog(@"wm_base_handle_ping");
   xdg_wm_base_pong(xdg_wm_base, serial);

--- a/Source/wayland/WaylandServer+Xdgshell.m
+++ b/Source/wayland/WaylandServer+Xdgshell.m
@@ -28,7 +28,6 @@
 #include "wayland/WaylandServer.h"
 #include <AppKit/NSEvent.h>
 #include <AppKit/NSApplication.h>
-#include <AppKit/NSWindow.h>
 #include <AppKit/NSGraphics.h>
 
 static void

--- a/Source/wayland/WaylandServer.m
+++ b/Source/wayland/WaylandServer.m
@@ -781,7 +781,7 @@ WaylandServer (SurfaceRoles)
       break;
     case NSPopUpMenuWindowLevel:
       NSDebugLog(@"[%d] NSPopUpMenuWindowLevel", win);
-      [self createPopup:win];
+      [self createPopup:get_window_with_id(wlconfig, win)];
       break;
     case NSScreenSaverWindowLevel:
       NSDebugLog(@"[%d] NSScreenSaverWindowLevel", win);

--- a/Source/wayland/WaylandServer.m
+++ b/Source/wayland/WaylandServer.m
@@ -781,7 +781,7 @@ WaylandServer (SurfaceRoles)
       break;
     case NSPopUpMenuWindowLevel:
       NSDebugLog(@"[%d] NSPopUpMenuWindowLevel", win);
-      [self createPopup:get_window_with_id(wlconfig, win)];
+      [self createPopup:window];
       break;
     case NSScreenSaverWindowLevel:
       NSDebugLog(@"[%d] NSScreenSaverWindowLevel", win);


### PR DESCRIPTION
This pull request resolves several build errors encountered when compiling with Wayland support (./configure --enable-server=wayland) on Debian 13 Testing (codename trixie) using Clang version 16.0.6.

The updates include:

- Selector Naming Issues: Corrected method declarations to properly align with Objective-C selector conventions.
- Function Pointer Compatibility: Fixed mismatched function pointer types to align with expected signatures.
- Implicit Declarations: Added necessary includes and declarations for Wayland functions to prevent implicit declaration errors.
- Type Corrections: Adjusted type usage to match expected formats and avoid type mismatch errors.

If this PR is accepted, I will work on a follow-up PR will address additional build issues on Arch Linux with Clang 18.1.8.