### PR TITLE
Fix double-subtraction of strut in _NET_WORKAREA height

### DIFF
--- a/Source/x11/XGServerWindow.m
+++ b/Source/x11/XGServerWindow.m
@@ -4582,7 +4582,6 @@ _workAreas(Display *dpy, Window root)
       // X coordinates need to be flipped to OpenStep coordinates
       if (frame.origin.y > 0.0)
 	{
-	  frame.size.height -= frame.origin.y;
 	  frame.origin.y = 0.0;
 	}
       [array addObject: [NSValue valueWithRect: frame]];


### PR DESCRIPTION
Per the EWMH spec, `_NET_WORKAREA` returns a geometry that already excludes space reserved by `_NET_WM_STRUT`. Subtracting `origin.y` from the height double-counted the top strut, making the reported workarea shorter than it should be.

For example, a 22px top strut on a 1080px screen yields `_NET_WORKAREA` height=1058. The code subtracted 22 again, producing height=1036 — a 22px shortfall causing mispositioned windows.

Remove the incorrect height adjustment; keep the `origin.y` zeroing for GNUstep's bottom-left coordinate system.

Bug uncovered while developing [Gershwin Desktop](https://github.com/gershwin-desktop).