### PR TITLE
back/cairo: keep the exact clip across a graphics state save

### DIFF
--- a/Headers/cairo/CairoGState.h
+++ b/Headers/cairo/CairoGState.h
@@ -36,6 +36,7 @@
   @public
     cairo_t *_ct;
     CairoSurface *_surface;
+    NSMutableArray *_clipPaths;  /* base-space clip paths, in application order */
 }
 
 - (void) GSCurrentSurface: (CairoSurface **)surface : (int *)x : (int *)y;

--- a/Source/cairo/CairoGState.m
+++ b/Source/cairo/CairoGState.m
@@ -113,7 +113,42 @@ static inline cairo_filter_t cairoFilterFromNSImageInterpolation(NSImageInterpol
 }
 
 
-@implementation CairoGState 
+/* Emit a base-space bezier path onto a cairo context, resetting any current
+ * path first.  Used to replay tracked clip paths onto a copied context. */
+static void
+appendBezierToCairo(cairo_t *ct, NSBezierPath *bpath)
+{
+  NSInteger count = [bpath elementCount];
+  NSInteger i;
+
+  cairo_new_path(ct);
+  for (i = 0; i < count; i++)
+    {
+      NSPoint points[3];
+
+      switch ([bpath elementAtIndex: i associatedPoints: points])
+        {
+          case NSMoveToBezierPathElement:
+            cairo_move_to(ct, points[0].x, points[0].y);
+            break;
+          case NSLineToBezierPathElement:
+            cairo_line_to(ct, points[0].x, points[0].y);
+            break;
+          case NSCurveToBezierPathElement:
+            cairo_curve_to(ct, points[0].x, points[0].y,
+                           points[1].x, points[1].y,
+                           points[2].x, points[2].y);
+            break;
+          case NSClosePathBezierPathElement:
+            cairo_close_path(ct);
+            break;
+          default:
+            break;
+        }
+    }
+}
+
+@implementation CairoGState
 
 + (void) initialize
 {
@@ -129,6 +164,7 @@ static inline cairo_filter_t cairoFilterFromNSImageInterpolation(NSImageInterpol
       cairo_destroy(_ct);
     }
   RELEASE(_surface);
+  RELEASE(_clipPaths);
 
   [super dealloc];
 }
