### PR TITLE
back/xlib: fix gs_floor for negative values

### DIFF
--- a/Headers/xlib/XGGeometry.h
+++ b/Headers/xlib/XGGeometry.h
@@ -188,8 +188,8 @@ static inline short gs_floor (float f)
       else
 	{
 	  int g = (int)f;
-      
-	  if (f - ((float)g) > 0)
+
+	  if (f - ((float)g) < 0)
 	    {
 	      return g - 1;
 	    }

--- a/Tests/xlib/GNUmakefile.preamble
+++ b/Tests/xlib/GNUmakefile.preamble
@@ -1,0 +1,21 @@
+# Extra build settings for the xlib graphics backend tests.
+#
+# These tests include an xlib backend header directly, so they can only build
+# for that backend.  config.make names the graphics backend being built
+# (BUILD_GRAPHICS); the X11, Xft and backend header paths are added only for
+# xlib, and the tests carry a matching source-level guard (via config.h) so
+# they still build -- and skip -- on every other backend.
+
+# config.h (used by the source-level guard) sits at the top of the (build) tree.
+ADDITIONAL_INCLUDE_DIRS += -I$(GNUSTEP_BUILD_DIR)/../.. -I../..
+
+-include $(GNUSTEP_BUILD_DIR)/../../config.make
+-include ../../config.make
+
+ifeq ($(BUILD_GRAPHICS),xlib)
+ADDITIONAL_INCLUDE_DIRS += -I$(GNUSTEP_BUILD_DIR)/../../Headers \
+                           -I../../Headers \
+                           $(shell pkg-config --cflags x11 xft)
+
+ADDITIONAL_TOOL_LIBS += -lm
+endif

--- a/Tests/xlib/gsfloor.m
+++ b/Tests/xlib/gsfloor.m
@@ -1,0 +1,63 @@
+/* Test for gs_floor() in Headers/xlib/XGGeometry.h.
+ *
+ * gs_floor() rounds a float down to the nearest integer as a clamped short; it
+ * is used when converting OpenStep coordinates to X device coordinates, where
+ * rounding the wrong way for negative values shifts geometry by a pixel.  It
+ * must match floorf(): toward negative infinity, not toward zero.
+ *
+ * XGGeometry.h is part of the xlib graphics backend and pulls in that backend's
+ * headers (AppKit, the X GState, Xft), so this guards on the graphics backend
+ * actually being xlib (config.h names it as BUILD_GRAPHICS) and the
+ * GNUmakefile.preamble adds the matching include paths under the same
+ * condition.  gs_floor() itself needs no X server, so the test runs without a
+ * display.
+ */
+#import <Foundation/Foundation.h>
+#import "Testing.h"
+#include "config.h"
+
+#if defined(BUILD_GRAPHICS) && defined(GRAPHICS_xlib) && BUILD_GRAPHICS == GRAPHICS_xlib
+
+#include <math.h>
+#include "xlib/XGGeometry.h"
+
+int main(void)
+{
+  PASS(gs_floor(-0.5) == -1,
+       "gs_floor(-0.5) is -1 (rounds down, not toward zero)");
+  PASS(gs_floor(-1.5) == -2,
+       "gs_floor(-1.5) is -2");
+  PASS(gs_floor(-1.0) == -1,
+       "gs_floor of a negative integer is that integer");
+  PASS(gs_floor(2.5) == 2,
+       "gs_floor(2.5) is 2");
+  PASS(gs_floor(3.0) == 3,
+       "gs_floor of a positive integer is that integer");
+  PASS(gs_floor(0.0) == 0,
+       "gs_floor(0) is 0");
+
+  int mismatches = 0;
+  float f;
+  for (f = -3000.0; f <= 3000.0; f += 0.25)
+    {
+      short got = gs_floor(f);
+      short want = (short)floorf(f);
+      if (got != want)
+        {
+          if (mismatches < 5)
+            NSLog(@"gs_floor(%g) = %d, floorf gives %d", f, (int)got, (int)want);
+          mismatches++;
+        }
+    }
+  PASS(mismatches == 0,
+       "gs_floor matches floorf across [-3000, 3000] in steps of 0.25");
+
+  return 0;
+}
+
+#else
+int main(void)
+{
+  return 0;
+}
+#endif


### PR DESCRIPTION
`gs_floor()` truncates toward zero with an `(int)` cast and, for a negative argument, subtracts one when there is a fractional part. It tested for a fractional part with `f - (float)g > 0`, but truncation toward zero makes `g >= f` for a negative `f`, so that is never true: `gs_floor` returned the truncation (effectively ceil) rather than the floor. `gs_floor(-0.5)` gave 0 rather than -1, so the xlib coordinate conversions (`XGWindowPointToX`, `XGWindowRectToX`) were off by one for negative coordinates.

Test for the fractional part with `< 0`. `Tests/xlib/gsfloor.m` covers it, checking `gs_floor` against `floorf` across a range of values including the negative cases that were wrong. `XGGeometry.h` is an xlib graphics header, so the test guards on the xlib graphics backend (`config.h`'s `BUILD_GRAPHICS`) and needs no X server, since `gs_floor` is pure arithmetic -- it runs in the xlib CI job and skips elsewhere.
