### PR TITLE
back/x11: set _NET_WM_PID and WM_CLIENT_MACHINE on each window

### DIFF
--- a/Source/x11/XGServerWindow.m
+++ b/Source/x11/XGServerWindow.m
@@ -1992,6 +1992,35 @@ _get_next_prop_new_event(Display *display, XEvent *event, char *arg)
 		      (unsigned char *)&window->win_attrs,
 		      sizeof(GNUstepWMAttributes)/sizeof(CARD32));
 
+  // Let an EWMH window manager associate this window with our process.
+  // The specification requires WM_CLIENT_MACHINE to accompany _NET_WM_PID.
+  if ((generic.wm & XGWM_EWMH) != 0)
+    {
+      NSProcessInfo	*pInfo = [NSProcessInfo processInfo];
+      long		pid = [pInfo processIdentifier];
+      const char	*host_name = [[pInfo hostName] UTF8String];
+
+/* Warning ... X-bug .. when we specify 32bit data X actually expects data
+ * of type 'long' or 'unsigned long' even on machines where those types
+ * hold 64bit values.
+ */
+      XChangeProperty(dpy, window->ident,
+	generic._NET_WM_PID_ATOM, XA_CARDINAL,
+	32, PropModeReplace,
+	(unsigned char *)&pid, 1);
+
+      if (host_name != NULL && *host_name != '\0')
+	{
+	  XTextProperty	machine;
+
+	  if (XStringListToTextProperty((char **)&host_name, 1, &machine) != 0)
+	    {
+	      XSetWMClientMachine(dpy, window->ident, &machine);
+	      XFree(machine.value);
+	    }
+	}
+    }
+
   // send to the WM window style hints
   if ((generic.wm & XGWM_WINDOWMAKER) == 0)
     {


### PR DESCRIPTION
Closes #74.

An EWMH window manager uses `_NET_WM_PID` to find the process owning a window, for example to kill one that does not answer `_NET_WM_PING`. It was only set on the root window, not on the client windows, so it was effectively missing. `WM_CLIENT_MACHINE` is required alongside it.

Set both on each window in `-window::::` for EWMH window managers, using `[NSProcessInfo hostName]` for the client machine (as suggested in the issue) so the value stays consistent with the rest of GNUstep.

Verified under Xvfb with openbox: `xprop` on the application windows reports `_NET_WM_PID` equal to the process id and `WM_CLIENT_MACHINE` equal to the host name.
