### PR TITLE
back/x11: check allocations in RSmoothScaleImage

### DIFF
--- a/Source/x11/scale.c
+++ b/Source/x11/scale.c
@@ -404,7 +404,6 @@ CLIST	*contrib;		/* array of contribution lists */
 #define CLAMP(v,l,h)    ((v)<(l) ? (l) : (v) > (h) ? (h) : v)
 
 
-/* return of calloc is not checked if NULL in the function below! */
 RImage*
 RSmoothScaleImage(RImage *src, unsigned new_width, unsigned new_height)
 {    
@@ -422,14 +421,25 @@ RSmoothScaleImage(RImage *src, unsigned new_width, unsigned new_height)
 
     
     dst = RCreateImage(new_width, new_height, False);
+    if (!dst)
+	return NULL;
 
     /* create intermediate image to hold horizontal zoom */
     tmp = RCreateImage(dst->width, src->height, False);
+    if (!tmp) {
+	RReleaseImage(dst);
+	return NULL;
+    }
     xscale = (double)new_width / (double)src->width;
     yscale = (double)new_height / (double)src->height;
 
     /* pre-calculate filter contributions for a row */
     contrib = (CLIST *)calloc(new_width, sizeof(CLIST));
+    if (!contrib) {
+	RReleaseImage(dst);
+	RReleaseImage(tmp);
+	return NULL;
+    }
     if (xscale < 1.0) {
 	width = fwidth / xscale;
 	fscale = 1.0 / xscale;
@@ -514,6 +524,11 @@ RSmoothScaleImage(RImage *src, unsigned new_width, unsigned new_height)
     
     /* pre-calculate filter contributions for a column */
     contrib = (CLIST *)calloc(dst->height, sizeof(CLIST));
+    if (!contrib) {
+	RReleaseImage(dst);
+	RReleaseImage(tmp);
+	return NULL;
+    }
     if(yscale < 1.0) {
 	width = fwidth / yscale;
 	fscale = 1.0 / yscale;

--- a/Tests/x11/GNUmakefile.preamble
+++ b/Tests/x11/GNUmakefile.preamble
@@ -1,0 +1,22 @@
+# Extra build settings for the x11 backend tests.
+#
+# A backend test compiles a backend source file directly, so it can only build
+# for the backend it belongs to.  config.make names the backend being built
+# (BUILD_SERVER); the X11 headers and library are added only for x11, and
+# raster.m carries a matching source-level guard (via config.h) so the test
+# still builds -- and skips -- on every other backend.
+
+# config.h (used by the source-level guard) sits at the top of the (build) tree.
+ADDITIONAL_INCLUDE_DIRS += -I$(GNUSTEP_BUILD_DIR)/../.. -I../..
+
+-include $(GNUSTEP_BUILD_DIR)/../../config.make
+-include ../../config.make
+
+ifeq ($(BUILD_SERVER),x11)
+ADDITIONAL_INCLUDE_DIRS += -I$(GNUSTEP_BUILD_DIR)/../../Headers \
+                           -I$(GNUSTEP_BUILD_DIR)/../../Source \
+                           -I../../Headers -I../../Source \
+                           $(shell pkg-config --cflags x11)
+
+ADDITIONAL_TOOL_LIBS += $(shell pkg-config --libs x11)
+endif

--- a/Tests/x11/scale.m
+++ b/Tests/x11/scale.m
@@ -1,0 +1,68 @@
+/* Coverage and regression test for the scalers in Source/x11/scale.c.
+ *
+ * RSmoothScaleImage() allocated its destination and intermediate images with
+ * RCreateImage() and its filter-contribution arrays with calloc() but did not
+ * check any of them for NULL.  RCreateImage() returns NULL for a request over
+ * the maximum image size, so scaling to an over-large size dereferenced the
+ * NULL destination (segfault).  It now checks each allocation and returns NULL.
+ *
+ * The real source is compiled in directly (with raster.c for RCreateImage and
+ * friends) so the test does not need the gui-linked back bundle.
+ *
+ * scale.c is x11 backend code, so this guards on the backend actually being
+ * built (config.h names it as BUILD_SERVER), compiling and running only for
+ * x11 and skipping cleanly on every other backend.  The GNUmakefile.preamble
+ * adds the X11 headers and library under the same condition.
+ */
+#import <Foundation/Foundation.h>
+#import "Testing.h"
+#include "config.h"
+
+#if defined(BUILD_SERVER) && defined(SERVER_x11) && BUILD_SERVER == SERVER_x11
+
+#include <X11/Xlib.h>
+#include "x11/wraster.h"
+#include "x11/raster.c"
+#include "x11/scale.c"
+
+int
+main(void)
+{
+  RImage	*src = RCreateImage(4, 4, 0);
+  RImage	*up;
+  RImage	*sm;
+  RImage	*huge;
+
+  memset(src->data, 0x40, (size_t)src->width * src->height * 3);
+
+  up = RScaleImage(src, 8, 8);
+  PASS(up != NULL && up->width == 8 && up->height == 8,
+    "RScaleImage produces an image of the requested size");
+  if (up != NULL)
+    RReleaseImage(up);
+
+  sm = RSmoothScaleImage(src, 8, 8);
+  PASS(sm != NULL && sm->width == 8 && sm->height == 8,
+    "RSmoothScaleImage produces an image of the requested size");
+  if (sm != NULL)
+    RReleaseImage(sm);
+
+  /* A request larger than the maximum image size makes RCreateImage return
+   * NULL; RSmoothScaleImage must propagate that rather than dereference it. */
+  huge = RSmoothScaleImage(src, 100000, 4);
+  PASS(huge == NULL,
+    "RSmoothScaleImage returns NULL for an over-large request");
+
+  RReleaseImage(src);
+  return 0;
+}
+
+#else
+
+int
+main(void)
+{
+  return 0;
+}
+
+#endif


### PR DESCRIPTION
`RSmoothScaleImage()` allocated its destination and intermediate images with `RCreateImage()` and its filter-contribution lists with `calloc()`, but checked none of them. `RCreateImage()` returns NULL for a request larger than the maximum image size, so scaling to an over-large size dereferenced the NULL destination and crashed.

Check each of those allocations and return NULL, releasing what was already allocated, on failure. `Tests/x11/scale.m` scales up with both scalers and requests an over-large smooth scale, which segfaults before the change and returns NULL after.
