### PR TITLE
Derive the default bold font from the system font family in the art and win32 enumerators

### DIFF
--- a/Source/art/FTFontEnumerator.m
+++ b/Source/art/FTFontEnumerator.m
@@ -457,6 +457,77 @@ static void load_font_configuration(void)
   DESTROY(families_pending);
 }
 
+/* The bold face of the family that `systemFont` (a family or face name)
+   belongs to, or nil.  This lets a custom system font, set through the
+   NSFont default, resolve to its own bold variant instead of falling
+   through to an unrelated hardcoded family. */
+static NSString *
+ftBoldFaceForSystemFont(NSString *systemFont)
+{
+  NSArray *faces = [fcfg_allFontFamilies objectForKey: systemFont];
+  NSUInteger i, n;
+
+  if (faces == nil)
+    {
+      NSEnumerator *fe = [fcfg_allFontFamilies keyEnumerator];
+      NSString *family;
+
+      while (faces == nil && (family = [fe nextObject]) != nil)
+        {
+          NSArray *fs = [fcfg_allFontFamilies objectForKey: family];
+
+          n = [fs count];
+          for (i = 0; i < n; i++)
+            {
+              if ([[[fs objectAtIndex: i] objectAtIndex: 0]
+                    isEqualToString: systemFont])
+                {
+                  faces = fs;
+                  break;
+                }
+            }
+        }
+    }
+  if (faces == nil)
+    return nil;
+
+  n = [faces count];
+  for (i = 0; i < n; i++)
+    {
+      NSArray *face = [faces objectAtIndex: i];
+
+      if ([[face objectAtIndex: 3] unsignedIntValue] & NSBoldFontMask)
+        return [face objectAtIndex: 0];
+    }
+  return nil;
+}
+
+/* The name of a plain (non-bold, non-italic) enumerated face carrying
+   `trait`, or nil.  Used to pick a fixed-pitch default from the enumerated
+   fonts rather than embedding a specific family name. */
+static NSString *
+ftPlainFaceWithTrait(NSFontTraitMask trait)
+{
+  NSEnumerator *fe = [fcfg_allFontFamilies objectEnumerator];
+  NSArray *faces;
+
+  while ((faces = [fe nextObject]) != nil)
+    {
+      NSUInteger i, n = [faces count];
+
+      for (i = 0; i < n; i++)
+        {
+          NSArray *face = [faces objectAtIndex: i];
+          NSFontTraitMask t = [[face objectAtIndex: 3] unsignedIntValue];
+
+          if ((t & trait) == trait
+              && (t & (NSBoldFontMask | NSItalicFontMask)) == 0)
+            return [face objectAtIndex: 0];
+        }
+    }
+  return nil;
+}
+
 @implementation FTFontEnumerator
 
 + (FTFaceInfo *) fontWithName: (NSString *)name
