### PR TITLE
ci: run the x11 backend tests under Xvfb, with libXmu and libXext

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,11 +59,17 @@ jobs:
       # packages for xlib runtime
       APT_PACKAGES_xlib: >-
         libxt-dev
-        
+        libxmu-dev
+        libxext-dev
+        xvfb
+
       # packages for cairo runtime
       APT_PACKAGES_cairo: >-
         libxt-dev
         libcairo2-dev
+        libxmu-dev
+        libxext-dev
+        xvfb
 
       # packages for headless runtime
       APT_PACKAGES_headless: >-
@@ -98,4 +104,8 @@ jobs:
       - name: Run tests
         run: |
           . $INSTALL_PATH/share/GNUstep/Makefiles/GNUstep.sh
-          make check
+          if [ "${{ matrix.server }}" = "x11" ]; then
+            xvfb-run -a make check
+          else
+            make check
+          fi


### PR DESCRIPTION
The backend tests that compile the x11/wraster sources in (#92, #94) need two things the x11 jobs don't currently provide:

- libXmu, because `context.c` calls `XmuLookupStandardColormap`. The backend library links lazily and builds without it, but a test executable that pulls `context.c` in has to resolve it. libXext is needed for the XSHM path.
- an X server, since the rendering tests open a display. They skip when there is none, so at the moment they only skip.

This adds `libxmu-dev`, `libxext-dev` and `xvfb` to the x11 jobs and runs `make check` under `xvfb-run` there. The headless job is unchanged.

I ran it on my fork with both tests present and both x11 jobs build and run them green: https://github.com/DTW-Thalion/libs-back/actions/runs/29034045425

@fredkiefer - addressing this PR before #92 and #94 preferred.
