### PR TITLE
ci: build and test the art backend

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,8 @@ jobs:
             graphics: cairo
           - server: x11
             graphics: xlib
+          - server: x11
+            graphics: art
           - server: headless
             graphics: headless
 
@@ -58,6 +60,14 @@ jobs:
 
       # packages for xlib runtime
       APT_PACKAGES_xlib: >-
+        libxt-dev
+        libxmu-dev
+        libxext-dev
+        xvfb
+
+      # packages for art runtime
+      APT_PACKAGES_art: >-
+        libart-2.0-dev
         libxt-dev
         libxmu-dev
         libxext-dev


### PR DESCRIPTION
The art backend is not built by any CI job, so the art-guarded test code in
Tests/art never runs. This adds an art entry to the Linux matrix, with
libart-2.0-dev and the same x11 runtime packages the xlib job uses, so the
art backend is built and its tests run under xvfb.

On my fork the new job builds the art backend and runs the art compositing
tests (9 assertions) that the other jobs skip; the other three jobs are
unaffected.
