### PR TITLE
back/x11: demote the failed-offset-detection log to a debug log

### DIFF
--- a/Source/x11/XGServerWindow.m
+++ b/Source/x11/XGServerWindow.m
@@ -1151,7 +1151,7 @@ _get_next_prop_new_event(Display *display, XEvent *event, char *arg)
     }
   if (o->known == NO)
     {
-      NSLog(@"Failed to determine offsets for style %d", style);
+      NSDebugLLog(@"Offset", @"Failed to determine offsets for style %d", style);
       return NO;
     }
   return YES;


### PR DESCRIPTION
The log referenced in #32 was already changed to a debug log in 9299fa1. This does the same for the sibling message in `-[XGServer(WindowOps) _checkStyle:]`, which still logs "Failed to determine offsets for style" once per window style when the window manager does not reparent. That is expected on rootless and exported servers (fifteen lines on start), and the code handles it by guessing the offsets, so it is demoted to a debug log under the same `Offset` level.

Verified under a bare Xvfb (no reparenting): the message prints fifteen times before this change and none after.
