### PR TITLE
tests: cover the gsc colour conversions and GSFunction evaluator

### DIFF
--- a/Tests/gsc/GNUmakefile.preamble
+++ b/Tests/gsc/GNUmakefile.preamble
@@ -1,0 +1,4 @@
+ADDITIONAL_INCLUDE_DIRS += -I$(GNUSTEP_BUILD_DIR)/../../Headers \
+                           -I$(GNUSTEP_BUILD_DIR)/../../Source \
+                           -I../../Headers -I../../Source \
+                           -I$(GNUSTEP_BUILD_DIR)/../.. -I../..

--- a/Tests/gsc/gscolors.m
+++ b/Tests/gsc/gscolors.m
@@ -1,0 +1,139 @@
+/* Tests for the device colour-space conversions in Source/gsc/gscolors.c.
+ *
+ * gscolors.c is backend-independent (it is part of the shared gsc code built
+ * for every backend), so this test compiles the source in directly and runs
+ * on every configuration with no per-backend guard.
+ */
+#import <Foundation/Foundation.h>
+#import "Testing.h"
+
+#include "gsc/gscolors.c"
+
+/* Colour components are floats; compare with a small tolerance. */
+static BOOL
+eq(float a, float b)
+{
+  float d = a - b;
+
+  return (d < 0.0001 && d > -0.0001) ? YES : NO;
+}
+
+static BOOL
+isRGB(device_color_t c, float r, float g, float b)
+{
+  return (c.space == rgb_colorspace
+    && eq(c.field[0], r) && eq(c.field[1], g) && eq(c.field[2], b))
+    ? YES : NO;
+}
+
+int
+main(void)
+{
+  START_SET("gscolors conversions")
+
+  device_color_t	c;
+
+  /* --- gray <-> rgb --- */
+  gsMakeColor(&c, gray_colorspace, 0.4, 0, 0, 0);
+  gsColorToRGB(&c);
+  PASS(isRGB(c, 0.4, 0.4, 0.4), "gray converts to an equal-component rgb");
+
+  gsMakeColor(&c, rgb_colorspace, 0.3, 0.59, 0.11 * 2, 0);
+  gsColorToGray(&c);
+  PASS(c.space == gray_colorspace
+    && eq(c.field[0], 0.3 * 0.3 + 0.59 * 0.59 + (0.11 * 2) * 0.11),
+    "rgb converts to gray using the 0.3/0.59/0.11 luma weights");
+
+  /* --- hsb -> rgb, known values --- */
+  gsMakeColor(&c, hsb_colorspace, 0.0, 1.0, 1.0, 0);
+  gsColorToRGB(&c);
+  PASS(isRGB(c, 1.0, 0.0, 0.0), "hsb hue 0 is red");
+
+  gsMakeColor(&c, hsb_colorspace, 1.0 / 3.0, 1.0, 1.0, 0);
+  gsColorToRGB(&c);
+  PASS(isRGB(c, 0.0, 1.0, 0.0), "hsb hue 1/3 is green");
+
+  gsMakeColor(&c, hsb_colorspace, 2.0 / 3.0, 1.0, 1.0, 0);
+  gsColorToRGB(&c);
+  PASS(isRGB(c, 0.0, 0.0, 1.0), "hsb hue 2/3 is blue");
+
+  gsMakeColor(&c, hsb_colorspace, 0.5, 0.0, 0.7, 0);
+  gsColorToRGB(&c);
+  PASS(isRGB(c, 0.7, 0.7, 0.7),
+    "hsb with zero saturation is a gray of the brightness");
+
+  /* --- rgb -> hsb -> rgb round trips --- */
+  {
+    float t[][3] = {
+      {1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0},
+      {0.2, 0.5, 0.8}, {0.9, 0.3, 0.6}, {0.5, 0.5, 0.5}
+    };
+    int i;
+    BOOL ok = YES;
+
+    for (i = 0; i < 6; i++)
+      {
+	gsMakeColor(&c, rgb_colorspace, t[i][0], t[i][1], t[i][2], 0);
+	gsColorToHSB(&c);
+	PASS(c.space == hsb_colorspace, "rgb->hsb sets the hsb colour space");
+	gsColorToRGB(&c);
+	if (!isRGB(c, t[i][0], t[i][1], t[i][2]))
+	  {
+	    ok = NO;
+	  }
+      }
+    PASS(ok == YES, "rgb -> hsb -> rgb round-trips");
+  }
+
+  /* --- cmyk -> rgb, known values --- */
+  gsMakeColor(&c, cmyk_colorspace, 0.0, 0.0, 0.0, 0.0);
+  gsColorToRGB(&c);
+  PASS(isRGB(c, 1.0, 1.0, 1.0), "cmyk all-zero is white");
+
+  gsMakeColor(&c, cmyk_colorspace, 0.0, 0.0, 0.0, 1.0);
+  gsColorToRGB(&c);
+  PASS(isRGB(c, 0.0, 0.0, 0.0), "cmyk k=1 is black");
+
+  gsMakeColor(&c, cmyk_colorspace, 1.0, 0.0, 0.0, 0.0);
+  gsColorToRGB(&c);
+  PASS(isRGB(c, 0.0, 1.0, 1.0), "cmyk cyan is (0,1,1) rgb");
+
+  /* --- rgb -> cmyk -> rgb round trips, and the black-generation invariant --- */
+  {
+    float t[][3] = {
+      {1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0},
+      {0.2, 0.5, 0.8}, {0.9, 0.3, 0.6}
+    };
+    int i;
+    BOOL round = YES;
+    BOOL invariant = YES;
+
+    for (i = 0; i < 5; i++)
+      {
+	float r = t[i][0], g = t[i][1], b = t[i][2];
+	float cc, mm, yy, kk;
+
+	gsMakeColor(&c, rgb_colorspace, r, g, b, 0);
+	gsColorToCMYK(&c);
+	PASS(c.space == cmyk_colorspace, "rgb->cmyk sets the cmyk colour space");
+	cc = c.field[0]; mm = c.field[1]; yy = c.field[2]; kk = c.field[3];
+	/* under-colour removal keeps component + black == 1 - rgb */
+	if (!eq(cc + kk, 1.0 - r) || !eq(mm + kk, 1.0 - g)
+	  || !eq(yy + kk, 1.0 - b))
+	  {
+	    invariant = NO;
+	  }
+	gsColorToRGB(&c);
+	if (!isRGB(c, r, g, b))
+	  {
+	    round = NO;
+	  }
+      }
+    PASS(invariant == YES,
+      "rgb->cmyk keeps component+black equal to 1-rgb per channel");
+    PASS(round == YES, "rgb -> cmyk -> rgb round-trips");
+  }
+
+  END_SET("gscolors conversions")
+  return 0;
+}

