### PR TITLE
try to fix extended char handling in NSEvent

### DIFF
--- a/Source/x11/XIMInputServer.m
+++ b/Source/x11/XIMInputServer.m
@@ -151,11 +151,17 @@
     {
       /* Always returns a Latin-1 string according to the manpage */
       count = XLookupString (event, buf, BUF_LEN, &keysym, NULL);
-      if (count)
+      if (count == 1)
 	{
 	  keys = [[[NSString alloc] initWithBytes: buf
 					   length: count
 					 encoding: NSISOLatin1StringEncoding] autorelease];
+	}
+      else if (count > 1) // manpage lies and we suppose UTF-8
+	{
+	  keys = [[[NSString alloc] initWithBytes: buf
+					   length: count
+					 encoding: NSUTF8StringEncoding] autorelease];
 	}
 
       if (keysymptr)


### PR DESCRIPTION
Issue described in https://github.com/gnustep/libs-back/issues/49

I found out that sometimes XLookupString returns more than one char for a single key, which does not make much sense for Latin1.
So I suspect I am getting back UTF-8 in that case and indeed, interpreting that string as such works!

Looks like X11 got "extended" here beyond the Spec that says Latin1 only. The question remains why it is happening for characters contained in Latin1?
Last found is that €, not contained in Latin1 gets not back.

However I think this "hack" is pretty safe, since if only one char is returned, Latin1 is used as per-spec.