### PR TITLE
Fix: only link libGL for the wayland EGL test when EGL is enabled

### DIFF
--- a/Tests/cairo/GNUmakefile.preamble
+++ b/Tests/cairo/GNUmakefile.preamble
@@ -27,6 +27,11 @@ ADDITIONAL_OBJCFLAGS += -D_GNU_SOURCE
 
 ADDITIONAL_TOOL_LIBS += $(shell pkg-config --libs cairo wayland-client)
 
-# The EGL/OpenGL context test calls the GL API directly, so it also needs libGL.
+# The EGL/OpenGL context test calls the GL API directly, so it also needs
+# libGL, but only where the backend was built with EGL.  Without EGL the test
+# compiles to an inert skip and libGL need not be present, so linking it there
+# would break the build on systems that have no libGL.
+ifeq ($(WITH_EGL),yes)
 wlglcontext_TOOL_LIBS += -lGL
+endif
 endif


### PR DESCRIPTION
The `ci (wayland, cairo)` job has been red on master since #155 merged
(run 29806772471): 143 tests pass, then one test fails to build.

```
Building cairo/wlglcontext.m
 Linking test_tool wlglcontext ...
/usr/bin/ld: cannot find -lGL: No such file or directory
collect2: error: ld returned 1 exit status
```

`Tests/cairo/GNUmakefile.preamble` added `-lGL` to the `wlglcontext` tool
for every `wayland-cairo` build. On the CI container EGL and GL are present
only as weston's runtime dependencies (`libegl1`, `libwayland-egl1`), not as
development libraries, so `configure` reports:

```
checking for EGL/egl.h... no
checking for eglGetDisplay in -lEGL... no
```

With EGL unavailable the backend is built without it and `wlglcontext.m`
compiles to its `#else` skip stub, which makes no GL calls. But the tool was
still linked against `-lGL`, and libGL's development library is absent, so the
link fails and the test run reports a failed build.

This gates the `-lGL` on `WITH_EGL`, matching the source-level guard in the
test, so libGL is only needed where the EGL code path is actually built.

Verified locally against the wayland+cairo backend:

- Reconfigured with EGL hidden (`ac_cv_header_EGL_egl_h=no`,
  `ac_cv_lib_EGL_eglGetDisplay=no`) to reproduce the CI state
  (`WITH_EGL=no`, `HAVE_EGL` undefined). Before this change the `wlglcontext`
  link line carried `-lGL`; after it, the link libs are
  `-lcairo -lgnustep -lm -lobjc -lpthread -lwayland` and the test builds and
  skips cleanly.
- With EGL present (`WITH_EGL=yes`) the link still carries `-lGL` and the test
  runs (3 passed), so the EGL path is unchanged.
