### PR TITLE
back/wayland: build the X11 pasteboard owner into gpbs

### DIFF
--- a/Tools/GNUmakefile
+++ b/Tools/GNUmakefile
@@ -54,6 +54,18 @@ gpbs_C_FILES += xdnd.c
 endif
 endif
 
+# The wayland backend has no pasteboard owner of its own, so build the X11
+# owner into gpbs when X11 is available; it reaches the desktop clipboard
+# through XWayland.  Without X11 gpbs stays an internal-only pasteboard.
+ifeq ($(BUILD_SERVER),wayland)
+ifneq ($(findstring -lX11,$(GRAPHIC_LIBS)),)
+gpbs_OBJC_FILES += xpbs.m
+ifeq ($(BACKEND_BUNDLE),yes)
+gpbs_C_FILES += xdnd.c
+endif
+endif
+endif
+
 ifeq ($(BUILD_SERVER),win32)
 gpbs_OBJC_FILES += win32pbs.m 
 endif


### PR DESCRIPTION
Closes #71.

`gpbs` selects `XPbOwner` as its pasteboard owner on every platform except Windows, but `xpbs.m`, which defines that class, was compiled only for the x11 server. A wayland build therefore produced a `gpbs` with no pasteboard owner, so `NSPasteboard` was disconnected from the desktop clipboard and paste was disabled in GNUstep applications.

Compile `xpbs.m` and `xdnd.c` into `gpbs` for a wayland build when X11 is available, so the X11 owner reaches the desktop clipboard through XWayland. Guarding on X11 (rather than an unconditional `x11 wayland` filter) keeps a wayland build without X11 unchanged, since configure does not require X11 for the wayland server.

Verified on a wayland session: after `wl-copy`, an `NSPasteboard` probe reads the copied text through the wayland-built `gpbs` (both the wayland-native and X clipboard paths bridge via XWayland).

Thanks to @danjboyd for the diagnosis and the reproduction.