@@ -490,6 +561,19 @@ static void load_font_configuration(void)
 
 - (NSString *) defaultBoldSystemFontName
 {
+  /* Derive the bold face from the configured system font family, so a
+     custom system font gets its own bold variant.  The hardcoded names
+     remain only as a last resort. */
+  NSString *systemFont = [[NSUserDefaults standardUserDefaults]
+                           stringForKey: @"NSFont"];
+  NSString *name;
+
+  if (systemFont == nil)
+    systemFont = [self defaultSystemFontName];
+  name = ftBoldFaceForSystemFont(systemFont);
+  if (name != nil && [fcfg_allFontNames containsObject: name])
+    return name;
+
   if ([fcfg_allFontNames containsObject: @"BitstreamVeraSans-Bold"])
     return @"BitstreamVeraSans-Bold";
   if ([fcfg_allFontNames containsObject: @"FreeSansBold"])
@@ -499,6 +583,11 @@ static void load_font_configuration(void)
 
 - (NSString *) defaultFixedPitchFontName
 {
+  NSString *name = ftPlainFaceWithTrait(NSFixedPitchFontMask);
+
+  if (name != nil && [fcfg_allFontNames containsObject: name])
+    return name;
+
   if ([fcfg_allFontNames containsObject: @"BitstreamVeraSansMono-Roman"])
     return @"BitstreamVeraSansMono-Roman";
   if ([fcfg_allFontNames containsObject: @"FreeMono"])

--- a/Source/winlib/WIN32FontEnumerator.m
+++ b/Source/winlib/WIN32FontEnumerator.m
@@ -28,6 +28,8 @@
 #include <Foundation/NSAutoreleasePool.h>
 #include <Foundation/NSDebug.h>
 #include <Foundation/NSDictionary.h>
+#include <Foundation/NSEnumerator.h>
+#include <Foundation/NSUserDefaults.h>
 #include <Foundation/NSValue.h>
 
 #include "winlib/WIN32FontEnumerator.h"
@@ -262,6 +264,57 @@ int CALLBACK fontfamilyenum(ENUMLOGFONTEXW *lpelfe, NEWTEXTMETRICEXW *lpntme,
 
 - (NSString*) defaultBoldSystemFontName
 {
+  /* Derive the bold face from the configured system font family, so a
+     custom system font (set through the NSFont default) gets its own bold
+     variant instead of the hardcoded Tahoma Bold.  Falls back to Tahoma
+     Bold when the family has no bold face.  Fixed-pitch is left hardcoded
+     because the family enumeration here does not record that trait. */
+  NSString *systemFont = [[NSUserDefaults standardUserDefaults]
+                           stringForKey: @"NSFont"];
+  NSArray *faces;
+
+  if (systemFont == nil)
+    systemFont = [self defaultSystemFontName];
+
+  faces = [allFontFamilies objectForKey: systemFont];
+  if (faces == nil)
+    {
+      NSEnumerator *fe = [allFontFamilies keyEnumerator];
+      NSString *family;
+
+      while (faces == nil && (family = [fe nextObject]) != nil)
+        {
+          NSArray *fs = [allFontFamilies objectForKey: family];
+          NSUInteger i, n = [fs count];
+
+          for (i = 0; i < n; i++)
+            {
+              if ([[[fs objectAtIndex: i] objectAtIndex: 0]
+                    isEqualToString: systemFont])
+                {
+                  faces = fs;
+                  break;
+                }
+            }
+        }
+    }
+  if (faces != nil)
+    {
+      NSUInteger i, n = [faces count];
+
+      for (i = 0; i < n; i++)
+        {
+          NSArray *face = [faces objectAtIndex: i];
+
+          if ([[face objectAtIndex: 3] unsignedIntValue] & NSBoldFontMask)
+            {
+              NSString *name = [face objectAtIndex: 0];
+
+              if ([allFontNames containsObject: name])
+                return name;
+            }
+        }
+    }
   return @"Tahoma Bold";
 }
 


### PR DESCRIPTION
The art `FTFontEnumerator` and the Windows `WIN32FontEnumerator` kept hardcoded priority lists in `defaultBoldSystemFontName`, the same problem #172 addressed in the fontconfig enumerator: a custom system font (the `NSFont` default) without a matching `NSBoldFont` fell through to an unrelated hardcoded family, so bold UI text rendered in regular weight (issue #170, case 1).

Both backends already record each family's faces with their traits, so the bold face is now taken from the configured system font's own family, keeping the hardcoded names only as a last resort. The art enumerator also picks the fixed-pitch default from an enumerated fixed-pitch face; the win32 family enumeration does not record that trait, so its fixed-pitch default (Courier New) is unchanged.

Verified on the art backend: with `NSFont` set to a custom family, `defaultBoldSystemFontName` returns that family's bold face instead of the hardcoded one, and `defaultFixedPitchFontName` returns an enumerated fixed-pitch face instead of a fixed name; with `NSFont` unset the results are unchanged. The win32 change was built against the win32/winlib backend (MSYS2/ucrt64), where the backend compiles and links.

Together with #172 (the fontconfig enumerator) this covers the backends listed in the issue.

Closes #170.
