### PR TITLE
back/winlib: fix the dash pattern type in the win32 graphics state

### DIFF
--- a/Source/winlib/WIN32GState.m
+++ b/Source/winlib/WIN32GState.m
@@ -1375,7 +1375,7 @@ HBITMAP GSCreateBitmap(HDC hDC, NSInteger pixelsWide, NSInteger pixelsHigh,
   if (patternCount > 0)
     {
       NSInteger i = 0;
-      CGFloat* thePattern[patternCount];
+      CGFloat thePattern[patternCount];
       CGFloat phase = 0.0;
 
       penStyle = PS_GEOMETRIC | PS_USERSTYLE;


### PR DESCRIPTION
The dash pattern was declared as an array of CGFloat pointers rather than an
array of CGFloat, so -getLineDash:count:phase: filled it with dash lengths cast
to pointers and the pen pattern was built from the pointer values.  It also did
not compile on a modern compiler.  Declare it as an array of CGFloat.
