### PR TITLE
Fix: do not flush a context that has no window server

### DIFF
--- a/Source/cairo/CairoContext.m
+++ b/Source/cairo/CairoContext.m
@@ -143,7 +143,11 @@
   // FIXME:  Anyone know how this can be handled/fixed correctly...
   
 #if BUILD_SERVER == SERVER_x11
-  XFlush([(XGServer *)server xDisplay]);
+  /* A context drawing somewhere other than a window has no server to flush. */
+  if (server != nil)
+    {
+      XFlush([(XGServer *)server xDisplay]);
+    }
 #elif BUILD_SERVER == SERVER_win32
   CairoSurface *surface = nil;
 

--- a/Tests/cairo/bitmapcontextflush.m
+++ b/Tests/cairo/bitmapcontextflush.m
@@ -1,0 +1,71 @@
+/* A graphics context whose destination is an NSBitmapImageRep is not attached
+ * to a window, so it has no window server behind it.  Flushing such a context
+ * has to be harmless: the x11 flush reaches for the server of the context, and
+ * with no window there is nothing to ask.
+ *
+ * It needs a running window server to create the context at all, so it skips
+ * cleanly when there is none, and guards on the cairo graphics backend.
+ */
+#import <Foundation/NSObject.h>
+#import "Testing.h"
+#include "config.h"
+
+#if defined(BUILD_GRAPHICS) && defined(GRAPHICS_cairo) \
+  && BUILD_GRAPHICS == GRAPHICS_cairo
+
+#import <AppKit/AppKit.h>
+#include <stdlib.h>
+
+int
+main(int argc, const char **argv)
+{
+  CREATE_AUTORELEASE_POOL(pool);
+  NSBitmapImageRep *rep;
+  NSGraphicsContext *ctxt;
+
+  if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
+    {
+      NSLog(@"no window server available; skipping bitmap context flush test");
+      DESTROY(pool);
+      return 0;
+    }
+
+  [NSApplication sharedApplication];
+
+  rep = AUTORELEASE([[NSBitmapImageRep alloc]
+    initWithBitmapDataPlanes: NULL
+                  pixelsWide: 8
+                  pixelsHigh: 8
+               bitsPerSample: 8
+             samplesPerPixel: 4
+                    hasAlpha: YES
+                    isPlanar: NO
+              colorSpaceName: NSDeviceRGBColorSpace
+                 bytesPerRow: 0
+                bitsPerPixel: 0]);
+
+  ctxt = [NSGraphicsContext graphicsContextWithBitmapImageRep: rep];
+  PASS(ctxt != nil,
+       "a graphics context can be made for a bitmap representation");
+
+  [NSGraphicsContext saveGraphicsState];
+  [NSGraphicsContext setCurrentContext: ctxt];
+  [ctxt flushGraphics];
+  [NSGraphicsContext restoreGraphicsState];
+
+  PASS([NSGraphicsContext currentContext] != ctxt,
+       "flushing a bitmap context leaves the graphics state stack in step");
+
+  DESTROY(pool);
+  return 0;
+}
+
+#else
+
+int
+main(int argc, const char **argv)
+{
+  return 0;
+}
+
+#endif


### PR DESCRIPTION
A context from `+[NSGraphicsContext graphicsContextWithBitmapImageRep:]`
segfaults on its first flush. `-[CairoContext flushGraphics]` passes the server
of the context straight to `XFlush`, and `server` is only assigned in
`-[GSContext initWithContextInfo:]` when the destination attribute is a window,
so any other destination reaches `XFlush(NULL)`.

Do not flush when there is no server.

This only stops the crash. Drawing into such a context still produces nothing,
because the cairo backend has no surface class to attach to a bitmap
destination: every CairoSurface subclass is backed by a window or by a print
stream. That part is #184 and is not addressed here.

Tests/cairo/bitmapcontextflush.m aborted at the flush before, with 1 of its 2
assertions run, and both pass after. The cairo suite goes from 319 to 321
assertions with no failures, and the whole backend suite runs clean on
x11/cairo.

Refers to #184
