### PR TITLE
Draw the context shadow in GSGState rather than in each backend

### DIFF
--- a/Headers/gsc/GSGState.h
+++ b/Headers/gsc/GSGState.h
@@ -94,6 +94,11 @@ typedef enum {
 - (void) setShadow: (NSShadow *)shadow;
 - (NSShadow *) shadow;
 
+/* Paints the current path with the current colour. Implemented by each
+   backend, which is what lets the shadow below be drawn here. */
+- (void) _paintPath: (ctxt_object_t)drawType;
+- (void) _drawShadowForOperation: (ctxt_object_t)drawType;
+
 - (void) compositeGState: (GSGState *)source
                 fromRect: (NSRect)aRect
                  toPoint: (NSPoint)aPoint

--- a/Source/art/path.m
+++ b/Source/art/path.m
@@ -30,9 +30,6 @@ Path handling.
 
 #include <AppKit/NSAffineTransform.h>
 #include <AppKit/NSBezierPath.h>
-#include <AppKit/NSColor.h>
-#include <AppKit/NSGraphics.h>
-#include <AppKit/NSShadow.h>
 
 #include "ARTGState.h"
 
@@ -45,7 +42,7 @@ Path handling.
 #include <libart_lgpl/libart.h>
 #include <libart_lgpl/art_svp_intersect.h>
 
-@interface ARTGState (ShadowRendering)
+@interface ARTGState (PathPainting)
 - (void) _stroke: (ArtVpath *)vp;
 @end
 
@@ -956,57 +953,38 @@ static void clip_svp_callback(void *data, int y, int start,
   UPDATE_UNBUFFERED
 }
 
-/* Renders the current path offset by the active shadow, in the shadow colour,
-   as a plain (unblurred) shadow, before the path itself is drawn.  The shadow
-   parameters live on the shared GSGState. */
-- (void) _drawShadowForOperation: (ctxt_object_t)drawType
+- (void) _paintPath: (ctxt_object_t)drawType
 {
-  NSColor *shadowColor;
-  NSBezierPath *savedPath, *shadowPath;
-  NSAffineTransform *xform;
-  device_color_t savedColor, dc;
-  NSSize soffset;
-  CGFloat r, g, b, a;
-  BOOL isStroke = (drawType == path_stroke);
-  color_state_t cs = isStroke ? COLOR_STROKE : COLOR_FILL;
-
-  if (_shadow == nil || path == nil || [path isEmpty])
-    return;
-
-  shadowColor = [[_shadow shadowColor]
-    colorUsingColorSpaceName: NSDeviceRGBColorSpace];
-  if (shadowColor == nil)
-    return;
-  [shadowColor getRed: &r green: &g blue: &b alpha: &a];
-
-  soffset = [_shadow shadowOffset];
-  savedPath = path;
-  shadowPath = [path copy];
-  xform = [NSAffineTransform transform];
-  [xform translateXBy: soffset.width yBy: soffset.height];
-  [shadowPath transformUsingAffineTransform: xform];
-
-  savedColor = isStroke ? strokeColor : fillColor;
-  gsMakeColor(&dc, rgb_colorspace, r, g, b, 0);
-  dc.field[AINDEX] = a;
-
-  path = shadowPath;
-  [self setColor: &dc state: cs];
-  if (isStroke)
+  switch (drawType)
     {
-      ArtVpath *vp = [self _vpath_from_current_path: NO];
+      case path_eofill:
+        [self _fill: ART_WIND_RULE_ODDEVEN];
+        break;
+      case path_fill:
+        [self _fill: ART_WIND_RULE_NONZERO];
+        break;
+      case path_stroke:
+        {
+          ArtVpath *vp;
 
-      if (vp)
-        [self _stroke: vp];
+          if (!wi || !wi->data) return;
+          if (all_clipped) return;
+          if (!stroke_color[3]) return;
+
+          /* TODO: this is wrong. we should transform _after_ we dash and
+             stroke */
+          vp = [self _vpath_from_current_path: NO];
+          if (!vp)
+            return;
+
+          [self _stroke: vp];
+
+          [path removeAllPoints];
+          break;
+        }
+      default:
+        break;
     }
-  else
-    {
-      [self _fill: (drawType == path_eofill)
-        ? ART_WIND_RULE_ODDEVEN : ART_WIND_RULE_NONZERO];
-    }
-  [self setColor: &savedColor state: cs];
-  path = savedPath;
-  RELEASE(shadowPath);
 }
 
 - (void) DPSeofill
@@ -1018,7 +996,7 @@ static void clip_svp_callback(void *data, int y, int start,
     }
 
   [self _drawShadowForOperation: path_eofill];
-  [self _fill: ART_WIND_RULE_ODDEVEN];
+  [self _paintPath: path_eofill];
 }
 
 - (void) DPSfill
