### PR TITLE
back/x11: do not spin in count_offset for a zero mask

### DIFF
--- a/Source/x11/context.c
+++ b/Source/x11/context.c
@@ -607,7 +607,7 @@ count_offset(unsigned long mask)
     int i;
     
     i=0;
-    while ((mask & 1)==0) {
+    while (mask != 0 && (mask & 1)==0) {
 	i++;
 	mask = mask >> 1;
     }

--- a/Tests/x11/GNUmakefile.preamble
+++ b/Tests/x11/GNUmakefile.preamble
@@ -1,0 +1,23 @@
+# Extra build settings for the x11 backend tests.
+#
+# A backend test compiles a backend source file directly, so it can only build
+# for the backend it belongs to.  config.make names the backend being built
+# (BUILD_SERVER); the X11 headers and libraries are added only for x11, and the
+# tests carry a matching source-level guard (via config.h) so they still build
+# -- and skip -- on every other backend.  The tests also compile the wraster
+# image sources, which need the Xext, Xrender and Xmu libraries.
+
+# config.h (used by the source-level guard) sits at the top of the (build) tree.
+ADDITIONAL_INCLUDE_DIRS += -I$(GNUSTEP_BUILD_DIR)/../.. -I../..
+
+-include $(GNUSTEP_BUILD_DIR)/../../config.make
+-include ../../config.make
+
+ifeq ($(BUILD_SERVER),x11)
+ADDITIONAL_INCLUDE_DIRS += -I$(GNUSTEP_BUILD_DIR)/../../Headers \
+                           -I$(GNUSTEP_BUILD_DIR)/../../Source \
+                           -I../../Headers -I../../Source \
+                           $(shell pkg-config --cflags x11 xext xrender)
+
+ADDITIONAL_TOOL_LIBS += $(shell pkg-config --libs x11 xext xrender) -lXmu -lm
+endif

--- a/Tests/x11/GNUmakefile.preamble
+++ b/Tests/x11/GNUmakefile.preamble
@@ -5,7 +5,13 @@
 # (BUILD_SERVER); the X11 headers and libraries are added only for x11, and the
 # tests carry a matching source-level guard (via config.h) so they still build
 # -- and skip -- on every other backend.  The tests also compile the wraster
-# image sources, which need the Xext, Xrender and Xmu libraries.
+# image sources and context.c, which need libX11 and libXmu, libXext for the
+# XSHM path, and libXrender for the render path in a cairo-graphics build.
+#
+# Each library is queried on its own so that a package pkg-config cannot find
+# does not discard the flags for the ones it can (pkg-config fails as a whole
+# when any named package is missing), and so a library that a given graphics
+# backend does not use is simply left out.
 
 # config.h (used by the source-level guard) sits at the top of the (build) tree.
 ADDITIONAL_INCLUDE_DIRS += -I$(GNUSTEP_BUILD_DIR)/../.. -I../..
@@ -17,7 +23,12 @@ ifeq ($(BUILD_SERVER),x11)
 ADDITIONAL_INCLUDE_DIRS += -I$(GNUSTEP_BUILD_DIR)/../../Headers \
                            -I$(GNUSTEP_BUILD_DIR)/../../Source \
                            -I../../Headers -I../../Source \
-                           $(shell pkg-config --cflags x11 xext xrender)
+                           $(shell pkg-config --cflags x11) \
+                           $(shell pkg-config --cflags xext 2>/dev/null) \
+                           $(shell pkg-config --cflags xrender 2>/dev/null)
 
-ADDITIONAL_TOOL_LIBS += $(shell pkg-config --libs x11 xext xrender) -lXmu -lm
+ADDITIONAL_TOOL_LIBS += $(shell pkg-config --libs x11) \
+                        $(shell pkg-config --libs xext 2>/dev/null) \
+                        $(shell pkg-config --libs xrender 2>/dev/null) \
+                        -lXmu -lm
 endif

--- a/Tests/x11/context.m
+++ b/Tests/x11/context.m
@@ -19,7 +19,6 @@
 #if defined(BUILD_SERVER) && defined(SERVER_x11) && BUILD_SERVER == SERVER_x11
 
 #include <X11/Xlib.h>
-#include <X11/extensions/XShm.h>
 #include "x11/wraster.h"
 #include "x11/raster.c"
 #include "x11/scale.c"

--- a/Tests/x11/context.m
+++ b/Tests/x11/context.m
@@ -1,0 +1,54 @@
+/* Test for count_offset() in Source/x11/context.c.
+ *
+ * count_offset() returns the position of the lowest set bit of an X visual's
+ * colour mask; RCreateContext() uses it to derive the red/green/blue shifts of
+ * a TrueColor or DirectColor visual.  It is a static helper, so the context
+ * source is compiled in directly to reach it.  The mask is unsigned and can be
+ * zero (a StaticGray or GrayScale visual carries no colour masks), so zero is
+ * checked alongside the ordinary channel masks.
+ *
+ * context.c is x11 backend code, so this guards on the backend actually being
+ * built (config.h names it as BUILD_SERVER) and the GNUmakefile.preamble adds
+ * the X11 libraries under the same condition.  count_offset() needs no X
+ * server, so the test runs without a display.
+ */
+#import <Foundation/Foundation.h>
+#import "Testing.h"
+#include "config.h"
+
+#if defined(BUILD_SERVER) && defined(SERVER_x11) && BUILD_SERVER == SERVER_x11
+
+#include <X11/Xlib.h>
+#include <X11/extensions/XShm.h>
+#include "x11/wraster.h"
+#include "x11/raster.c"
+#include "x11/scale.c"
+#include "x11/context.c"
+#include "x11/xutil.c"
+
+int main(void)
+{
+  PASS(count_offset(0) == 0,
+       "count_offset of a zero mask is 0 and does not loop forever");
+  PASS(count_offset(0xffUL) == 0,
+       "count_offset of a mask with bit 0 set is 0");
+  PASS(count_offset(0xff00UL) == 8,
+       "count_offset of 0xff00 is 8");
+  PASS(count_offset(0xff0000UL) == 16,
+       "count_offset of 0xff0000 is 16");
+  PASS(count_offset(0xf800UL) == 11,
+       "count_offset of a 16-bit 565 red mask is 11");
+  PASS(count_offset(0x07e0UL) == 5,
+       "count_offset of a 16-bit 565 green mask is 5");
+  PASS(count_offset(0x80000000UL) == 31,
+       "count_offset of the top bit of a 32-bit mask is 31");
+
+  return 0;
+}
+
+#else
+int main(void)
+{
+  return 0;
+}
+#endif


### PR DESCRIPTION
`count_offset()` shifts a colour mask right until its lowest bit is set, to find the mask's bit offset. With a zero mask the condition `(mask & 1) == 0` never becomes false and `mask` stays zero, so it loops forever. It is called on a TrueColor visual's red/green/blue masks, which are non-zero for a valid visual, but a malformed visual with a zero mask hangs `RCreateContext`.

Stop when the mask reaches zero, returning 0.

`Tests/x11/context.m` covers this: it compiles `context.c` in with its wraster siblings (the same arrangement the convert test in #94 uses) and checks `count_offset` over a range of masks including zero. `count_offset` needs no X server, so the test runs wherever the x11 backend is built. Before this change the zero-mask case loops forever, so a revert shows up as a hang rather than a wrong value.
