### PR TITLE
Support building natively on Windows

### DIFF
--- a/Tools/gpbs.m
+++ b/Tools/gpbs.m
@@ -38,7 +38,12 @@
 #endif
 
 #include <signal.h>
+#ifdef	HAVE_UNISTD_H
 #include <unistd.h>
+#else
+#include <io.h>
+#define strcasecmp _stricmp
+#endif
 #include <ctype.h>
 
 #ifdef __MINGW__


### PR DESCRIPTION
When building for Windows using a native toolchain (i.e. not MinGW or MSYS), `<unistd.h>` is not available.  Include `<io.h>` instead and define `strcasecmp`.