@@ -1030,7 +1008,7 @@ static void clip_svp_callback(void *data, int y, int start,
     }
 
   [self _drawShadowForOperation: path_fill];
-  [self _fill: ART_WIND_RULE_NONZERO];
+  [self _paintPath: path_fill];
 }
 
 - (void) DPSrectfill: (CGFloat)x : (CGFloat)y : (CGFloat)w : (CGFloat)h
@@ -1436,23 +1414,8 @@ Currently, a single scale value is applied to dashing and stroking. This
 will give correct results as long as both axises are scaled the same.
 
 */
-  ArtVpath *vp;
-
-  if (!wi || !wi->data) return;
-  if (all_clipped) return;
-  if (!stroke_color[3]) return;
-
   [self _drawShadowForOperation: path_stroke];
-
-  /* TODO: this is wrong. we should transform _after_ we dash and
-     stroke */
-  vp = [self _vpath_from_current_path: NO];
-  if (!vp)
-    return;
-
-  [self _stroke: vp];
-
-  [path removeAllPoints];
+  [self _paintPath: path_stroke];
 }
 
 @end

--- a/Source/cairo/CairoGState.m
+++ b/Source/cairo/CairoGState.m
@@ -783,12 +783,63 @@ appendBezierToCairo(cairo_t *ct, NSBezierPath *bpath)
     }
 }
 
+- (void) _paintPath: (ctxt_object_t)drawType
+{
+  device_color_t c;
+
+  if (_ct == NULL)
+    return;
+
+  c = (drawType == path_stroke) ? strokeColor : fillColor;
+  gsColorToRGB(&c);
+  // The underlying concept does not allow to determine if alpha is set or not.
+  cairo_set_source_rgba(_ct, c.field[0], c.field[1], c.field[2], c.field[AINDEX]);
+  [self _setPath];
+
+  switch (drawType)
+    {
+      case path_eofill:
+        cairo_set_fill_rule(_ct, CAIRO_FILL_RULE_EVEN_ODD);
+        cairo_fill(_ct);
+        cairo_set_fill_rule(_ct, CAIRO_FILL_RULE_WINDING);
+        break;
+      case path_fill:
+        cairo_fill(_ct);
+        break;
+      case path_stroke:
+        {
+          BOOL zeroLineWidth = NO;
+
+          // If the line width is 0, draw a thin line.
+          // cairo (and Quartz) will draw nothing with a line width of 0.
+          // See the PostScript Language Reference, 3rd ed, p. 674
+          if (cairo_get_line_width(_ct) == 0)
+            {
+              double w1 = 1.0;
+              double w2 = 1.0;
+
+              cairo_device_to_user_distance(_ct, &w1, &w2);
+              cairo_set_line_width(_ct, w1);
+              zeroLineWidth = YES;
+            }
+
+          cairo_stroke(_ct);
+
+          if (zeroLineWidth)
+            {
+              cairo_set_line_width(_ct, 0);
+            }
+          break;
+        }
+      default:
+        break;
+    }
+}
+
 - (void) DPSeofill
 {
   if (_ct)
     {
-      device_color_t c;
-
       if (pattern != nil)
         {
           [self eofillPath: path withPattern: pattern];
@@ -796,69 +847,15 @@ appendBezierToCairo(cairo_t *ct, NSBezierPath *bpath)
         }
 
       [self _drawShadowForOperation: path_eofill];
-
-      c = fillColor;
-      gsColorToRGB(&c);
-      // The underlying concept does not allow to determine if alpha is set or not.
-      cairo_set_source_rgba(_ct, c.field[0], c.field[1], c.field[2], c.field[AINDEX]);
-      [self _setPath];
-      cairo_set_fill_rule(_ct, CAIRO_FILL_RULE_EVEN_ODD);
-      cairo_fill(_ct);
-      cairo_set_fill_rule(_ct, CAIRO_FILL_RULE_WINDING);
+      [self _paintPath: path_eofill];
     }
   [self DPSnewpath];
-}
-
-/* Renders the current path offset by the active shadow, in the shadow colour,
-   as a plain (unblurred) shadow.  The shadow parameters live on the shared
-   GSGState so that any backend can render a shadow the same way; blur is not
-   yet applied. */
-- (void) _drawShadowForOperation: (ctxt_object_t)drawType
-{
-  NSColor *shadowColor;
-  NSSize soffset;
-  CGFloat r, g, b, a;
-
-  if (_shadow == nil || _ct == NULL)
-    return;
-
-  shadowColor = [[_shadow shadowColor]
-    colorUsingColorSpaceName: NSDeviceRGBColorSpace];
-  if (shadowColor == nil)
-    return;
-  [shadowColor getRed: &r green: &g blue: &b alpha: &a];
-
-  soffset = [_shadow shadowOffset];
-
-  cairo_save(_ct);
-  /* The offset is expressed in the current user space, which is what the path
-     is built in, so translate by it directly. */
-  cairo_translate(_ct, soffset.width, soffset.height);
-  cairo_set_source_rgba(_ct, r, g, b, a);
-  [self _setPath];
-  switch (drawType)
-    {
-      case path_eofill:
-        cairo_set_fill_rule(_ct, CAIRO_FILL_RULE_EVEN_ODD);
-        /* fall through */
-      case path_fill:
-        cairo_fill(_ct);
-        break;
-      case path_stroke:
-        cairo_stroke(_ct);
-        break;
-      default:
-        break;
-    }
-  cairo_restore(_ct);
 }
 
 - (void) DPSfill
 {
   if (_ct)
     {
-      device_color_t c;
-
       if (pattern != nil)
         {
           [self fillPath: path withPattern: pattern];
@@ -866,13 +863,7 @@ appendBezierToCairo(cairo_t *ct, NSBezierPath *bpath)
         }
 
       [self _drawShadowForOperation: path_fill];
-
-      c = fillColor;
-      gsColorToRGB(&c);
-      // The underlying concept does not allow to determine if alpha is set or not.
-      cairo_set_source_rgba(_ct, c.field[0], c.field[1], c.field[2], c.field[AINDEX]);
-      [self _setPath];
-      cairo_fill(_ct);
+      [self _paintPath: path_fill];
     }
   [self DPSnewpath];
 }
