### PR TITLE
back/cairo: give cairo a UTF-8 filename for PS and PDF output

### DIFF
--- a/Source/cairo/CairoPDFSurface.m
+++ b/Source/cairo/CairoPDFSurface.m
@@ -37,7 +37,7 @@
 
   // FIXME: Hard coded size in points
   size = NSMakeSize(400, 400);
-  _surface = cairo_pdf_surface_create([path fileSystemRepresentation], 
+  _surface = cairo_pdf_surface_create([path UTF8String],
                                       size.width, size.height);
   if (cairo_surface_status(_surface))
     {

--- a/Source/cairo/CairoPSSurface.m
+++ b/Source/cairo/CairoPSSurface.m
@@ -37,7 +37,7 @@
 
   // FIXME: Hard coded size in points
   size = NSMakeSize(400, 400);
-  _surface = cairo_ps_surface_create([path fileSystemRepresentation], size.width, size.height);
+  _surface = cairo_ps_surface_create([path UTF8String], size.width, size.height);
   if (cairo_surface_status(_surface))
     {
       DESTROY(self);


### PR DESCRIPTION
cairo_ps_surface_create and cairo_pdf_surface_create take a UTF-8 char* file
name, but -fileSystemRepresentation returns a UTF-16 unichar* on Windows, so the
PS and PDF surfaces did not compile there.  Use -UTF8String, which is a UTF-8
char* on every platform.
