### PR TITLE
winlib: stroke in the stroke colour

### DIFF
--- a/Source/winlib/WIN32GState.m
+++ b/Source/winlib/WIN32GState.m
@@ -1374,12 +1374,11 @@ HBITMAP GSCreateBitmap(HDC hDC, NSInteger pixelsWide, NSInteger pixelsHigh,
   NSInteger patternCount = 0;
   
   SetBkMode(hDC, TRANSPARENT);
+  /* The pen built from this below draws the stroke, so it takes the stroke
+     colour; the brush that fills takes the fill colour. */
   br.lbStyle = BS_SOLID;
-  br.lbColor = wfcolor;
+  br.lbColor = wscolor;
   br.lbHatch = 0;
-  /*
-  brush = CreateBrushIndirect(&br);
-  */
   brush = CreateSolidBrush(wfcolor);
   oldBrush = SelectObject(hDC, brush);
 

--- a/Tests/winlib/winlibstroke.m
+++ b/Tests/winlib/winlibstroke.m
@@ -119,6 +119,35 @@ main(void)
 	"the first dash of a dashed stroke paints black")
       PASS(rep != nil && pixelIs(rep, 12, h / 2, 255, 255, 255),
 	"the gap after the first dash stays white")
+
+      /* A stroke takes the stroke colour even when the fill colour differs. */
+      img = beginImage(w, h);
+      [[NSColor colorWithDeviceRed: 1 green: 1 blue: 1 alpha: 1] set];
+      NSRectFill(NSMakeRect(0, 0, w, h));
+      [[NSColor colorWithDeviceRed: 0 green: 1 blue: 0 alpha: 1] setFill];
+      [[NSColor colorWithDeviceRed: 0 green: 0 blue: 1 alpha: 1] setStroke];
+      {
+	NSBezierPath *p = [NSBezierPath bezierPath];
+
+	[p setLineWidth: 6.0];
+	[p moveToPoint: NSMakePoint(0, h / 2)];
+	[p lineToPoint: NSMakePoint(w, h / 2)];
+	[p stroke];
+      }
+      rep = endImage(img, w, h);
+      PASS(rep != nil && pixelIs(rep, w / 2, h / 2, 0, 0, 255),
+	"a stroke paints in the stroke colour, not the fill colour")
+
+      /* And a fill still takes the fill colour. */
+      img = beginImage(w, h);
+      [[NSColor colorWithDeviceRed: 1 green: 1 blue: 1 alpha: 1] set];
+      NSRectFill(NSMakeRect(0, 0, w, h));
+      [[NSColor colorWithDeviceRed: 0 green: 1 blue: 0 alpha: 1] setFill];
+      [[NSColor colorWithDeviceRed: 0 green: 0 blue: 1 alpha: 1] setStroke];
+      [[NSBezierPath bezierPathWithRect: NSMakeRect(10, 10, 20, 20)] fill];
+      rep = endImage(img, w, h);
+      PASS(rep != nil && pixelIs(rep, w / 2, h / 2, 0, 255, 0),
+	"a fill paints in the fill colour")
     }
 
   LEAVE_POOL


### PR DESCRIPTION
The pen -setStyle: builds comes from a LOGBRUSH holding wfcolor, the fill colour, so on winlib a stroke paints in whatever colour was last filled with rather than the stroke colour. It stays hidden most of the time because -set sets both colours together; it shows as soon as they differ, as -setStroke: and the drop shadow in #168 both do.

Tests/winlib/winlibstroke.m now sets the fill green and the stroke blue and checks that a stroke paints blue and a fill paints green. The stroke assertion fails without this change.

The commented-out CreateBrushIndirect line next to it is removed, since with the LOGBRUSH now holding the stroke colour it would read as building the fill brush from the wrong one.