@@ -890,35 +881,8 @@ appendBezierToCairo(cairo_t *ct, NSBezierPath *bpath)
 {
   if (_ct)
     {
-      BOOL zeroLineWidth = NO;
-      device_color_t c;
-
       [self _drawShadowForOperation: path_stroke];
-
-      c = strokeColor;
-      gsColorToRGB(&c);
-      // The underlying concept does not allow to determine if alpha is set or not.
-      cairo_set_source_rgba(_ct, c.field[0], c.field[1], c.field[2], c.field[AINDEX]);
-      [self _setPath];
-
-      // If the line width is 0, draw a thin line.
-      // cairo (and Quartz) will draw nothing with a line width of 0.
-      // See the PostScript Language Reference, 3rd ed, p. 674
-      if (cairo_get_line_width(_ct) == 0)
-	{
-	  double w1 = 1.0;
-	  double w2 = 1.0;
-	  cairo_device_to_user_distance(_ct, &w1, &w2);
-	  cairo_set_line_width(_ct, w1);
-	  zeroLineWidth = YES;
-	}
-
-      cairo_stroke(_ct);
-
-      if (zeroLineWidth)
-	{
-	  cairo_set_line_width(_ct, 0);
-	}
+      [self _paintPath: path_stroke];
     }
   [self DPSnewpath];
 }

--- a/Source/gsc/GSGState.m
+++ b/Source/gsc/GSGState.m
@@ -33,6 +33,7 @@
 #import <AppKit/NSColor.h>
 #import <AppKit/NSColorSpace.h>
 #import <AppKit/NSImage.h>
+#import <AppKit/NSShadow.h>
 #import <GNUstepGUI/GSFontInfo.h>
 #import <AppKit/NSGraphics.h>
 #import "gsc/GSContext.h"
