### PR TITLE
Fix: draw a gradient on every backend, not just cairo and opal

### DIFF
--- a/Source/gsc/GSGState.m
+++ b/Source/gsc/GSGState.m
@@ -25,6 +25,7 @@
 */
 
 #include "config.h"
+#import <Foundation/NSException.h>
 #import <Foundation/NSObjCRuntime.h>
 #import <Foundation/NSValue.h>
 #import <Foundation/NSDictionary.h>
@@ -32,6 +33,7 @@
 #import <AppKit/NSBezierPath.h>
 #import <AppKit/NSColor.h>
 #import <AppKit/NSColorSpace.h>
+#import <AppKit/NSGradient.h>
 #import <AppKit/NSImage.h>
 #import <GNUstepGUI/GSFontInfo.h>
 #import <AppKit/NSGraphics.h>
@@ -1416,14 +1418,206 @@ typedef enum {
 
 @implementation GSGState (NSGradient)
 
+/* A gradient is painted by interpolating its colours and filling a series
+ * of bands with the fill operation the backend already has, so that every
+ * backend draws one.  A backend whose drawing library takes a gradient
+ * directly overrides both methods.
+ */
+
+/* Bands are a device pixel apart, between these limits. */
+#define	GRADIENT_MIN_STEPS	2
+#define	GRADIENT_MAX_STEPS	256
+
+/* The caller clips before drawing, so a band reaches well past the area
+ * being painted rather than being measured against the clip.
+ */
+#define	GRADIENT_SPREAD(length)	((length) * 16.0 + 1024.0)
+
+- (int) _stepsForGradientFrom: (NSPoint)from to: (NSPoint)to
+{
+  NSPoint	a = [ctm transformPoint: from];
+  NSPoint	b = [ctm transformPoint: to];
+  CGFloat	dx = b.x - a.x;
+  CGFloat	dy = b.y - a.y;
+  int		steps = (int)ceil(sqrt(dx * dx + dy * dy));
+
+  if (steps < GRADIENT_MIN_STEPS)
+    {
+      steps = GRADIENT_MIN_STEPS;
+    }
+  if (steps > GRADIENT_MAX_STEPS)
+    {
+      steps = GRADIENT_MAX_STEPS;
+    }
+  return steps;
+}
+
+/* Set the fill colour to the gradient's colour at a location, and say
+ * whether it could be done.  A stop may hold a colour with no RGB
+ * components, a pattern for one, which the component accessors refuse.
+ */
+- (BOOL) _setColorFromGradient: (NSGradient*)gradient at: (CGFloat)location
+{
+  NSColor	*rgb = nil;
+
+  NS_DURING
+    {
+      NSColor	*color = [gradient interpolatedColorAtLocation: location];
+
+      if (nil != color)
+	{
+	  rgb = [color colorUsingColorSpaceName: NSDeviceRGBColorSpace];
+	  if (nil == rgb)
+	    {
+	      rgb = [color colorUsingColorSpaceName: NSCalibratedRGBColorSpace];
+	    }
+	}
+    }
+  NS_HANDLER
+    {
+      rgb = nil;
+    }
+  NS_ENDHANDLER
+
+  if (nil == rgb)
+    {
+      return NO;
+    }
+  [self DPSsetalpha: [rgb alphaComponent]];
+  [self DPSsetrgbcolor: [rgb redComponent]
+		      : [rgb greenComponent]
+		      : [rgb blueComponent]];
+  return YES;
+}
+
+- (void) _fillGradientQuad: (NSPoint*)corners
+{
+  NSBezierPath	*oldPath = path;
+
+  path = [[NSBezierPath alloc] init];
+  [path moveToPoint: corners[0]];
+  [path lineToPoint: corners[1]];
+  [path lineToPoint: corners[2]];
+  [path lineToPoint: corners[3]];
+  [path closePath];
+  [path transformUsingAffineTransform: ctm];
+  [self DPSfill];
+  RELEASE(path);
+  path = oldPath;
+}
+
+- (void) _fillGradientCircleAt: (NSPoint)center radius: (CGFloat)radius
+{
+  NSBezierPath	*oldPath = path;
+
+  path = [[NSBezierPath alloc] init];
+  [path appendBezierPathWithArcWithCenter: center
+				  radius: radius
+			      startAngle: 0.0
+				endAngle: 360.0];
+  [path closePath];
+  [path transformUsingAffineTransform: ctm];
+  [self DPSfill];
+  RELEASE(path);
+  path = oldPath;
+}
+
+- (void) _saveGradientColor: (device_color_t*)fill
+		     stroke: (device_color_t*)stroke
+		      state: (color_state_t*)state
+		    pattern: (NSImage**)image
+{
+  *fill = fillColor;
+  *stroke = strokeColor;
+  *state = cstate;
+  *image = RETAIN(pattern);
+}
+
+- (void) _restoreGradientColor: (device_color_t*)fill
+			stroke: (device_color_t*)stroke
+			 state: (color_state_t)state
+		       pattern: (NSImage*)image
+{
+  [self setColor: fill state: COLOR_FILL];
+  [self setColor: stroke state: COLOR_STROKE];
+  cstate = state;
+  if (nil != image)
+    {
+      [self GSSetPatterColor: image];
+    }
+  RELEASE(image);
+}
+
 - (void) drawGradient: (NSGradient*)gradient
            fromCenter: (NSPoint)startCenter
                radius: (CGFloat)startRadius
-             toCenter: (NSPoint)endCenter 
+             toCenter: (NSPoint)endCenter
                radius: (CGFloat)endRadius
               options: (NSUInteger)options
 {
-  [self subclassResponsibility: _cmd];
+  device_color_t	savedFill;
+  device_color_t	savedStroke;
+  color_state_t		savedState;
+  NSImage		*savedPattern;
+  CGFloat		dx = endCenter.x - startCenter.x;
+  CGFloat		dy = endCenter.y - startCenter.y;
+  CGFloat		span;
+  BOOL			outward = (endRadius >= startRadius) ? YES : NO;
+  int			steps;
+  int			i;
+
+  span = sqrt(dx * dx + dy * dy) + fabs(endRadius - startRadius);
+  if (span <= 0.0)
+    {
+      return;
+    }
+  [self _saveGradientColor: &savedFill
+		    stroke: &savedStroke
+		     state: &savedState
+		   pattern: &savedPattern];
+
+  steps = [self _stepsForGradientFrom: NSMakePoint(0.0, 0.0)
+				   to: NSMakePoint(span, 0.0)];
+
+  /* Anything past the outer circle takes the colour of that end. */
+  if (options & NSGradientDrawsAfterEndingLocation)
+    {
+      if (YES == [self _setColorFromGradient: gradient
+					  at: (YES == outward) ? 1.0 : 0.0])
+	{
+	  CGFloat	spread = GRADIENT_SPREAD(span);
+
+	  [self DPSrectfill: startCenter.x - spread : startCenter.y - spread
+			   : spread * 2.0 : spread * 2.0];
+	}
+    }
+
+  /* Paint the larger circles first so the smaller ones land on top. */
+  for (i = 0; i <= steps; i++)
+    {
+      CGFloat	t = (YES == outward)
+	? 1.0 - (CGFloat)i / (CGFloat)steps
+	: (CGFloat)i / (CGFloat)steps;
+      CGFloat	radius = startRadius + (endRadius - startRadius) * t;
+      NSPoint	center;
+
+      if (radius <= 0.0)
+	{
+	  continue;
+	}
+      if (NO == [self _setColorFromGradient: gradient at: t])
+	{
+	  continue;
+	}
+      center.x = startCenter.x + dx * t;
+      center.y = startCenter.y + dy * t;
+      [self _fillGradientCircleAt: center radius: radius];
+    }
+
+  [self _restoreGradientColor: &savedFill
+		       stroke: &savedStroke
+			state: savedState
+		      pattern: savedPattern];
 }
 
 - (void) drawGradient: (NSGradient*)gradient
@@ -1431,7 +1625,73 @@ typedef enum {
               toPoint: (NSPoint)endPoint
               options: (NSUInteger)options
 {
-  [self subclassResponsibility: _cmd];
+  device_color_t	savedFill;
+  device_color_t	savedStroke;
+  color_state_t		savedState;
+  NSImage		*savedPattern;
+  CGFloat		dx = endPoint.x - startPoint.x;
+  CGFloat		dy = endPoint.y - startPoint.y;
+  CGFloat		length = sqrt(dx * dx + dy * dy);
+  CGFloat		ux, uy, sx, sy, spread, overlap;
+  int			steps;
+  int			i;
+
+  if (length <= 0.0)
+    {
+      return;
+    }
+  [self _saveGradientColor: &savedFill
+		    stroke: &savedStroke
+		     state: &savedState
+		   pattern: &savedPattern];
+
+  steps = [self _stepsForGradientFrom: startPoint to: endPoint];
+  ux = dx / length;			/* along the gradient */
+  uy = dy / length;
+  spread = GRADIENT_SPREAD(length);
+  sx = -uy * spread;			/* across it */
+  sy = ux * spread;
+  /* Bands overlap by half their width so no seam is left between them.
+   * The next band is painted over the overlap, so the colours do not move.
+   */
+  overlap = 0.5 / (CGFloat)steps;
+
+  for (i = 0; i < steps; i++)
+    {
+      CGFloat	a0 = (CGFloat)i / (CGFloat)steps;
+      CGFloat	a1 = (CGFloat)(i + 1) / (CGFloat)steps + overlap;
+      NSPoint	corners[4];
+
+      if (NO == [self _setColorFromGradient: gradient
+					  at: (a0 + (CGFloat)(i + 1)
+					       / (CGFloat)steps) / 2.0])
+	{
+	  continue;
+	}
+      if (0 == i && (options & NSGradientDrawsBeforeStartingLocation))
+	{
+	  a0 = -spread / length;
+	}
+      if (steps - 1 == i && (options & NSGradientDrawsAfterEndingLocation))
+	{
+	  a1 = 1.0 + spread / length;
+	}
+
+      corners[0] = NSMakePoint(startPoint.x + dx * a0 + sx,
+			       startPoint.y + dy * a0 + sy);
+      corners[1] = NSMakePoint(startPoint.x + dx * a1 + sx,
+			       startPoint.y + dy * a1 + sy);
+      corners[2] = NSMakePoint(startPoint.x + dx * a1 - sx,
+			       startPoint.y + dy * a1 - sy);
+      corners[3] = NSMakePoint(startPoint.x + dx * a0 - sx,
+			       startPoint.y + dy * a0 - sy);
+      [self _fillGradientQuad: corners];
+    }
+
+  [self _restoreGradientColor: &savedFill
+		       stroke: &savedStroke
+			state: savedState
+		      pattern: savedPattern];
 }
 
 @end

--- a/Tests/cairo/GNUmakefile.preamble
+++ b/Tests/cairo/GNUmakefile.preamble
@@ -8,8 +8,10 @@ ADDITIONAL_INCLUDE_DIRS += -I$(GNUSTEP_BUILD_DIR)/../.. -I../..
 -include ../../config.make
 
 # The rendering tests drive the installed backend through AppKit, so link the
-# gui for the raster graphics backends they build for.
-ifneq ($(filter $(BUILD_GRAPHICS),cairo art),)
+# gui wherever they build.  The gradient test builds for every graphics
+# backend that draws, so this has to cover all of them rather than the two
+# the older tests were written for.
+ifneq ($(BUILD_GRAPHICS),headless)
 ADDITIONAL_TOOL_LIBS += -lgnustep-gui
 endif
 

--- a/Tests/cairo/gradient.m
+++ b/Tests/cairo/gradient.m
@@ -20,16 +20,22 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(pool);
+  START_SET("gradient")
 
   if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
     {
-      NSLog(@"no window server available; skipping gradient test");
-      DESTROY(pool);
-      return 0;
+      SKIP("no window server available")
     }
 
-  [NSApplication sharedApplication];
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
 
   /* Create a small pattern image and make a pattern color (non-RGB). */
   NSImage *pat = [[NSImage alloc] initWithSize: NSMakeSize(4, 4)];
@@ -71,7 +77,7 @@ main(int argc, const char **argv)
   [rimg release];
   [rg release];
 
-  DESTROY(pool);
+  END_SET("gradient")
   return 0;
 }
 
@@ -80,6 +86,9 @@ main(int argc, const char **argv)
 int
 main(int argc, const char **argv)
 {
+  START_SET("gradient")
+    SKIP("back is not built with a graphics backend that draws")
+  END_SET("gradient")
   return 0;
 }
 

--- a/Tests/cairo/gradient.m
+++ b/Tests/cairo/gradient.m
@@ -1,14 +1,18 @@
-/* Regression test: drawing an NSGradient with a non-RGB (pattern) colour
- * must not raise an NSInternalInconsistencyException.  The fix in
- * CairoGState normalizes colours to an RGB-compatible colour space before
- * accessing -redComponent/-greenComponent/-blueComponent.
+/* Regression test: drawing an NSGradient must not raise, including when a
+ * stop holds a non-RGB colour such as a pattern, whose -redComponent,
+ * -greenComponent and -blueComponent refuse to answer.
+ *
+ * This runs against whichever graphics backend is built, because every
+ * backend has to be able to draw a gradient.  Before GSGState gained an
+ * implementation, only cairo and opal overrode the two gradient methods and
+ * the rest reached the subclassResponsibility in the base class.
  */
 #import <Foundation/NSObject.h>
 #import "Testing.h"
 #include "config.h"
 
-#if defined(BUILD_GRAPHICS) && defined(GRAPHICS_cairo) \
-  && BUILD_GRAPHICS == GRAPHICS_cairo
+#if defined(BUILD_GRAPHICS) && defined(GRAPHICS_headless) \
+  && BUILD_GRAPHICS != GRAPHICS_headless
 
 #import <AppKit/AppKit.h>
 #include <stdlib.h>


### PR DESCRIPTION
An NSGradient did not draw on the art, xlib or winlib backends. GSGState raises subclassResponsibility for -drawGradient:fromPoint:toPoint:options: and its radial counterpart, and only CairoGState and OpalGState override them. The raise was uncaught, so AppKit opened a modal alert panel and the process waited on it for good, which is why this shows up as a hang rather than an error.

GSGState now paints a gradient itself, interpolating the stops and filling a series of bands with the fill operation each backend already has. Cairo and opal keep their native versions. A stop whose colour has no RGB components, a pattern for instance, is skipped instead of raising.

Bands are a device pixel apart up to a ceiling of 256, so a very large gradient is approximated, and they reach past the area painted because the caller clips first. Verified on cairo, art and xlib; winlib and headless get the same code but were not exercised.

Tests/cairo/gradient.m now builds against whichever backend is built. Where the general drawing tests should live is #167.

Its 2 assertions fail before and pass after, on art and xlib. The full suite is unchanged at 319 passed, 24 skipped, 0 failed.

Closes #187.
