### PR TITLE
back/gsc: initialise the bounding box in the stream context DPSpathbbox

### DIFF
--- a/Source/gsc/GSStreamContext.m
+++ b/Source/gsc/GSStreamContext.m
@@ -634,6 +634,10 @@ fpfloat(FILE *stream, float f)
 
 - (void) DPSpathbbox: (CGFloat*)llx : (CGFloat*)lly : (CGFloat*)urx : (CGFloat*)ury
 {
+  /* A write-only stream context keeps no path geometry, so the bounding box
+   * cannot be computed here; return an empty box rather than leaving the
+   * caller's variables uninitialised. */
+  *llx = *lly = *urx = *ury = 0.0;
 }
 
 - (void) DPSrcurveto: (CGFloat)x1 : (CGFloat)y1 : (CGFloat)x2 : (CGFloat)y2 


### PR DESCRIPTION
The stream context keeps no path geometry, so `-DPSpathbbox::::` could not compute a bounding box and returned with the caller's four output variables left uninitialised. Set them to an empty box instead.