@@ -188,6 +189,52 @@
 - (NSShadow *) shadow
 {
   return _shadow;
+}
+
+- (void) _paintPath: (ctxt_object_t)drawType
+{
+  [self subclassResponsibility: _cmd];
+}
+
+/* Renders the current path offset by the active shadow, in the shadow colour,
+   as a plain (unblurred) shadow, before the path itself is drawn. Blur is not
+   applied. */
+- (void) _drawShadowForOperation: (ctxt_object_t)drawType
+{
+  NSColor *shadowColor;
+  NSBezierPath *savedPath, *shadowPath;
+  NSAffineTransform *xform;
+  device_color_t savedColor, dc;
+  NSSize soffset;
+  CGFloat r, g, b, a;
+  color_state_t cs = (drawType == path_stroke) ? COLOR_STROKE : COLOR_FILL;
+
+  if (_shadow == nil || path == nil || [path isEmpty])
+    return;
+
+  shadowColor = [[_shadow shadowColor]
+    colorUsingColorSpaceName: NSDeviceRGBColorSpace];
+  if (shadowColor == nil)
+    return;
+  [shadowColor getRed: &r green: &g blue: &b alpha: &a];
+
+  soffset = [_shadow shadowOffset];
+  savedPath = path;
+  shadowPath = [path copy];
+  xform = [NSAffineTransform transform];
+  [xform translateXBy: soffset.width yBy: soffset.height];
+  [shadowPath transformUsingAffineTransform: xform];
+
+  savedColor = (cs == COLOR_STROKE) ? strokeColor : fillColor;
+  gsMakeColor(&dc, rgb_colorspace, r, g, b, 0);
+  dc.field[AINDEX] = a;
+
+  path = shadowPath;
+  [self setColor: &dc state: cs];
+  [self _paintPath: drawType];
+  [self setColor: &savedColor state: cs];
+  path = savedPath;
+  RELEASE(shadowPath);
 }
 
 // This is only a fall back, the method should not be called any more.

--- a/Source/winlib/WIN32GState.m
+++ b/Source/winlib/WIN32GState.m
@@ -46,7 +46,6 @@
 #import <AppKit/NSAffineTransform.h>
 #import <AppKit/NSBezierPath.h>
 #import <AppKit/NSColor.h>
-#import <AppKit/NSShadow.h>
 #import <AppKit/NSFont.h>
 #import <AppKit/NSGraphics.h>
 
