### PR TITLE
back/wayland: guard the window operations against an unknown window number

### DIFF
--- a/Source/wayland/WaylandServer.m
+++ b/Source/wayland/WaylandServer.m
@@ -550,6 +550,9 @@ WaylandServer (WindowOps)
   NSDebugLog(@"termwindow: win=%d", win);
   struct window *window = get_window_with_id(wlconfig, win);
 
+  if (window == NULL)
+    return;
+
   [self destroyWindowShell:window];
   // FIXME should wait for buffer release before detroying it
   //
@@ -589,6 +592,9 @@ WaylandServer (WindowOps)
   struct window *window = get_window_with_id(wlconfig, win);
   const char    *cString = [window_title UTF8String];
 
+  if (window == NULL)
+    return;
+
   if (window->toplevel)
     {
       xdg_toplevel_set_title(window->toplevel, cString);
@@ -602,6 +608,9 @@ WaylandServer (WindowOps)
   struct window *window = get_window_with_id(wlconfig, win);
 
   NSDebugLog(@"miniwindow");
+  if (window == NULL)
+    return;
+
   if (window->toplevel)
     {
       xdg_toplevel_set_minimized(window->toplevel);
@@ -618,6 +627,9 @@ WaylandServer (WindowOps)
   struct window *window;
 
   window = get_window_with_id(wlconfig, winId);
+  if (window == NULL)
+    return;
+
   // FIXME we could resize the current surface instead of creating a new one
   if (window->wcs)
     {
@@ -631,6 +643,9 @@ WaylandServer (WindowOps)
 - (void)orderwindow:(int)op:(int)otherWin:(int)win
 {
   struct window *window = get_window_with_id(wlconfig, win);
+
+  if (window == NULL)
+    return;
 
   if (op == NSWindowOut)
     {
@@ -679,6 +694,9 @@ WaylandServer (WindowOps)
   struct window *window = get_window_with_id(wlconfig, win);
 
   NSDebugLog(@"[%d] placewindow: %@", win, NSStringFromRect(rect));
+  if (window == NULL)
+    return;
+
   WaylandConfig *config = window->wlconfig;
 
   NSRect frame;
@@ -755,6 +773,10 @@ WaylandServer (WindowOps)
 - (NSRect)windowbounds:(int)win
 {
   struct window *window = get_window_with_id(wlconfig, win);
+
+  if (window == NULL)
+    return NSZeroRect;
+
   NSDebugLog(@"windowbounds: win=%d, pos=%dx%d size=%dx%d", window->window_id,
 	     window->pos_x, window->pos_y, window->width, window->height);
 
@@ -778,6 +800,10 @@ WaylandServer (WindowOps)
 - (void)setwindowlevel:(int)level:(int)win
 {
   struct window *window = get_window_with_id(wlconfig, win);
+
+  if (window == NULL)
+    return;
+
   window->level = level;
 
   NSDebugLog(@"setwindowlevel: level=%d win=%d", level, win);
@@ -787,6 +813,10 @@ WaylandServer (WindowOps)
 {
   NSDebugLog(@"windowlevel: %d", win);
   struct window *window = get_window_with_id(wlconfig, win);
+
+  if (window == NULL)
+    return 0;
+
   return window->level;
 }
 

--- a/Tests/cairo/waylandunknownwindow.m
+++ b/Tests/cairo/waylandunknownwindow.m
@@ -1,0 +1,96 @@
+/* Regression test for the window operations on WaylandServer
+ * (Source/wayland/WaylandServer.m) when handed a window number that no window
+ * has.
+ *
+ * get_window_with_id() returns NULL for an unknown window number (its header
+ * notes that callers must handle this), which happens for a stale number, for
+ * example one referred to after its window was terminated.  The window
+ * operations dereferenced the result without checking, so an unknown number
+ * crashed the server; -flushwindowrect: already guarded against it, and the x11
+ * backend guards every such lookup.  The fix guards the remaining ones, so an
+ * unknown number is ignored, -windowlevel: reports 0, and -windowbounds:
+ * reports NSZeroRect.
+ *
+ * Like the other backend tests it builds only for the wayland+cairo backend and
+ * skips on every other one, and at run time it skips when no compositor can be
+ * reached.
+ */
+#import <Foundation/Foundation.h>
+#import "Testing.h"
+#include "config.h"
+
+#if defined(BUILD_SERVER) && defined(SERVER_wayland) \
+  && defined(BUILD_GRAPHICS) && defined(GRAPHICS_cairo) \
+  && BUILD_SERVER == SERVER_wayland && BUILD_GRAPHICS == GRAPHICS_cairo
+
+#import <AppKit/AppKit.h>
+#import <GNUstepGUI/GSDisplayServer.h>
+
+int
+main(void)
+{
+  START_SET("WaylandServer unknown window number")
+  ENTER_POOL
+
+  GSDisplayServer *server = nil;
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+      server = GSCurrentServer();
+      if (server == nil)
+	{
+	  server = [GSDisplayServer serverWithAttributes: nil];
+	}
+    }
+  NS_HANDLER
+    {
+      server = nil;
+    }
+  NS_ENDHANDLER
+
+  if (server == nil)
+    {
+      SKIP("no Wayland compositor available")
+    }
+  else
+    {
+      int unknown = 999999;
+
+      /* None of these operations has a window with this number; each must
+       * ignore it rather than dereference a NULL window record. */
+      [server setwindowlevel: NSNormalWindowLevel : unknown];
+      [server titlewindow: @"unknown" : unknown];
+      [server miniwindow: unknown];
+      [server orderwindow: NSWindowOut : 0 : unknown];
+      [server placewindow: NSMakeRect(0, 0, 20, 20) : unknown];
+      [server setWindowdevice: unknown
+		    forContext: [NSGraphicsContext currentContext]];
+      [server termwindow: unknown];
+
+      /* The two query operations report the empty answers. */
+      PASS([server windowlevel: unknown] == 0,
+	"windowlevel: on an unknown window number returns 0")
+      PASS(NSEqualRects([server windowbounds: unknown], NSZeroRect) == YES,
+	"windowbounds: on an unknown window number returns NSZeroRect")
+      PASS(YES,
+	"window operations on an unknown window number do not crash")
+    }
+
+  LEAVE_POOL
+  END_SET("WaylandServer unknown window number")
+  return 0;
+}
+
+#else
+
+int
+main(void)
+{
+  START_SET("WaylandServer unknown window number")
+    SKIP("back is not built with the wayland+cairo backend")
+  END_SET("WaylandServer unknown window number")
+  return 0;
+}
+
+#endif


### PR DESCRIPTION
get_window_with_id() returns NULL for a window number that no window has, for
example a stale number used after its window was terminated, and its header
notes that callers must handle this.  Most of the window operations
dereferenced the result without checking, so an unknown number crashed the
server, although -flushwindowrect: already guarded against it and the x11
backend guards every such lookup.  Guard the remaining operations, ignoring an
unknown number, reporting 0 from -windowlevel: and NSZeroRect from
-windowbounds:, and add a test.
