### PR TITLE
winlib: report a real bounding box for a glyph

### DIFF
--- a/Source/winlib/WIN32FontInfo.m
+++ b/Source/winlib/WIN32FontInfo.m
@@ -127,6 +127,8 @@ NSString *win32_font_family(NSString *fontName);
   HFONT old;
   GLYPHMETRICS gm;
   NSRect rect;
+  /* GetGlyphOutline takes no null transform, so hand it the identity one. */
+  static const MAT2 identity = {{0, 1}, {0, 0}, {0, 0}, {0, 1}};
 
   hdc = CreateCompatibleDC(NULL);
   old = SelectObject(hdc, hFont);
@@ -138,13 +140,13 @@ NSString *win32_font_family(NSString *fontName);
 NSLog(@"No glyph for U%d", c);
       return NSMakeRect(0, 0, 0, 0);	// No such glyph
     }
-  if (GDI_ERROR != GetGlyphOutlineW(hdc, windowsGlyph, 
-				   GGO_METRICS, // || GGO_GLYPH_INDEX
-				   &gm, 0, NULL, NULL))
+  if (GDI_ERROR != GetGlyphOutlineW(hdc, windowsGlyph,
+				   GGO_METRICS | GGO_GLYPH_INDEX,
+				   &gm, 0, NULL, &identity))
     {
-      rect = NSMakeRect(gm.gmptGlyphOrigin.x, 
+      rect = NSMakeRect(gm.gmptGlyphOrigin.x,
 			gm.gmptGlyphOrigin.y - gm.gmBlackBoxY,
-			gm.gmCellIncX, gm.gmCellIncY);
+			gm.gmBlackBoxX, gm.gmBlackBoxY);
     }
   else
     {


### PR DESCRIPTION
-boundingRectForGlyph: on winlib always returned an empty rect.

GetGlyphOutline takes no null transformation matrix, and it was given one, so every call returned GDI_ERROR and the method fell through to NSZeroRect. Two smaller things went with it: the glyph index was passed without GGO_GLYPH_INDEX, which asks GDI to read it as a character code instead, and the size of the rect came from the cell increment rather than the black box, and the vertical part of the cell increment is zero for horizontal text.

With the identity matrix in place, 14pt Tahoma gives 13 by 11 for a W, 1 by 11 for an i and 1 by 2 for a period sitting 2 to the right of the origin; 28pt gives 28 by 23 for the W.

The assertion covering this in Tests/winlib/win32fontmetrics.m fails on master and passes with this. Built and run on Windows, win32 + winlib; nothing else in Tests/winlib changes.