--- a/Tests/gsc/gsfunction.m
+++ b/Tests/gsc/gsfunction.m
@@ -1,0 +1,222 @@
+/* Tests for the PostScript type-0 (sampled) function evaluator in
+ * Source/gsc/GSFunction.m.
+ *
+ * GSFunction is a plain Foundation object, so this test compiles the source in
+ * directly and runs on every backend with no per-backend guard.
+ */
+#import <Foundation/Foundation.h>
+#import "Testing.h"
+
+#include "gsc/GSFunction.m"
+
+static BOOL
+eq(double a, double b)
+{
+  double d = a - b;
+
+  return (d < 0.0001 && d > -0.0001) ? YES : NO;
+}
+
+/* Build a FunctionType 0 spec dictionary. */
+static NSDictionary *
+spec(NSArray *size, NSArray *domain, NSArray *range, int bps,
+  const void *bytes, unsigned len, NSArray *encode, NSArray *decode)
+{
+  NSMutableDictionary *d = [NSMutableDictionary dictionary];
+
+  [d setObject: [NSNumber numberWithInt: 0] forKey: @"FunctionType"];
+  [d setObject: [NSNumber numberWithInt: bps] forKey: @"BitsPerSample"];
+  [d setObject: [NSData dataWithBytes: bytes length: len] forKey: @"DataSource"];
+  [d setObject: size forKey: @"Size"];
+  [d setObject: domain forKey: @"Domain"];
+  [d setObject: range forKey: @"Range"];
+  if (encode)
+    [d setObject: encode forKey: @"Encode"];
+  if (decode)
+    [d setObject: decode forKey: @"Decode"];
+  return d;
+}
+
+#define N(x) [NSNumber numberWithDouble: (x)]
+
+int
+main(void)
+{
+  START_SET("GSFunction type 0")
+  ENTER_POOL
+
+  /* --- 1-in 1-out, linear ramp over two samples --- */
+  {
+    unsigned char data[] = {0, 255};
+    GSFunction *f = [[GSFunction alloc] initWith:
+      spec([NSArray arrayWithObjects: N(2), nil],
+	   [NSArray arrayWithObjects: N(0), N(1), nil],
+	   [NSArray arrayWithObjects: N(0), N(1), nil],
+	   8, data, 2, nil, nil)];
+    double in, out;
+
+    PASS(f != nil, "a minimal type-0 function is created");
+    in = 0.0; [f eval: &in : &out];
+    PASS(eq(out, 0.0), "ramp at domain minimum is 0");
+    in = 1.0; [f eval: &in : &out];
+    PASS(eq(out, 1.0), "ramp at domain maximum is 1");
+    in = 0.5; [f eval: &in : &out];
+    PASS(eq(out, 0.5), "ramp interpolates linearly at the midpoint");
+    in = 0.25; [f eval: &in : &out];
+    PASS(eq(out, 0.25), "ramp interpolates linearly at a quarter");
+    /* inputs outside the domain clamp to the ends */
+    in = -5.0; [f eval: &in : &out];
+    PASS(eq(out, 0.0), "input below the domain clamps to the minimum");
+    in = 99.0; [f eval: &in : &out];
+    PASS(eq(out, 1.0), "input above the domain clamps to the maximum");
+    RELEASE(f);
+  }
+
+  /* --- Range/Decode scales the output --- */
+  {
+    unsigned char data[] = {0, 255};
+    GSFunction *f = [[GSFunction alloc] initWith:
+      spec([NSArray arrayWithObjects: N(2), nil],
+	   [NSArray arrayWithObjects: N(0), N(1), nil],
+	   [NSArray arrayWithObjects: N(0), N(10), nil],
+	   8, data, 2, nil, nil)];
+    double in, out;
+
+    in = 1.0; [f eval: &in : &out];
+    PASS(eq(out, 10.0), "output is scaled into the range");
+    in = 0.5; [f eval: &in : &out];
+    PASS(eq(out, 5.0), "midpoint is scaled into the range");
+    RELEASE(f);
+  }
+
+  /* --- Domain other than [0,1] is normalised --- */
+  {
+    unsigned char data[] = {0, 255};
+    GSFunction *f = [[GSFunction alloc] initWith:
+      spec([NSArray arrayWithObjects: N(2), nil],
+	   [NSArray arrayWithObjects: N(0), N(2), nil],
+	   [NSArray arrayWithObjects: N(0), N(1), nil],
+	   8, data, 2, nil, nil)];
+    double in, out;
+
+    in = 1.0; [f eval: &in : &out];
+    PASS(eq(out, 0.5), "a domain of [0,2] maps its midpoint to 0.5");
+    in = 2.0; [f eval: &in : &out];
+    PASS(eq(out, 1.0), "a domain of [0,2] maps its maximum to 1");
+    RELEASE(f);
+  }
+
+  /* --- 16 bits per sample --- */
+  {
+    unsigned char data[] = {0x00, 0x00, 0xFF, 0xFF};
+    GSFunction *f = [[GSFunction alloc] initWith:
+      spec([NSArray arrayWithObjects: N(2), nil],
+	   [NSArray arrayWithObjects: N(0), N(1), nil],
+	   [NSArray arrayWithObjects: N(0), N(1), nil],
+	   16, data, 4, nil, nil)];
+    double in, out;
+
+    PASS(f != nil, "a 16-bit function is created");
+    in = 0.0; [f eval: &in : &out];
+    PASS(eq(out, 0.0), "16-bit sample 0x0000 is 0");
+    in = 1.0; [f eval: &in : &out];
+    PASS(eq(out, 1.0), "16-bit sample 0xFFFF is 1");
+    RELEASE(f);
+  }
+
+  /* --- rejects unsupported specs --- */
+  {
+    unsigned char data[] = {0, 255};
+    NSMutableDictionary *d = [[spec([NSArray arrayWithObjects: N(2), nil],
+	   [NSArray arrayWithObjects: N(0), N(1), nil],
+	   [NSArray arrayWithObjects: N(0), N(1), nil],
+	   8, data, 2, nil, nil) mutableCopy] autorelease];
+
+    [d setObject: [NSNumber numberWithInt: 3] forKey: @"FunctionType"];
+    PASS(nil == [[GSFunction alloc] initWith: d],
+      "a non-zero FunctionType is rejected");
+    [d setObject: [NSNumber numberWithInt: 0] forKey: @"FunctionType"];
+    [d setObject: [NSNumber numberWithInt: 12] forKey: @"BitsPerSample"];
+    PASS(nil == [[GSFunction alloc] initWith: d],
+      "an unsupported BitsPerSample is rejected");
+    [d setObject: [NSNumber numberWithInt: 8] forKey: @"BitsPerSample"];
+    [d removeObjectForKey: @"DataSource"];
+    PASS(nil == [[GSFunction alloc] initWith: d],
+      "a missing DataSource is rejected");
+  }
+
+  /* --- 2-in 1-out bilinear interpolation --- */
+  {
+    /* corners indexed x + y*2: (0,0)=0 (1,0)=1 (0,1)=1 (1,1)=0 */
+    unsigned char data[] = {0, 255, 255, 0};
+    GSFunction *f = [[GSFunction alloc] initWith:
+      spec([NSArray arrayWithObjects: N(2), N(2), nil],
+	   [NSArray arrayWithObjects: N(0), N(1), N(0), N(1), nil],
+	   [NSArray arrayWithObjects: N(0), N(1), nil],
+	   8, data, 4, nil, nil)];
+    double in[2], out;
+
+    in[0] = 0; in[1] = 0; [f eval: in : &out];
+    PASS(eq(out, 0.0), "bilinear corner (0,0)");
+    in[0] = 1; in[1] = 0; [f eval: in : &out];
+    PASS(eq(out, 1.0), "bilinear corner (1,0)");
+    in[0] = 0; in[1] = 1; [f eval: in : &out];
+    PASS(eq(out, 1.0), "bilinear corner (0,1)");
+    in[0] = 1; in[1] = 1; [f eval: in : &out];
+    PASS(eq(out, 0.0), "bilinear corner (1,1)");
+    in[0] = 0.5; in[1] = 0.5; [f eval: in : &out];
+    PASS(eq(out, 0.5), "bilinear centre is the average of the corners");
+    RELEASE(f);
+  }
+
+  /* --- GSFunction2in3out must agree with the general evaluator --- */
+  {
+    /* 2x2 grid, 3 outputs, 8-bit: 4 samples * 3 comps = 12 bytes */
+    unsigned char data[] = {
+       0,  10,  20,     255, 100,  30,
+      40, 200, 128,      60,  70, 250
+    };
+    NSDictionary *d =
+      spec([NSArray arrayWithObjects: N(2), N(2), nil],
+	   [NSArray arrayWithObjects: N(0), N(1), N(0), N(1), nil],
+	   [NSArray arrayWithObjects: N(0), N(1), N(0), N(1), N(0), N(1), nil],
+	   8, data, 12, nil, nil);
+    GSFunction *base = [[GSFunction alloc] initWith: d];
+    GSFunction2in3out *spc = [[GSFunction2in3out alloc] initWith: d];
+    double pts[][2] = {
+      {0,0}, {1,0}, {0,1}, {1,1}, {0.5,0.5}, {0.25,0.75}, {0.9,0.1}
+    };
+    int k;
+    BOOL agree = YES;
+
+    PASS(spc != nil, "a 2-in 3-out function is created");
+    for (k = 0; k < 7; k++)
+      {
+	double ob[3], os[3];
+
+	[base eval: pts[k] : ob];
+	[spc eval: pts[k] : os];
+	if (!eq(ob[0], os[0]) || !eq(ob[1], os[1]) || !eq(ob[2], os[2]))
+	  {
+	    agree = NO;
+	  }
+      }
+    PASS(agree == YES,
+      "GSFunction2in3out matches the general evaluator at every test point");
+
+    /* affectedRect reflects the domain */
+    {
+      NSRect r = [spc affectedRect];
+
+      PASS(eq(r.origin.x, 0.0) && eq(r.origin.y, 0.0)
+	&& eq(r.size.width, 1.0) && eq(r.size.height, 1.0),
+	"affectedRect covers the domain");
+    }
+    RELEASE(base);
+    RELEASE(spc);
+  }
+
+  LEAVE_POOL
+  END_SET("GSFunction type 0")
+  return 0;
+}


### PR DESCRIPTION
Adds tests for backend-independent code, using the Tests harness from #86.

`Tests/gsc/gscolors.m` and `Tests/gsc/gsfunction.m` cover the colour-space conversions in `Source/gsc/gscolors.c` (gray/rgb/hsb/cmyk and their round trips, under-colour-removal) and the type-0 sampled-function evaluator in `Source/gsc/GSFunction.m` (linear and bilinear interpolation, domain normalisation and input clamping, range and decode scaling, 8- and 16-bit samples, malformed-spec rejection, and a check that the cached `GSFunction2in3out` agrees with the base evaluator).

The gsc sources are plain C/Foundation with no backend dependency, so these compile the source in directly and need no per-backend guard. 48 tests, all passing.
