### PR TITLE
back/fontconfig: resolve default bold and fixed-pitch fonts through fontconfig

### DIFF
--- a/Source/fontconfig/FCFontEnumerator.m
+++ b/Source/fontconfig/FCFontEnumerator.m
@@ -453,8 +453,67 @@ static NSArray *faFromFc(FcPattern *pat)
   return @"Helvetica";
 }
 
+/* Return the enumerated font name of fontconfig's best match for pat,
+   applying the usual configuration and default substitutions, or nil.
+   Reuses faFromFc so the returned name is the same one under which the
+   font was enumerated (and thus present in allFontNames).  The caller
+   owns pat. */
+static NSString *
+fcDefaultFontName(FcPattern *pat)
+{
+  NSString *name = nil;
+  FcPattern *match;
+  FcResult result;
+
+  FcConfigSubstitute(NULL, pat, FcMatchPattern);
+  FcDefaultSubstitute(pat);
+  match = FcFontMatch(NULL, pat, &result);
+  if (match != NULL)
+    {
+      NSArray *fontArray = faFromFc(match);
+
+      if (fontArray != nil)
+        {
+          name = [fontArray objectAtIndex: 0];
+        }
+      FcPatternDestroy(match);
+    }
+  return name;
+}
+
 - (NSString *) defaultBoldSystemFontName
 {
+  /* Ask fontconfig for the bold face of the configured system font family,
+     so a custom system font (set through the NSFont default) gets its own
+     bold variant instead of an unrelated hardcoded family.  The list below
+     is only a last resort when fontconfig cannot resolve a bold face. */
+  NSString *systemFont = [[NSUserDefaults standardUserDefaults]
+                           stringForKey: @"NSFont"];
+  NSString *family;
+  NSString *name;
+  FcPattern *pat;
+
+  if (systemFont == nil)
+    {
+      systemFont = [self defaultSystemFontName];
+    }
+  family = [[FCFontEnumerator fontWithName: systemFont] familyName];
+  if (family == nil)
+    {
+      family = systemFont;
+    }
+
+  pat = FcPatternBuild(NULL,
+                       FC_FAMILY, FcTypeString, (const FcChar8 *)[family UTF8String],
+                       FC_WEIGHT, FcTypeInteger, FC_WEIGHT_BOLD,
+                       (char *)NULL);
+  name = fcDefaultFontName(pat);
+  FcPatternDestroy(pat);
+  if (name != nil && [allFontNames containsObject: name])
+    {
+      return name;
+    }
+
   if ([allFontNames containsObject: @"DejaVuSans-Bold"])
     {
       return @"DejaVuSans-Bold";
@@ -480,6 +539,21 @@ static NSArray *faFromFc(FcPattern *pat)
 
 - (NSString *) defaultFixedPitchFontName
 {
+  /* Ask fontconfig for the system's configured monospace font rather than
+     assuming a fixed list of family names.  The list below is only a last
+     resort. */
+  NSString *name;
+  FcPattern *pat = FcPatternBuild(NULL,
+                                  FC_FAMILY, FcTypeString, (const FcChar8 *)"monospace",
+                                  (char *)NULL);
+
+  name = fcDefaultFontName(pat);
+  FcPatternDestroy(pat);
+  if (name != nil && [allFontNames containsObject: name])
+    {
+      return name;
+    }
+
   if ([allFontNames containsObject: @"DejaVuSansMono"])
     {
       return @"DejaVuSansMono";


### PR DESCRIPTION
Requires: [libs-gui/PR#816](https://github.com/gnustep/libs-gui/pull/816)

`defaultBoldSystemFontName` and `defaultFixedPitchFontName` in the fontconfig enumerator kept hardcoded priority lists of font names. When a user configures a custom system font (the `NSFont` default) without a matching `NSBoldFont`, the bold lookup falls through to an unrelated hardcoded family, fontconfig can't find it, and bold UI text silently renders in regular weight (issue #170, case 1).

Instead of string lists, this asks fontconfig — which is already the enumeration engine here — for the right face:

- **bold**: derive the bold face of the configured system font family via `FC_WEIGHT_BOLD`.
- **fixed-pitch**: match the `monospace` generic.

The match is converted through the existing `faFromFc`, so the returned name is exactly the one under which the font was enumerated (guaranteed present in `allFontNames`). The historic lists remain only as a last resort when fontconfig resolves nothing, so behaviour can only improve — the default (DejaVu) case is unchanged.

Verified on the shared FCFontEnumerator across the graphics backends that use it:
- **cairo (x11)** and **xlib**: with `NSFont` unset, bold/fixed resolve to `DejaVuSans-Bold`/`DejaVuSansMono` as before; with `NSFont` set to a non-default family (Bitstream Charter), bold now correctly derives `CharterBT-Bold` (same family, bold weight) rather than the old `DejaVuSans-Bold`.
- **wayland+cairo**: builds and uses the same graphics-layer resolution (server-independent).

Scope: this fixes the shared fontconfig enumerator (cairo, xlib). The art backend's `FTFontEnumerator` and the Windows `WIN32FontEnumerator` keep their own copies of the hardcoded logic; the same idea applies there (fontconfig for FT, GDI `LOGFONT` weight/pitch for Win32) and is left as a follow-up. The broader architectural cleanup in #170 (de-duplication, plist ranking) is also out of scope here.

Addresses #170.