@@ -1164,47 +1163,6 @@ HBITMAP GSCreateBitmap(HDC hDC, NSInteger pixelsWide, NSInteger pixelsHigh,
 - (void)DPSeoclip 
 {
   [self _paintPath: path_eoclip];
-}
-
-/* Renders the current path offset by the active shadow, in the shadow colour,
-   as a plain (unblurred) shadow, before the path itself is drawn.  The shadow
-   parameters live on the shared GSGState. */
-- (void) _drawShadowForOperation: (ctxt_object_t)drawType
-{
-  NSColor *shadowColor;
-  NSBezierPath *savedPath, *shadowPath;
-  NSAffineTransform *xform;
-  device_color_t savedColor, dc;
-  NSSize soffset;
-  CGFloat r, g, b, a;
-  color_state_t cs = (drawType == path_stroke) ? COLOR_STROKE : COLOR_FILL;
-
-  if (_shadow == nil || path == nil || [path isEmpty])
-    return;
-
-  shadowColor = [[_shadow shadowColor]
-    colorUsingColorSpaceName: NSDeviceRGBColorSpace];
-  if (shadowColor == nil)
-    return;
-  [shadowColor getRed: &r green: &g blue: &b alpha: &a];
-
-  soffset = [_shadow shadowOffset];
-  savedPath = path;
-  shadowPath = [path copy];
-  xform = [NSAffineTransform transform];
-  [xform translateXBy: soffset.width yBy: soffset.height];
-  [shadowPath transformUsingAffineTransform: xform];
-
-  savedColor = (cs == COLOR_STROKE) ? strokeColor : fillColor;
-  gsMakeColor(&dc, rgb_colorspace, r, g, b, 0);
-  dc.field[AINDEX] = a;
-
-  path = shadowPath;
-  [self setColor: &dc state: cs];
-  [self _paintPath: drawType];
-  [self setColor: &savedColor state: cs];
-  path = savedPath;
-  RELEASE(shadowPath);
 }
 
 - (void)DPSeofill

--- a/Source/xlib/XGGState.m
+++ b/Source/xlib/XGGState.m
@@ -33,10 +33,8 @@
 #import <Foundation/NSException.h>
 #import <AppKit/NSAffineTransform.h>
 #import <AppKit/NSBezierPath.h>
-#import <AppKit/NSColor.h>
 #import <AppKit/NSFont.h>
 #import <AppKit/NSGraphics.h>
-#import <AppKit/NSShadow.h>
 
 #import "xlib/XGGeometry.h"
 #import "xlib/XGContext.h"
@@ -74,7 +72,6 @@ xrRGBToPixel(RContext* context, device_color_t color)
 
 @interface XGGState (Private)
 - (void) _alphaBuffer: (gswindow_device_t *)dest_win;
-- (void) _paintPath: (ctxt_object_t) drawType;
 - (void) createGraphicContext;
 - (void) copyGraphicContext;
 - (void) setAlphaColor: (float)color;
@@ -1470,55 +1467,6 @@ static Region emptyRegion;
 - (void)DPSeoclip 
 {
   [self _paintPath: path_eoclip];
-}
-
-/* Renders the current path offset by the active shadow, in the shadow colour,
-   as a plain (unblurred) shadow, before the path itself is drawn.  The shadow
-   parameters live on the shared GSGState.  The colour state is invalidated so
-   that the following real paint reloads its own colour. */
-- (void) _drawShadowForOperation: (ctxt_object_t)drawType
-{
-  NSColor *shadowColor;
-  NSBezierPath *savedPath, *shadowPath;
-  NSAffineTransform *xform;
-  device_color_t savedColor, dc;
-  NSSize soffset;
-  CGFloat r, g, b, a;
-  color_state_t cs = (drawType == path_stroke) ? COLOR_STROKE : COLOR_FILL;
-
-  if (_shadow == nil || path == nil || [path isEmpty])
-    return;
-
-  shadowColor = [[_shadow shadowColor]
-    colorUsingColorSpaceName: NSDeviceRGBColorSpace];
-  if (shadowColor == nil)
-    return;
-  [shadowColor getRed: &r green: &g blue: &b alpha: &a];
-
-  soffset = [_shadow shadowOffset];
-  savedPath = path;
-  shadowPath = [path copy];
-  xform = [NSAffineTransform transform];
-  [xform translateXBy: soffset.width yBy: soffset.height];
-  [shadowPath transformUsingAffineTransform: xform];
-
-  savedColor = (cs == COLOR_STROKE) ? strokeColor : fillColor;
-  gsMakeColor(&dc, rgb_colorspace, r, g, b, 0);
-  dc.field[AINDEX] = a;
-
-  path = shadowPath;
-  [self setColor: &dc state: cs];
-  [self _paintPath: drawType];
-  path = savedPath;
-  RELEASE(shadowPath);
-
-  /* Setting the shadow colour overwrote the fill or stroke colour ivar; put it
-     back and invalidate the loaded colour so the real paint reloads it. */
-  if (cs == COLOR_STROKE)
-    strokeColor = savedColor;
-  else
-    fillColor = savedColor;
-  cstate &= ~cs;
 }
 
 - (void)DPSeofill


### PR DESCRIPTION
Follows the suggestion on #168: with a -_paintPath: in every backend, the shadow drawing itself belongs in GSGState.

Each raster backend had its own copy of the same shadow rendering, differing only in how it painted the path. GSGState now does it once and calls -_paintPath: for the painting. xlib and winlib already had that method. cairo and art gain one, and their fill, even-odd fill and stroke now go through it too, which is where the rest of the removed lines come from. Net 252 lines out, 137 in.

Checked on each backend, drawing a shape with a coloured shadow at a known offset and reading the pixels back:

    x11 + cairo      Tests/cairo/dropshadow.m, 8 assertions, all pass
    x11 + art        same test, 8 assertions, all pass
    x11 + xlib       the test guards itself off here, so the same drawing was
                     run by hand against a live X server: 8 checks, all pass
    wayland + cairo  same, run under a live compositor: 8 checks, all pass
    win32 + winlib   built and run on Windows: 8 checks, all pass
    headless, opal   build clean
    xdps             not buildable here, it wants pswrap

winlib needed #180, #181, #182 and #183 before it could be checked at all: its offscreen read came back upside down, its strokes took the fill colour, compositing painted a fixed grey, and glyph bounds were empty. With those four, Tests/winlib goes from 8 failing assertions to none and the shadow drawing passes there as well. This change gives winlib the same results before and after either way.