@@ -146,6 +182,8 @@ static inline cairo_filter_t cairoFilterFromNSImageInterpolation(NSImageInterpol
   CairoGState *copy = (CairoGState *)[super copyWithZone: zone];
 
   RETAIN(_surface);
+  /* super copies bitwise, so replace the shared pointer with our own list. */
+  copy->_clipPaths = [_clipPaths mutableCopy];
 
   if (_ct)
     {
@@ -165,7 +203,6 @@ static inline cairo_filter_t cairoFilterFromNSImageInterpolation(NSImageInterpol
           cairo_path_t *cpath;
           cairo_matrix_t local_matrix;
 #if CAIRO_VERSION > CAIRO_VERSION_ENCODE(1, 4, 0)
-          cairo_rectangle_list_t *clip_rects;
           int	num_dashes;
 #endif
 
@@ -175,6 +212,36 @@ static inline cairo_filter_t cairoFilterFromNSImageInterpolation(NSImageInterpol
           if (status != CAIRO_STATUS_SUCCESS)
             {
               NSLog(@"Cairo status '%s' in set matrix", cairo_status_to_string(status));
+            }
+
+          /* Reproduce the clip exactly by replaying the tracked paths under the
+           * same (base-space) matrix.  This runs before the current path is
+           * copied below, since cairo_clip() clears the path.  The tolerance
+           * and antialias are matched first so a curved clip is flattened into
+           * the same mask as the original. */
+          if ([copy->_clipPaths count] != 0)
+            {
+              NSUInteger ci, cn = [copy->_clipPaths count];
+
+              cairo_set_tolerance(copy->_ct, cairo_get_tolerance(_ct));
+              cairo_set_antialias(copy->_ct, cairo_get_antialias(_ct));
+
+              for (ci = 0; ci < cn; ci++)
+                {
+                  NSBezierPath *cp = [copy->_clipPaths objectAtIndex: ci];
+
+                  appendBezierToCairo(copy->_ct, cp);
+                  if ([cp windingRule] == NSEvenOddWindingRule)
+                    {
+                      cairo_set_fill_rule(copy->_ct, CAIRO_FILL_RULE_EVEN_ODD);
+                      cairo_clip(copy->_ct);
+                      cairo_set_fill_rule(copy->_ct, CAIRO_FILL_RULE_WINDING);
+                    }
+                  else
+                    {
+                      cairo_clip(copy->_ct);
+                    }
+                }
             }
 
           cpath = cairo_copy_path(_ct);
@@ -216,60 +283,6 @@ static inline cairo_filter_t cairoFilterFromNSImageInterpolation(NSImageInterpol
               cairo_set_dash (copy->_ct, dashes, num_dashes, dash_offset);
               GS_ENDITEMBUF();
             }
-
-          // In cairo 1.4 there also is a way to get the current clipping path
-          clip_rects = cairo_copy_clip_rectangle_list(_ct);
-          status = clip_rects->status;
-          if (status == CAIRO_STATUS_SUCCESS)
-            {
-              int i;
-
-              if (cairo_version() >= CAIRO_VERSION_ENCODE(1, 6, 0))
-                {
-                  for (i = 0; i < clip_rects->num_rectangles; i++)
-                    {
-                      cairo_rectangle_t rect = clip_rects->rectangles[i];
-
-                      cairo_rectangle(copy->_ct, rect.x, rect.y, 
-                                      rect.width, rect.height);
-                      cairo_clip(copy->_ct);
-                    }
-                }
-              else
-                {
-                  for (i = 0; i < clip_rects->num_rectangles; i++)
-                    {
-                      cairo_rectangle_t rect = clip_rects->rectangles[i];
-                      NSSize size = [_surface size];
-
-                      cairo_rectangle(copy->_ct, rect.x, 
-                                      /* This strange computation is due 
-                                         to the device offset missing for 
-                                         clip rects in cairo < 1.6.0.  */
-                                      rect.y + 2*(offset.y - size.height), 
-                                      rect.width, rect.height);
-                      cairo_clip(copy->_ct);
-                    }
-                }
-            }
-          else if (status == CAIRO_STATUS_CLIP_NOT_REPRESENTABLE)
-            {
-              // We cannot get the exact clip, so we do the best we can
-              double x1;
-              double y1;
-              double x2;
-              double y2;
-
-              cairo_clip_extents(_ct, &x1, &y1, &x2, &y2);
-              cairo_rectangle(copy->_ct, x1, y1, x2 - x1, y2 - y1);
-              cairo_clip(copy->_ct);
-            }
-          else
-            {
-              NSLog(@"Cairo status '%s' in copy clip", cairo_status_to_string(status));
-            }
-
-          cairo_rectangle_list_destroy(clip_rects);
 #endif
         }
     }
@@ -507,6 +520,7 @@ static inline cairo_filter_t cairoFilterFromNSImageInterpolation(NSImageInterpol
       cairo_destroy(_ct);
       _ct = NULL;
     }
+  [_clipPaths removeAllObjects];
   if (!_surface)
     {
       return;
@@ -728,12 +742,31 @@ static inline cairo_filter_t cairoFilterFromNSImageInterpolation(NSImageInterpol
   cairo_set_antialias(_ct, [self shouldAntialias] ? CAIRO_ANTIALIAS_DEFAULT : CAIRO_ANTIALIAS_NONE);
 }
 
+/* Remember the path just intersected with the clip so a gstate copy can
+ * reproduce it exactly.  cairo only exposes its clip as a user-space rectangle
+ * list, which cannot represent a non-rectangular clip, so tracking the paths
+ * ourselves is the only way -copyWithZone: can keep the real clip shape. */
+- (void) _trackClipPath: (NSWindingRule)rule
+{
+  NSBezierPath *snapshot;
+
+  if (_clipPaths == nil)
+    {
+      _clipPaths = [[NSMutableArray alloc] initWithCapacity: 2];
+    }
+  snapshot = [path copy];
+  [snapshot setWindingRule: rule];
+  [_clipPaths addObject: snapshot];
+  RELEASE(snapshot);
+}
+
 - (void) DPSclip
 {
   if (_ct)
     {
       [self _setPath];
       cairo_clip(_ct);
+      [self _trackClipPath: NSNonZeroWindingRule];
      }
 }
 
@@ -745,6 +778,7 @@ static inline cairo_filter_t cairoFilterFromNSImageInterpolation(NSImageInterpol
       cairo_set_fill_rule(_ct, CAIRO_FILL_RULE_EVEN_ODD);
       cairo_clip(_ct);
       cairo_set_fill_rule(_ct, CAIRO_FILL_RULE_WINDING);
+      [self _trackClipPath: NSEvenOddWindingRule];
     }
 }
 
@@ -799,6 +833,7 @@ static inline cairo_filter_t cairoFilterFromNSImageInterpolation(NSImageInterpol
   if (_ct)
     {
       cairo_reset_clip(_ct);
+      [_clipPaths removeAllObjects];
     }
 }
 

--- a/Tests/cairo/clipsaverestore.m
+++ b/Tests/cairo/clipsaverestore.m
@@ -1,0 +1,137 @@
+/* Tests that a non-rectangular clip survives the graphics state save/restore
+ * stack in the cairo backend.  A clip set before -saveGraphicsState is carried
+ * onto the copied state, and drawing there must stay inside the real clip
+ * shape, not its bounding box.  Rectangular clips always survived; the shapes
+ * exercised here (triangle, oval, even-odd ring) are the ones cairo cannot
+ * report as a rectangle list, so the state copy has to reproduce them itself.
+ *
+ * It needs a running window server, so it skips cleanly when there is none, and
+ * guards on the cairo graphics backend.  Colours are checked with a small
+ * tolerance for the backend's fixed-point arithmetic.
+ */
+#import <Foundation/NSObject.h>
+#import "Testing.h"
+#include "config.h"
+
+#if defined(BUILD_GRAPHICS) && defined(GRAPHICS_cairo) \
+  && BUILD_GRAPHICS == GRAPHICS_cairo
+
+#import <AppKit/AppKit.h>
+#include <stdlib.h>
+
+static NSImage *
+beginImage(int w, int h)
+{
+  NSImage *img = [[NSImage alloc] initWithSize: NSMakeSize(w, h)];
+  [img lockFocus];
+  [[NSColor whiteColor] set];
+  NSRectFill(NSMakeRect(0, 0, w, h));
+  return img;
+}
+
+static NSBitmapImageRep *
+endImage(NSImage *img, int w, int h)
+{
+  NSBitmapImageRep *rep;
+  [[NSGraphicsContext currentContext] flushGraphics];
+  rep = [[NSBitmapImageRep alloc]
+          initWithFocusedViewRect: NSMakeRect(0, 0, w, h)];
+  [img unlockFocus];
+  [img release];
+  return [rep autorelease];
+}
+
+/* Check the RGB sample at (x, y) with a small tolerance. */
+static BOOL
+pixelIs(NSBitmapImageRep *rep, int x, int y, int r, int g, int b)
+{
+  NSUInteger px[5];
+
+  [rep getPixel: px atX: x y: y];
+  return (abs((int)px[0] - r) <= 2
+          && abs((int)px[1] - g) <= 2
+          && abs((int)px[2] - b) <= 2);
+}
+
+/* Clip to the given path, save, fill everything red, restore.  The fill runs on
+ * the copied state that inherited the clip. */
+static NSBitmapImageRep *
+clipSaveFill(int w, int h, NSBezierPath *clip)
+{
+  NSImage *img = beginImage(w, h);
+
+  [clip addClip];
+  [NSGraphicsContext saveGraphicsState];
+  [[NSColor colorWithDeviceRed: 1.0 green: 0.0 blue: 0.0 alpha: 1.0] set];
+  NSRectFill(NSMakeRect(0, 0, w, h));
+  [NSGraphicsContext restoreGraphicsState];
+  return endImage(img, w, h);
+}
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(pool);
+  int w = 24, h = 24;
+  NSBitmapImageRep *rep;
+  NSBezierPath *p;
+
+  if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
+    {
+      NSLog(@"no window server available; skipping clip save/restore tests");
+      DESTROY(pool);
+      return 0;
+    }
+
+  [NSApplication sharedApplication];
+
+  /* A triangle with the right angle at (3,3) and hypotenuse (21,3)-(3,21).
+   * Read back (top-left origin) its interior is the lower-left half: (7,16) is
+   * inside, (18,6) is above the hypotenuse, outside the triangle but inside its
+   * bounding box.  If the clip were reduced to its bounding box, (18,6) would
+   * fill. */
+  p = [NSBezierPath bezierPath];
+  [p moveToPoint: NSMakePoint(3, 3)];
+  [p lineToPoint: NSMakePoint(21, 3)];
+  [p lineToPoint: NSMakePoint(3, 21)];
+  [p closePath];
+  rep = clipSaveFill(w, h, p);
+  PASS(rep != nil && pixelIs(rep, 7, 16, 255, 0, 0),
+       "a triangle clip still paints its interior after save/restore");
+  PASS(rep != nil && pixelIs(rep, 18, 6, 255, 255, 255),
+       "a triangle clip is not widened to its bounding box by save/restore");
+
+  /* An oval clip: the centre is inside, a bounding-box corner is outside. */
+  p = [NSBezierPath bezierPathWithOvalInRect: NSMakeRect(3, 3, 18, 18)];
+  rep = clipSaveFill(w, h, p);
+  PASS(rep != nil && pixelIs(rep, 12, 12, 255, 0, 0),
+       "an oval clip still paints its interior after save/restore");
+  PASS(rep != nil && pixelIs(rep, 4, 4, 255, 255, 255),
+       "an oval clip corner is not filled after save/restore");
+
+  /* An even-odd ring (outer rect minus inner rect): a point on the ring is
+   * inside, the central hole is outside.  Checks that the even-odd rule is
+   * carried across the save as well as the geometry. */
+  p = [NSBezierPath bezierPath];
+  [p appendBezierPathWithRect: NSMakeRect(3, 3, 18, 18)];
+  [p appendBezierPathWithRect: NSMakeRect(9, 9, 6, 6)];
+  [p setWindingRule: NSEvenOddWindingRule];
+  rep = clipSaveFill(w, h, p);
+  PASS(rep != nil && pixelIs(rep, 5, 12, 255, 0, 0),
+       "an even-odd ring clip still paints the ring after save/restore");
+  PASS(rep != nil && pixelIs(rep, 12, 12, 255, 255, 255),
+       "an even-odd ring clip keeps its hole after save/restore");
+
+  DESTROY(pool);
+  return 0;
+}
+
+#else
+
+int
+main(int argc, const char **argv)
+{
+  return 0;
+}
+
+#endif

--- a/Tests/cairo/clipsaverestore.m
+++ b/Tests/cairo/clipsaverestore.m
@@ -68,6 +68,26 @@ clipSaveFill(int w, int h, NSBezierPath *clip)
   return endImage(img, w, h);
 }
 
