### PR TITLE
Fix: read back flipped views in the art backend

### DIFF
--- a/Source/art/ReadRect.m
+++ b/Source/art/ReadRect.m
@@ -45,7 +45,7 @@
   NSMutableDictionary *md = [[NSMutableDictionary alloc] init];
   NSAffineTransform *matrix;
 
-  int x0, y0, x1, y1, w, h, ox, oy;
+  int x0, y0, x1, y1, w, h;
   NSPoint p;
 
   /* Get the bounding rect in pixel coordinates. */
@@ -97,9 +97,6 @@
   matrix=[ctm copy];
   [matrix translateXBy: -x0 yBy: -y0];
 
-  ox = [matrix transformPoint: NSMakePoint(0, 0)].x - offset.x;
-  oy = offset.y - [matrix transformPoint: NSMakePoint(0, 0)].y;
-
   [md setObject: NSDeviceRGBColorSpace  forKey: @"ColorSpace"];
   [md setObject: [NSNumber numberWithUnsignedInt: 1]  forKey: @"HasAlpha"];
   [md setObject: [NSNumber numberWithUnsignedInt: 8]  forKey: @"BitsPerSample"];
@@ -121,8 +118,8 @@
 
     c.dst = [d mutableBytes];
 
-    c.src = wi->data + (oy - y1) * wi->bytes_per_line + (x0 + ox) * DI.bytes_per_pixel;
-    c.srca = wi->alpha + (oy - y1) * wi->sx + (x0 + ox);
+    c.src = wi->data + y0 * wi->bytes_per_line + x0 * DI.bytes_per_pixel;
+    c.srca = wi->alpha + y0 * wi->sx + x0;
 
     for (y = 0; y < h; y++)
       {


### PR DESCRIPTION
`-[ARTGState GSReadRect:]` located the source pixels in the window buffer through `ox`/`oy` derived from the current transform. For a view whose transform includes a flip these picked a row above the buffer (a negative source row), so the returned bitmap held out-of-bounds memory instead of the drawn content. Index the window buffer directly with the device space rectangle `(x0, y0)`, which is already clamped to the buffer bounds.

Same class of readback defect as #175 (xlib), in the art backend. Verified on x11 + art under a virtual display: a flipped view (e.g. NSTextField and any NSControl) goes from reading back garbage to the correct pixels; the gui rendering tests pass.
