### PR TITLE
Fix: fail a win32 font lookup for a face that is not installed

### DIFF
--- a/Source/winlib/WIN32FontInfo.m
+++ b/Source/winlib/WIN32FontInfo.m
@@ -37,6 +37,49 @@
 int win32_font_weight(LONG tmWeight);
 NSString *win32_font_family(NSString *fontName);
 
+/* CreateFontIndirect() picks a face for whatever it is handed, including an
+   empty name, so a name has to be checked against the enumerated families
+   before a font is built for it. */
+static BOOL
+win32_font_available(NSString *fontName)
+{
+  GSFontEnumerator *enumerator;
+  NSString *family;
+  NSRange hyphen;
+
+  if ([fontName length] == 0)
+    {
+      return NO;
+    }
+
+  enumerator = [GSFontEnumerator sharedEnumerator];
+  if ([[enumerator availableFonts] containsObject: fontName])
+    {
+      return YES;
+    }
+
+  /* The enumerator builds "<family> Bold" and the like from the family, so
+     the family is what has to exist. */
+  family = win32_font_family(fontName);
+  if ([[enumerator availableFontFamilies] containsObject: family])
+    {
+      return YES;
+    }
+
+  /* NSFont builds hyphenated names of this shape when it replaces Helvetica. */
+  hyphen = [family rangeOfString: @"-" options: NSBackwardsSearch];
+  if (hyphen.length != 0)
+    {
+      family = [family substringToIndex: hyphen.location];
+      if ([[enumerator availableFontFamilies] containsObject: family])
+        {
+          return YES;
+        }
+    }
+
+  return NO;
+}
+
 @interface WIN32FontInfo (Private)
 - (BOOL) setupAttributes;
 @end
@@ -48,6 +91,12 @@ NSString *win32_font_family(NSString *fontName);
 	screenFont: (BOOL)screenFont
 {
   if (screenFont)
+    {
+      RELEASE(self);
+      return nil;
+    }
+
+  if (!win32_font_available(name))
     {
       RELEASE(self);
       return nil;

--- a/Tests/winlib/win32fontlookup.m
+++ b/Tests/winlib/win32fontlookup.m
@@ -1,0 +1,108 @@
+/* A font name the win32 GDI backend cannot resolve has to fail, so that
+ * -[NSFont fontWithName:size:] returns nil and its callers can fall back.
+ * GDI substitutes a face for any name, including an empty one, so the lookup
+ * has to be checked against the enumerated families.
+ *
+ * The checks are font independent: they use the first family the enumerator
+ * lists rather than naming a face.
+ *
+ * It guards on the winlib graphics backend and skips when the backend cannot
+ * be reached.
+ */
+#import <Foundation/Foundation.h>
+#import "Testing.h"
+#include "config.h"
+
+#if defined(BUILD_GRAPHICS) && defined(GRAPHICS_winlib) \
+  && BUILD_GRAPHICS == GRAPHICS_winlib
+
+#import <AppKit/AppKit.h>
+#import <GNUstepGUI/GSFontInfo.h>
+
+int
+main(void)
+{
+  START_SET("win32 font lookup")
+  ENTER_POOL
+
+  GSFontEnumerator *e = nil;
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+      e = [GSFontEnumerator sharedEnumerator];
+    }
+  NS_HANDLER
+    {
+      e = nil;
+    }
+  NS_ENDHANDLER
+
+  if (e == nil)
+    {
+      SKIP("no font backend available")
+    }
+  else
+    {
+      NSArray *families = [e availableFontFamilies];
+
+      /* A name that is not a face at all has no font. */
+      PASS([NSFont fontWithName: @"ThereIsNoSuchFaceInstalled" size: 12] == nil,
+        "an unknown font name has no font")
+
+      /* Nor has an empty one: this is what -[NSFont initWithCoder:] asks for
+         when a xib font element carries neither a name nor a metaFont. */
+      PASS([NSFont fontWithName: @"" size: 12] == nil,
+        "an empty font name has no font")
+
+      /* A font that does exist still resolves, and reports the name asked
+         for rather than whatever the device substituted. */
+      if ([families count] > 0)
+        {
+          NSString *family = [families objectAtIndex: 0];
+          NSFont *font = [NSFont fontWithName: family size: 12];
+          NSFont *bold;
+
+          PASS(font != nil, "a listed family resolves to a font")
+          PASS_EQUAL([font fontName], family,
+            "the font reports the name it was asked for")
+
+          /* The enumerator advertises "<family> Bold" for every family, so
+             that name has to resolve too. */
+          bold = [NSFont fontWithName:
+            [family stringByAppendingString: @" Bold"] size: 12];
+          PASS(bold != nil, "a styled member of a listed family resolves")
+
+          /* NSFont builds hyphenated names of this shape when it replaces
+             Helvetica, so they have to keep working. */
+          bold = [NSFont fontWithName:
+            [family stringByAppendingString: @"-Bold"] size: 12];
+          PASS(bold != nil, "a hyphenated style of a listed family resolves")
+        }
+
+      /* The standard roles are unaffected. */
+      {
+        NSFont *system = [NSFont systemFontOfSize: 12];
+
+        PASS(system != nil && [system fontName] != nil,
+          "the system font resolves and has a name")
+      }
+    }
+
+  LEAVE_POOL
+  END_SET("win32 font lookup")
+  return 0;
+}
+
+#else
+
+int
+main(void)
+{
+  START_SET("win32 font lookup")
+    SKIP("back is not built with the winlib graphics backend")
+  END_SET("win32 font lookup")
+  return 0;
+}
+
+#endif


### PR DESCRIPTION
CreateFontIndirect picks a face for whatever name it is handed, including an empty one, so -[WIN32FontInfo initWithFontName:matrix:screenFont:] built a font for any name at all and -[NSFont fontWithName:size:] never returned nil for a face that is not installed. Callers that depend on that lookup failing then keep the wrong font instead of falling back: -[NSFont initWithCoder:] substitutes the system font only when fontWithName: fails, so a xib font element carrying no name leaves a cell holding a font whose name is nil. Measured here, such a font reports advance 11.00 for M where the system font reports 10.00, and a string that should be 99 points wide measures 104. On a macOS 26 runner both a nil name and an unknown face return nil, as does the freetype build.

A name is now checked against the enumerated fonts and families first. Both the "<family> Bold" form the enumerator advertises and the hyphenated form NSFont builds when it replaces Helvetica are accepted, so those keep resolving.

Tests/winlib/win32fontlookup.m. Two assertions fail before the change and none after. The eight other failures in Tests/winlib are unrelated, identical before and after, and belong to #180 to #183.