+/* Clip to the given path, then draw a gradient through
+ * -[NSGradient drawInRect:angle:], which saves and restores the graphics state
+ * itself.  The clip set beforehand has to survive that copy, so this reaches
+ * the same code as clipSaveFill but through the path gnustep/libs-gui#228
+ * reported.  The gradient runs green to blue, so a painted pixel has a zero red
+ * component while the background stays white. */
+static NSBitmapImageRep *
+clipGradientFill(int w, int h, NSBezierPath *clip)
+{
+  NSImage *img = beginImage(w, h);
+  NSGradient *g = [[NSGradient alloc]
+    initWithStartingColor: [NSColor colorWithDeviceRed: 0.0 green: 1.0 blue: 0.0 alpha: 1.0]
+              endingColor: [NSColor colorWithDeviceRed: 0.0 green: 0.0 blue: 1.0 alpha: 1.0]];
+
+  [clip addClip];
+  [g drawInRect: [clip bounds] angle: 90.0];
+  [g release];
+  return endImage(img, w, h);
+}
+
 int
 main(int argc, const char **argv)
 {
@@ -108,6 +128,17 @@ main(int argc, const char **argv)
        "an oval clip still paints its interior after save/restore");
   PASS(rep != nil && pixelIs(rep, 4, 4, 255, 255, 255),
        "an oval clip corner is not filled after save/restore");
