### PR TITLE
back/xdps: bound the AFM tokenizers to the ident buffer

### DIFF
--- a/Source/xdps/parseAFM.c
+++ b/Source/xdps/parseAFM.c
@@ -138,9 +138,10 @@ static char *token(stream)
     
     idx = 0;
     while (ch != EOF && ch != ' ' && ch != lineterm && ch != '\r'
-           && ch != '\t' && ch != ':' && ch != ';') 
+           && ch != '\t' && ch != ':' && ch != ';')
     {
-        ident[idx++] = ch;
+        if (idx < MAX_NAME - 1)
+            ident[idx++] = ch;
         ch = fgetc(stream);
     } /* while */
 
@@ -169,9 +170,10 @@ static char *linetoken(stream)
     while ((ch = fgetc(stream)) == ' ' || ch == '\t' ); 
     
     idx = 0;
-    while (ch != EOF && ch != lineterm && ch != '\r') 
+    while (ch != EOF && ch != lineterm && ch != '\r')
     {
-        ident[idx++] = ch;
+        if (idx < MAX_NAME - 1)
+            ident[idx++] = ch;
         ch = fgetc(stream);
     } /* while */
     


### PR DESCRIPTION
`token()` and `linetoken()` in `parseAFM.c` copy characters into the fixed `MAX_NAME` (4096) byte `ident` buffer with no bound (`ident[idx++] = ch`), so a token or line longer than 4096 bytes overruns the heap. This is reachable from `AFMParseFile` on a malformed AFM file.

Bound both loops (`if (idx < MAX_NAME - 1) ident[idx++] = ch;`), truncating the identifier while still consuming the rest. Confirmed under AddressSanitizer: a 5000-character token overruns the heap before the change and is truncated cleanly after.
