### PR TITLE
Wayland: guard the cursor operations against a NULL pointer proxy

### DIFF
--- a/Source/wayland/WaylandServer+Cursor.m
+++ b/Source/wayland/WaylandServer+Cursor.m
@@ -616,6 +616,10 @@ WaylandServer (Cursor)
 
 - (void)hidecursor
 {
+  if (wlconfig->pointer.wlpointer == NULL)
+    {
+      return;
+    }
   // to hide the cursor we set a NULL surface
   wl_pointer_set_cursor(wlconfig->pointer.wlpointer, wlconfig->pointer.serial,
 			NULL, 0, 0);
@@ -623,6 +627,10 @@ WaylandServer (Cursor)
 
 - (void)showcursor
 {
+  if (wlconfig->pointer.wlpointer == NULL)
+    {
+      return;
+    }
   // restore  the previous surface
   wl_pointer_set_cursor(wlconfig->pointer.wlpointer, wlconfig->pointer.serial,
 			wlconfig->cursor->surface,
@@ -773,6 +781,10 @@ WaylandServer (Cursor)
       return;
     }
   if (wayland_cursor->buffer == NULL)
+    {
+      return;
+    }
+  if (wlconfig->pointer.wlpointer == NULL)
     {
       return;
     }


### PR DESCRIPTION
The Wayland backend can crash during ordinary startup with a NULL dereference inside libwayland:

```
#0  wl_proxy_get_version ()  (libwayland-client)
#1  wl_pointer_set_cursor (wl_pointer=0x0, ...)
#2  -[WaylandServer(Cursor) setcursor:]      WaylandServer+Cursor.m
#3  -[WaylandServer(Cursor) initializeMouse] WaylandServer+Cursor.m
#4  -[WaylandServer(Cursor) standardcursor::]
#5  getStandardCursor                        NSCursor.m
#6  +[NSCursor initialize]                    NSCursor.m
...
#10 -[NSApplication nextEventMatchingMask:...]
```

`-hidecursor`, `-showcursor` and `-setcursor:` pass `wlconfig->pointer.wlpointer` to `wl_pointer_set_cursor()`. That proxy is NULL until the seat announces a pointer capability (`WaylandServer+Seat.m`), and a seat may legitimately have no pointer at all. When a cursor is set before the pointer is bound, `wl_pointer_set_cursor(NULL, ...)` dereferences NULL and crashes.

It is reachable in normal use: the first time `NSCursor` is touched, `+[NSCursor initialize]` lazily sets the standard cursor from inside `-initializeMouse` while events are being processed — before the seat round-trip has necessarily bound the pointer. This makes it an intermittent startup crash (it depends on the timing of the seat capability event).

The fix adds a NULL guard for `wlconfig->pointer.wlpointer` to the three call sites, matching the NULL guards already present in `-setcursor:`. A Wayland client must not assume the seat has a pointer device.

Reproduced and verified on WSLg (Wayland + cairo): before the change, a program that dispatches a mouse event during startup segfaulted intermittently (about 6 of 10 runs); after the change it is stable across many runs. The X11 (xlib, art) and win32 backends are unaffected — their cursor APIs (`XDefineCursor`, `SetCursor`/`ShowCursor`) tolerate the empty/NULL case, and only the Wayland path calls `wl_pointer_set_cursor` directly.