### PR TITLE
back/gsc: write the gstate operator, not the token gstaten

### DIFF
--- a/Source/gsc/GSStreamContext.m
+++ b/Source/gsc/GSStreamContext.m
@@ -353,7 +353,7 @@ fpfloat(FILE *stream, float f)
 - (void) DPSgstate
 {
   [super DPSgsave];
-  fprintf(gstream, "gstaten");
+  fprintf(gstream, "gstate\n");
 }
 
 - (void) DPSinitgraphics


### PR DESCRIPTION
`DPSgstate` wrote `gstaten` where it meant the `gstate` operator followed by a newline: the backslash of `\n` was dropped, so the stream gets the token `gstaten`, which is not an operator, with no separator before whatever is written next. The two methods next to it write `gsave\n` and `initgraphics\n`.

No test: exercising this needs a `GSStreamContext`, which pulls in the gui-linked graphics context and the font machinery, so a unit test would be disproportionate for a one-character fix.