+
+  /* The same oval, filled by a gradient.  -[NSGradient drawInRect:angle:] saves
+   * the graphics state internally, so the oval clip has to survive that save;
+   * this is the case reported in gnustep/libs-gui#228.  The centre is painted
+   * (non-white), a bounding-box corner stays white. */
+  p = [NSBezierPath bezierPathWithOvalInRect: NSMakeRect(3, 3, 18, 18)];
+  rep = clipGradientFill(w, h, p);
+  PASS(rep != nil && !pixelIs(rep, 12, 12, 255, 255, 255),
+       "a gradient clipped to an oval paints its interior");
+  PASS(rep != nil && pixelIs(rep, 4, 4, 255, 255, 255),
+       "a gradient clipped to an oval does not spill to its bounding box");
 
   /* An even-odd ring (outer rect minus inner rect): a point on the ring is
    * inside, the central hole is outside.  Checks that the even-odd rule is


### PR DESCRIPTION
Fixes #68.

`-[CairoGState copyWithZone:]` rebuilt the clip from `cairo_copy_clip_rectangle_list`, which reports a non-rectangular clip as `CLIP_NOT_REPRESENTABLE` and fell back to the clip bounding box. A clip set before `-saveGraphicsState` was widened to its bounding box on the copied state, so an NSGradient drawn in a bezier path spilled outside the shape (libs-gui #228).

Track the clip paths in base space as they are applied in `-DPSclip` and `-DPSeoclip`, drop them in `-DPSinitclip` and `-DPSinitgraphics`, and replay them onto the copied context. This keeps the separate per-state `cairo_t` that `GSDefineGState` and `DPSsetgstate` rely on, so it avoids the scrolling and image regressions the earlier `cairo_save`/`cairo_restore` approach caused.

`Tests/cairo/clipsaverestore.m` covers triangle, oval and even-odd ring clips across save and restore; it fails on master (the non-rectangular clips widen to their bounding box) and passes with the fix. The rest of the `Tests/cairo` suite is unchanged.
