### PR TITLE
winlib: read back the pixels that were asked for

### DIFF
--- a/Source/winlib/WIN32GState.m
+++ b/Source/winlib/WIN32GState.m
@@ -1574,6 +1574,7 @@ HBITMAP GSCreateBitmap(HDC hDC, NSInteger pixelsWide, NSInteger pixelsHigh,
   unsigned char *cdata;
   unsigned char *bits;
   int i = 0;
+  LONG row, stride;
   HDC hDC;
   HDC hdcMemDC = NULL;
   HBITMAP hbitmap = NULL;
@@ -1660,11 +1661,11 @@ HBITMAP GSCreateBitmap(HDC hDC, NSInteger pixelsWide, NSInteger pixelsHigh,
     }
 
   // Bit block transfer into our compatible memory DC.
-  if (!BitBlt(hdcMemDC, 0, 0, 
-    rcClient.right - rcClient.left, 
-    rcClient.bottom - rcClient.top, 
-    hDC, 
-    0, 0,
+  if (!BitBlt(hdcMemDC, 0, 0,
+    rcClient.right - rcClient.left,
+    rcClient.bottom - rcClient.top,
+    hDC,
+    rcClient.left, rcClient.top,
     SRCCOPY))
     {
       NSLog(@"BitBlt failed for window %d in GSReadRect. Error %d", 
@@ -1725,15 +1726,23 @@ HBITMAP GSCreateBitmap(HDC hDC, NSInteger pixelsWide, NSInteger pixelsHigh,
       return nil;
     }
 
-  // Copy to data
+  /* Copy to data.  GetDIBits hands back the rows bottom up, while the
+     bitmap wanted here starts with the top row, so they are taken in
+     reverse. */
   cdata = [data mutableBytes];
-  while (i < dwBmpSize)
+  stride = bmpCopied.bmWidth * 4;
+  for (row = 0; row < bmpCopied.bmHeight; row++)
     {
-      cdata[i+0] = bits[i+2];
-      cdata[i+1] = bits[i+1];
-      cdata[i+2] = bits[i+0];
-      cdata[i+3] = bits[i+3];
-      i += 4;
+      unsigned char *src = bits + (bmpCopied.bmHeight - 1 - row) * stride;
+      unsigned char *dst = cdata + row * stride;
+
+      for (i = 0; i < stride; i += 4)
+        {
+          dst[i+0] = src[i+2];
+          dst[i+1] = src[i+1];
+          dst[i+2] = src[i+0];
+          dst[i+3] = src[i+3];
+        }
     }
 
 

--- a/Tests/winlib/winlibreadrect.m
+++ b/Tests/winlib/winlibreadrect.m
@@ -1,0 +1,113 @@
+/* Read back tests for the winlib graphics backend: the rows of a read come
+ * back with the top of the drawing first, and reading part of a drawing gives
+ * that part rather than whatever is at the top of it.  This exercises
+ * WIN32GState's -GSReadRect:, which is what -initWithFocusedViewRect: goes
+ * through.
+ *
+ * It guards on the winlib graphics backend and skips when the backend cannot be
+ * reached; colours are checked with a small tolerance.
+ */
+#import <Foundation/Foundation.h>
+#import "Testing.h"
+#include "config.h"
+
+#if defined(BUILD_GRAPHICS) && defined(GRAPHICS_winlib) \
+  && BUILD_GRAPHICS == GRAPHICS_winlib
+
+#import <AppKit/AppKit.h>
+#include <stdlib.h>
+
+static BOOL
+pixelIs(NSBitmapImageRep *rep, int x, int y, int r, int g, int b)
+{
+  unsigned char *d = [rep bitmapData];
+  long bpr = [rep bytesPerRow];
+  long spp = [rep samplesPerPixel];
+  unsigned char *px = d + y * bpr + x * spp;
+
+  return (abs((int)px[0] - r) <= 2
+	  && abs((int)px[1] - g) <= 2
+	  && abs((int)px[2] - b) <= 2);
+}
+
+int
+main(void)
+{
+  START_SET("winlib read back")
+  ENTER_POOL
+
+  BOOL haveApp = NO;
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+      haveApp = YES;
+    }
+  NS_HANDLER
+    {
+      haveApp = NO;
+    }
+  NS_ENDHANDLER
+
+  if (haveApp == NO)
+    {
+      SKIP("no win32 gui available")
+    }
+  else
+    {
+      NSImage          *img;
+      NSBitmapImageRep *whole;
+      NSBitmapImageRep *part;
+      int               w = 40, h = 40;
+
+      /* White, with a red band along the bottom and a blue one along the top.
+       * A read of the whole drawing starts with its top row, so the blue band
+       * comes first and the red one last. */
+      img = [[NSImage alloc] initWithSize: NSMakeSize(w, h)];
+      [img lockFocus];
+      [[NSColor colorWithDeviceRed: 1 green: 1 blue: 1 alpha: 1] set];
+      NSRectFill(NSMakeRect(0, 0, w, h));
+      [[NSColor colorWithDeviceRed: 1 green: 0 blue: 0 alpha: 1] set];
+      NSRectFill(NSMakeRect(0, 0, w, 10));
+      [[NSColor colorWithDeviceRed: 0 green: 0 blue: 1 alpha: 1] set];
+      NSRectFill(NSMakeRect(0, h - 10, w, 10));
+      [[NSGraphicsContext currentContext] flushGraphics];
+      whole = [[NSBitmapImageRep alloc]
+		initWithFocusedViewRect: NSMakeRect(0, 0, w, h)];
+      part = [[NSBitmapImageRep alloc]
+	       initWithFocusedViewRect: NSMakeRect(0, 10, w, 10)];
+      [img unlockFocus];
+      [img release];
+      [whole autorelease];
+      [part autorelease];
+
+      PASS(whole != nil && pixelIs(whole, w / 2, 2, 0, 0, 255),
+	"a read starts with the top of the drawing")
+      PASS(whole != nil && pixelIs(whole, w / 2, h - 3, 255, 0, 0),
+	"a read ends with the bottom of the drawing")
+      PASS(whole != nil && pixelIs(whole, w / 2, h / 2, 255, 255, 255),
+	"what lies between the two comes back between them")
+      PASS(part != nil && [part pixelsHigh] == 10,
+	"reading part of a drawing gives a bitmap of that size")
+      PASS(part != nil && pixelIs(part, w / 2, 5, 255, 255, 255),
+	"reading part of a drawing gives that part, not the top of it")
+    }
+
+  LEAVE_POOL
+  END_SET("winlib read back")
+
+  return 0;
+}
+
+#else
+
+int
+main(void)
+{
+  START_SET("winlib read back")
+    SKIP("back is not built with the winlib graphics backend")
+  END_SET("winlib read back")
+  return 0;
+}
+
+#endif


### PR DESCRIPTION
-GSReadRect: on winlib returned the wrong pixels in two ways.

The rows were copied in the order GetDIBits hands them back, which is bottom up, while the caller wants the top row first, so anything read back through -initWithFocusedViewRect: came out upside down. And the BitBlt took its source from the window origin rather than from the rectangle it was given, so reading part of a drawing returned whatever sat at the top of the window instead.

Tests/winlib/winlibreadrect.m covers both, drawing a red band along the bottom and a blue one along the top and then reading the whole thing and a slice of the middle. 3 of its 5 assertions fail without the change.

Built and run on Windows, win32 + winlib. Tests/winlib goes from 8 failing assertions to 4: the row order was also what failed winlibcapsjoins, winlibimage, winlibimagerotate and winlibrender. The 4 that still fail, one in win32fontmetrics and three in winlibcomposite, fail the same way before and after and are a separate matter.

Found while checking #179 on winlib, where an offscreen pixel check could not be trusted until this was sorted out.
