### PR TITLE
Wayland: build pointer enter/leave with enterExitEventWithType:

### DIFF
--- a/Source/wayland/WaylandServer+Cursor.m
+++ b/Source/wayland/WaylandServer+Cursor.m
@@ -87,19 +87,17 @@ pointer_handle_enter(void *data, struct wl_pointer *pointer, uint32_t serial,
       gcontext = GSCurrentContext();
       eventLocation = NSMakePoint(sx, window->height - sy);
 
-      event = [NSEvent mouseEventWithType:NSMouseEntered
+      /* NSMouseEntered must be built with the enter/exit constructor;
+       * +mouseEventWithType: rejects it ("mouseEvent with wrong type"). */
+      event = [NSEvent enterExitEventWithType:NSMouseEntered
 				 location:eventLocation
 			    modifierFlags:wlconfig->modifiers
 				timestamp:wlconfig->pointer.last_timestamp
 			     windowNumber:window->window_id
 				  context:gcontext
 			      eventNumber:serial
-			       clickCount:0
-				 pressure:0.0
-			     buttonNumber:0
-				   deltaX:deltaX
-				   deltaY:deltaY
-				   deltaZ:0.];
+			   trackingNumber:0
+				 userData:NULL];
 
       [GSCurrentServer() postEvent:event atStart:NO];
     }
@@ -143,19 +141,19 @@ pointer_handle_leave(void *data, struct wl_pointer *pointer, uint32_t serial,
           gcontext = GSCurrentContext();
 
           eventLocation = NSMakePoint(wlconfig->pointer.x, wlconfig->pointer.y);
-          event = [NSEvent mouseEventWithType:NSMouseExited
+          /* NSMouseExited is not a plain mouse event: +mouseEventWithType:
+           * rejects it ("mouseEvent with wrong type").  This path is reached
+           * whenever the pointer leaves while a button is held - notably at
+           * the start of a drag - so it must use the enter/exit constructor. */
+          event = [NSEvent enterExitEventWithType:NSMouseExited
                           location:eventLocation
                       modifierFlags:0
                           timestamp:wlconfig->pointer.last_timestamp
                       windowNumber:window->window_id
                           context:gcontext
                       eventNumber:serial
-                      clickCount:0
-                          pressure:0.0
-                      buttonNumber:0
-                          deltaX:0
-                          deltaY:0
-                          deltaZ:0.];
+                      trackingNumber:0
+                          userData:NULL];
 
           [GSCurrentServer() postEvent:event atStart:NO];
         }


### PR DESCRIPTION
Closes #79 
The Wayland pointer enter and leave handlers build NSMouseEntered and NSMouseExited events with `+[NSEvent mouseEventWithType:]`, which raises `NSInvalidArgumentException` ("mouseEvent with wrong type") because `GSMouseEventMask` does not cover those two types; they belong to `GSEnterExitEventMask`. Both handlers now use `+[NSEvent enterExitEventWithType:...]`, the correct constructor for enter/exit events.

The raise happens inside `wl_display_dispatch` in `-[WaylandServer receivedEvent:]`, a run loop input source. `-[NSApplication run]` wraps event dispatch in NS_DURING/NS_HANDLER, so in normal use the exception is caught and logged and the application continues. `-[NSApplication runModalSession:]` has no such handler and dispatches events in NSModalPanelRunLoopMode, so an enter or leave raised while an NSOpenPanel or NSSavePanel is open unwinds the modal loop and the panel closes. 

This is issue #79: the file dialog closes as soon as the pointer moves over it or over another window of the same application. The same defect also aborts a drag, when the compositor sends `wl_pointer.leave` to take the pointer for the drag grab, which is why this PR is needed before #166.
