### PR TITLE
Fix: read back the correct region in the xlib backend

### DIFF
--- a/Source/xlib/XGGState.m
+++ b/Source/xlib/XGGState.m
@@ -1835,8 +1835,7 @@ NSDebugLLog(@"XGGraphics", @"Fill %@ X rect %d,%d,%d,%d",
 
   // --- determine region to read --------------------------------------
 
-  rect.origin = [ctm transformPoint: rect.origin];
-  srect = XGWindowRectToX(self, rect);
+  srect = XGViewRectToX(self, rect);
   srect = XGIntersectionRect (srect, accessibleRectForWindow (source_win));
   ssize.width = srect.width;
   ssize.height = srect.height;


### PR DESCRIPTION
`-[XGGState GSReadRect:]` transformed only the rectangle origin through the current transform and then flipped the whole rectangle again in `XGWindowRectToX`. For a view whose transform includes a flip this produced a read rectangle with a negative y origin, which no longer intersected the drawable. `GSReadRect:` then returned a dictionary without pixel data and `-[NSBitmapImageRep initWithFocusedViewRect:]` returned nil.

Convert the rectangle with `XGViewRectToX`, the same user space to X space conversion the drawing operations already use.

Verified on x11 + xlib under a virtual display: the gui rendering tests that read a view back into a bitmap (NSButton, NSForm, NSTableView, NSSlider, NSSplitView, NSTabView, NSTextField, NSViewController and others) go from returning a nil bitmap to passing.
