### PR TITLE
back/gsc: escape backslashes in the stream context PostScript strings

### DIFF
--- a/Source/gsc/GSStreamContext.m
+++ b/Source/gsc/GSStreamContext.m
@@ -1030,6 +1030,9 @@ static const char *hexdigits = "0123456789abcdef";
 	case ')':
 	    fputs("\\)", gstream);
 	    break;
+	case '\\':
+	    fputs("\\\\", gstream);
+	    break;
 	default:
 	    fputc(s[i], gstream);
 	    break;

--- a/Tests/gsc/GNUmakefile.preamble
+++ b/Tests/gsc/GNUmakefile.preamble
@@ -1,9 +1,14 @@
 # Extra build settings for the shared gsc tests.
 #
-# The gsc code is backend-independent, so these tests compile the source in
-# directly and need no per-backend guard.  Add the Headers and Source trees
-# (for gsc/gscolors.h and gsc/gscolors.c) and the build tree top (for config.h).
-ADDITIONAL_INCLUDE_DIRS += -I$(GNUSTEP_BUILD_DIR)/../../Headers \
+# Most gsc code is backend-independent, so these tests compile the source in
+# directly.  The build tree top (for config.h) has to come first so config.h
+# resolves there and not to any copy under Source; the Headers and Source trees
+# follow, for gsc/gscolors.h and gsc/gscolors.c.
+ADDITIONAL_INCLUDE_DIRS += -I$(GNUSTEP_BUILD_DIR)/../.. -I../.. \
+                           -I$(GNUSTEP_BUILD_DIR)/../../Headers \
                            -I$(GNUSTEP_BUILD_DIR)/../../Source \
-                           -I../../Headers -I../../Source \
-                           -I$(GNUSTEP_BUILD_DIR)/../.. -I../..
+                           -I../../Headers -I../../Source
+
+# psescape drives GSStreamContext, which lives in the backend bundle, so it
+# links the gui and loads a backend at run time (and skips with no display).
+psescape_TOOL_LIBS += -lgnustep-gui

--- a/Tests/gsc/psescape.m
+++ b/Tests/gsc/psescape.m
@@ -1,0 +1,105 @@
+/* Tests that GSStreamContext escapes PostScript string specials in the text
+ * show operators.  A GSStreamContext writes PostScript to a file, wrapping a
+ * shown string in ( ).  Any '(', ')' or '\' in the string has to be escaped
+ * with a backslash, or the emitted string is not well formed -- in particular
+ * a trailing backslash would escape the closing ')' and leave the string
+ * unterminated.
+ *
+ * GSStreamContext lives in the backend bundle, so the test needs a backend
+ * loaded (hence a window server); it opens the display named by the
+ * environment and skips when there is none.  The code under test is the same
+ * for every backend; it is built for the cairo backend, which is the one that
+ * loads on the test display.
+ */
+#import <Foundation/Foundation.h>
+#import "Testing.h"
+#include "config.h"
+
+#if defined(BUILD_GRAPHICS) && defined(GRAPHICS_cairo) \
+  && BUILD_GRAPHICS == GRAPHICS_cairo
+
+#import <AppKit/AppKit.h>
+#include <stdlib.h>
+
+@interface NSObject (GSStreamContextShow)
+- initWithContextInfo: (NSDictionary *)info;
+- (void) DPSshow: (const char*)s;
+@end
+
+static NSString *
+emitShow(Class cls, const char *s)
+{
+  NSString *path = [NSTemporaryDirectory()
+    stringByAppendingPathComponent: @"gsc_psescape.ps"];
+  NSDictionary *info = [NSDictionary dictionaryWithObject: path
+                                                  forKey: @"NSOutputFile"];
+  id ctxt = [[cls alloc] initWithContextInfo: info];
+
+  if (ctxt == nil)
+    return nil;
+  [ctxt DPSshow: s];
+  [ctxt release];    /* dealloc closes and flushes the stream */
+  return [NSString stringWithContentsOfFile: path
+                                   encoding: NSISOLatin1StringEncoding
+                                      error: NULL];
+}
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(pool);
+  Class cls;
+
+  if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
+    {
+      NSLog(@"no window server available; skipping PostScript escaping tests");
+      DESTROY(pool);
+      return 0;
+    }
+
+  [NSApplication sharedApplication];
+  cls = NSClassFromString(@"GSStreamContext");
+  PASS(cls != Nil, "the GSStreamContext class is available");
+  if (cls == Nil)
+    {
+      DESTROY(pool);
+      return 0;
+    }
+
+  {
+    NSString *out = emitShow(cls, "a(b)c");
+    PASS(out != nil
+      && [out rangeOfString: @"\\("].location != NSNotFound
+      && [out rangeOfString: @"\\)"].location != NSNotFound,
+      "show escapes parentheses in the string");
+  }
+
+  {
+    /* A backslash must be doubled, or PostScript reads it as an escape. */
+    NSString *out = emitShow(cls, "a\\b");
+    PASS(out != nil && [out rangeOfString: @"a\\\\b"].location != NSNotFound,
+      "show escapes a backslash in the string");
+  }
+
+  {
+    /* The dangerous case: an unescaped trailing backslash turns the closing
+     * ) into an escaped ) and leaves the PostScript string unterminated. */
+    NSString *out = emitShow(cls, "end\\");
+    PASS(out != nil
+      && [out rangeOfString: @"(end\\\\) show"].location != NSNotFound,
+      "show escapes a trailing backslash so the string stays terminated");
+  }
+
+  DESTROY(pool);
+  return 0;
+}
+
+#else
+
+int
+main(int argc, const char **argv)
+{
+  return 0;
+}
+
+#endif


### PR DESCRIPTION
GSStreamContext wraps a shown string in ( ) and escapes ( and ) in the body, but not the backslash.  A backslash in the string is then emitted verbatim, which the PostScript interpreter reads as an escape, and a trailing backslash escapes the closing ) and leaves the string unterminated.

Escape the backslash too.  Tests/gsc/psescape.m drives GSStreamContext to PostScript and checks the parenthesis and backslash escaping; it needs a backend loaded, so it is built for the cairo backend and skips when there is no display.
