### PR TITLE
tests: let the test framework manage the autorelease pools

### DIFF
--- a/Tests/art/compositedest.m
+++ b/Tests/art/compositedest.m
@@ -77,6 +77,8 @@ blend2(int a, int wa, int b, int wb)
 int
 main(void)
 {
+  START_SET("art destination compositing")
+
   unsigned char src[3], dst[3], srca[1], dsta[1];
   composite_run_t c;
 
@@ -192,6 +194,7 @@ main(void)
   PASS(dst[0] == 80 && dst[1] == 81 && dst[2] == 82 && dsta[0] == 255,
        "xor with an opaque source and empty destination copies the source");
 
+  END_SET("art destination compositing")
   return 0;
 }
 
@@ -200,6 +203,9 @@ main(void)
 int
 main(void)
 {
+  START_SET("art destination compositing")
+    SKIP("back is not built with the art graphics backend")
+  END_SET("art destination compositing")
   return 0;
 }
 

--- a/Tests/art/compositeplus.m
+++ b/Tests/art/compositeplus.m
@@ -66,6 +66,8 @@ r255(int c, int a)
 int
 main(void)
 {
+  START_SET("art additive compositing")
+
   unsigned char src[3], dst[3], srca[1], dsta[1];
   composite_run_t c;
 
@@ -165,6 +167,7 @@ main(void)
          "dissolve_oa uses the fraction as the source coverage");
   }
 
+  END_SET("art additive compositing")
   return 0;
 }
 
@@ -173,6 +176,9 @@ main(void)
 int
 main(void)
 {
+  START_SET("art additive compositing")
+    SKIP("back is not built with the art graphics backend")
+  END_SET("art additive compositing")
   return 0;
 }
 

--- a/Tests/art/compositing.m
+++ b/Tests/art/compositing.m
@@ -66,6 +66,8 @@ scale255(int c, int a)
 int
 main(void)
 {
+  START_SET("art compositing")
+
   unsigned char src[3], dst[3], srca[1], dsta[1];
   composite_run_t c;
 
@@ -151,6 +153,7 @@ main(void)
          "sout_oa scales the source over the inverted destination alpha");
   }
 
+  END_SET("art compositing")
   return 0;
 }
 
@@ -159,6 +162,9 @@ main(void)
 int
 main(void)
 {
+  START_SET("art compositing")
+    SKIP("back is not built with the art graphics backend")
+  END_SET("art compositing")
   return 0;
 }
 

--- a/Tests/cairo/clipsaverestore.m
+++ b/Tests/cairo/clipsaverestore.m
@@ -91,19 +91,25 @@ clipGradientFill(int w, int h, NSBezierPath *clip)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(pool);
+  START_SET("clip save and restore")
   int w = 24, h = 24;
   NSBitmapImageRep *rep;
   NSBezierPath *p;
 
   if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
     {
-      NSLog(@"no window server available; skipping clip save/restore tests");
-      DESTROY(pool);
-      return 0;
+      SKIP("no window server available")
     }
 
-  [NSApplication sharedApplication];
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
 
   /* A triangle with the right angle at (3,3) and hypotenuse (21,3)-(3,21).
    * Read back (top-left origin) its interior is the lower-left half: (7,16) is
@@ -153,7 +159,7 @@ main(int argc, const char **argv)
   PASS(rep != nil && pixelIs(rep, 12, 12, 255, 255, 255),
        "an even-odd ring clip keeps its hole after save/restore");
 
-  DESTROY(pool);
+  END_SET("clip save and restore")
   return 0;
 }
 
@@ -162,6 +168,9 @@ main(int argc, const char **argv)
 int
 main(int argc, const char **argv)
 {
+  START_SET("clip save and restore")
+    SKIP("back is not built with the cairo graphics backend")
+  END_SET("clip save and restore")
   return 0;
 }
 

--- a/Tests/cairo/clipstack.m
+++ b/Tests/cairo/clipstack.m
@@ -56,19 +56,25 @@ pixelIs(NSBitmapImageRep *rep, int x, int y, int r, int g, int b)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(pool);
+  START_SET("clip stack")
   int w = 20, h = 20;
   NSImage *img;
   NSBitmapImageRep *rep;
 
   if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
     {
-      NSLog(@"no window server available; skipping clip stack tests");
-      DESTROY(pool);
-      return 0;
+      SKIP("no window server available")
     }
 
-  [NSApplication sharedApplication];
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
 
   /* Two clips intersect: a clip to the left half and then to the top half
    * confine a fill to the top-left quadrant only. */
@@ -101,7 +107,7 @@ main(int argc, const char **argv)
        && pixelIs(rep, 3 * w / 4, h / 2, 255, 255, 255),
        "two disjoint clips leave nothing to draw");
 
-  DESTROY(pool);
+  END_SET("clip stack")
   return 0;
 }
 
@@ -110,6 +116,9 @@ main(int argc, const char **argv)
 int
 main(int argc, const char **argv)
 {
+  START_SET("clip stack")
+    SKIP("back is not built with the cairo graphics backend")
+  END_SET("clip stack")
   return 0;
 }
 

--- a/Tests/cairo/compatbitmap.m
+++ b/Tests/cairo/compatbitmap.m
@@ -34,19 +34,25 @@ makeRep(int spp, int bps, BOOL alpha, BOOL planar, NSString *cs)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(pool);
+  START_SET("compatible bitmap")
   NSImage *img;
   id ctxt;
   NSBitmapImageRep *alphaFirst;
 
   if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
     {
-      NSLog(@"no window server available; skipping compatible-bitmap tests");
-      DESTROY(pool);
-      return 0;
+      SKIP("no window server available")
     }
 
-  [NSApplication sharedApplication];
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
 
   img = [[NSImage alloc] initWithSize: NSMakeSize(4, 4)];
   [img lockFocus];
@@ -85,7 +91,7 @@ main(int argc, const char **argv)
 
   [img unlockFocus];
   [img release];
-  DESTROY(pool);
+  END_SET("compatible bitmap")
   return 0;
 }
 
@@ -94,6 +100,9 @@ main(int argc, const char **argv)
 int
 main(int argc, const char **argv)
 {
+  START_SET("compatible bitmap")
+    SKIP("back is not built with the cairo graphics backend")
+  END_SET("compatible bitmap")
   return 0;
 }
 

--- a/Tests/cairo/compositeops.m
+++ b/Tests/cairo/compositeops.m
@@ -68,18 +68,24 @@ composite(NSColor *fg, NSCompositingOperation op)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(pool);
+  START_SET("composite operators")
   NSColor *blue = [NSColor colorWithDeviceRed: 0.0 green: 0.0 blue: 1.0 alpha: 1.0];
   NSColor *green = [NSColor colorWithDeviceRed: 0.0 green: 1.0 blue: 0.0 alpha: 1.0];
 
   if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
     {
-      NSLog(@"no window server available; skipping compositing tests");
-      DESTROY(pool);
-      return 0;
+      SKIP("no window server available")
     }
 
-  [NSApplication sharedApplication];
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
 
   PASS(pixelIs(composite(blue, NSCompositeCopy), 10, 10, 0, 0, 255),
     "copy replaces the destination with the source");
@@ -96,7 +102,7 @@ main(int argc, const char **argv)
   PASS(pixelIs(composite(blue, NSCompositeClear), 10, 10, 0, 0, 0),
     "clear erases the destination");
 
-  DESTROY(pool);
+  END_SET("composite operators")
   return 0;
 }
 
@@ -105,6 +111,9 @@ main(int argc, const char **argv)
 int
 main(int argc, const char **argv)
 {
+  START_SET("composite operators")
+    SKIP("back is not built with the cairo graphics backend")
+  END_SET("composite operators")
   return 0;
 }
 

--- a/Tests/cairo/curves.m
+++ b/Tests/cairo/curves.m
@@ -58,19 +58,25 @@ pixelIs(NSBitmapImageRep *rep, int x, int y, int r, int g, int b)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(pool);
+  START_SET("curves")
   int w = 20, h = 20;
   NSImage *img;
   NSBitmapImageRep *rep;
 
   if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
     {
-      NSLog(@"no window server available; skipping curve tests");
-      DESTROY(pool);
-      return 0;
+      SKIP("no window server available")
     }
 
-  [NSApplication sharedApplication];
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
 
   /* A filled oval paints its centre and leaves the corners of the bounding box
    * clear, because the ellipse does not reach the corners. */
@@ -111,7 +117,7 @@ main(int argc, const char **argv)
   PASS(rep != nil && pixelIs(rep, 10, h - 1 - 4, 255, 255, 255),
        "a stroked cubic curve leaves the straight chord clear");
 
-  DESTROY(pool);
+  END_SET("curves")
   return 0;
 }
 
@@ -120,6 +126,9 @@ main(int argc, const char **argv)
 int
 main(int argc, const char **argv)
 {
+  START_SET("curves")
+    SKIP("back is not built with the cairo graphics backend")
+  END_SET("curves")
   return 0;
 }
 

--- a/Tests/cairo/dropshadow.m
+++ b/Tests/cairo/dropshadow.m
@@ -73,7 +73,7 @@ redShadow(void)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(pool);
+  START_SET("drop shadow")
   int w = 40, h = 40;
   NSImage *img;
   NSBitmapImageRep *rep;
@@ -86,13 +86,19 @@ main(int argc, const char **argv)
     if ((x11 == NULL || *x11 == '\0')
       && (wayland == NULL || *wayland == '\0'))
       {
-	NSLog(@"no window server available; skipping shadow tests");
-	DESTROY(pool);
-	return 0;
+	SKIP("no window server available")
       }
   }
 
-  [NSApplication sharedApplication];
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
 
   /* A blue rectangle with a red shadow offset to the lower right.  The shape
    * spans device x,y in 10..22 and the shadow 18..30 vertically 12..24. */
@@ -160,7 +166,7 @@ main(int argc, const char **argv)
   PASS(rep != nil && pixelIs(rep, 28, h - 1 - 16, 255, 255, 255),
        "a restored graphics state clears the shadow");
 
-  DESTROY(pool);
+  END_SET("drop shadow")
   return 0;
 }
 
@@ -169,6 +175,9 @@ main(int argc, const char **argv)
 int
 main(int argc, const char **argv)
 {
+  START_SET("drop shadow")
+    SKIP("back is not built with the cairo or art graphics backend")
+  END_SET("drop shadow")
   return 0;
 }
 

--- a/Tests/cairo/faceinfo.m
+++ b/Tests/cairo/faceinfo.m
@@ -45,7 +45,6 @@ int
 main(void)
 {
   START_SET("fontconfig face info")
-  ENTER_POOL
 
   Class faceClass = Nil;
   id gen = nil;
@@ -149,7 +148,6 @@ main(void)
       }
     }
 
-  LEAVE_POOL
   END_SET("fontconfig face info")
   return 0;
 }

--- a/Tests/cairo/fontenumeration.m
+++ b/Tests/cairo/fontenumeration.m
@@ -25,7 +25,6 @@ int
 main(void)
 {
   START_SET("fontconfig font enumeration")
-  ENTER_POOL
 
   GSFontEnumerator *e = nil;
 
@@ -92,7 +91,6 @@ main(void)
 	}
     }
 
-  LEAVE_POOL
   END_SET("fontconfig font enumeration")
   return 0;
 }

--- a/Tests/cairo/fontinstaller.m
+++ b/Tests/cairo/fontinstaller.m
@@ -41,7 +41,6 @@ int
 main(void)
 {
   START_SET("fontconfig font asset installer")
-  ENTER_POOL
 
   Class installerClass = Nil;
 
@@ -123,7 +122,6 @@ main(void)
       [fm removeItemAtPath: ttfPath error: NULL];
     }
 
-  LEAVE_POOL
   END_SET("fontconfig font asset installer")
   return 0;
 }

--- a/Tests/cairo/fontmetrics.m
+++ b/Tests/cairo/fontmetrics.m
@@ -30,18 +30,24 @@ near(CGFloat a, CGFloat b)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(pool);
+  START_SET("font metrics")
   NSFont *f, *big;
   CGFloat wi, wiiii, wW, wWWWW;
 
   if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
     {
-      NSLog(@"no window server available; skipping font metric tests");
-      DESTROY(pool);
-      return 0;
+      SKIP("no window server available")
     }
 
-  [NSApplication sharedApplication];
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
 
   f = [NSFont systemFontOfSize: 14];
   big = [NSFont systemFontOfSize: 28];
@@ -74,7 +80,7 @@ main(int argc, const char **argv)
   PASS([f maximumAdvancement].width >= wW,
     "the maximum advancement is at least the width of a W");
 
-  DESTROY(pool);
+  END_SET("font metrics")
   return 0;
 }
 
@@ -83,6 +89,9 @@ main(int argc, const char **argv)
 int
 main(int argc, const char **argv)
 {
+  START_SET("font metrics")
+    SKIP("back is not built with the cairo graphics backend")
+  END_SET("font metrics")
   return 0;
 }
 

--- a/Tests/cairo/fontpattern.m
+++ b/Tests/cairo/fontpattern.m
@@ -68,7 +68,6 @@ int
 main(void)
 {
   START_SET("fontconfig pattern round trip")
-  ENTER_POOL
 
   Class genClass = Nil;
   Class parserClass = Nil;
@@ -147,7 +146,6 @@ main(void)
 	"the expanded trait round-trips")
     }
 
-  LEAVE_POOL
   END_SET("fontconfig pattern round trip")
   return 0;
 }

--- a/Tests/cairo/glyphmetrics.m
+++ b/Tests/cairo/glyphmetrics.m
@@ -29,19 +29,25 @@ near(CGFloat a, CGFloat b)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(pool);
+  START_SET("glyph metrics")
   NSFont *f, *big, *mono;
   NSSize aW, ai;
   NSRect bW, bi;
 
   if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
     {
-      NSLog(@"no window server available; skipping glyph metric tests");
-      DESTROY(pool);
-      return 0;
+      SKIP("no window server available")
     }
 
-  [NSApplication sharedApplication];
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
 
   f = [NSFont systemFontOfSize: 14];
   big = [NSFont systemFontOfSize: 28];
@@ -73,7 +79,7 @@ main(int argc, const char **argv)
   PASS([f glyphIsEncoded: (NSGlyph)'A'],
     "a common character is an encoded glyph");
 
-  DESTROY(pool);
+  END_SET("glyph metrics")
   return 0;
 }
 
@@ -82,6 +88,9 @@ main(int argc, const char **argv)
 int
 main(int argc, const char **argv)
 {
+  START_SET("glyph metrics")
+    SKIP("back is not built with the cairo graphics backend")
+  END_SET("glyph metrics")
   return 0;
 }
 

--- a/Tests/cairo/gsaverestore.m
+++ b/Tests/cairo/gsaverestore.m
@@ -55,19 +55,25 @@ pixelIs(NSBitmapImageRep *rep, int x, int y, int r, int g, int b)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(pool);
+  START_SET("graphics state stack")
   int w = 20, h = 20;
   NSImage *img;
   NSBitmapImageRep *rep;
 
   if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
     {
-      NSLog(@"no window server available; skipping save/restore tests");
-      DESTROY(pool);
-      return 0;
+      SKIP("no window server available")
     }
 
-  [NSApplication sharedApplication];
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
 
   /* Restoring the graphics state recovers the earlier fill colour: red is set,
    * the state saved, blue set, then restored, so a fill uses red again. */
@@ -134,7 +140,7 @@ main(int argc, const char **argv)
   PASS(rep != nil && pixelIs(rep, 3 * w / 4, h / 2, 255, 0, 0),
        "an outer restore recovers the first colour on the stack");
 
-  DESTROY(pool);
+  END_SET("graphics state stack")
   return 0;
 }
 
@@ -143,6 +149,9 @@ main(int argc, const char **argv)
 int
 main(int argc, const char **argv)
 {
+  START_SET("graphics state stack")
+    SKIP("back is not built with the cairo graphics backend")
+  END_SET("graphics state stack")
   return 0;
 }
 

--- a/Tests/cairo/imagealpha.m
+++ b/Tests/cairo/imagealpha.m
@@ -83,16 +83,22 @@ over(NSImage *img, int bg)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(pool);
+  START_SET("image alpha")
 
   if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
     {
-      NSLog(@"no window server available; skipping image alpha tests");
-      DESTROY(pool);
-      return 0;
+      SKIP("no window server available")
     }
 
-  [NSApplication sharedApplication];
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
 
   /* a half-transparent gray over black is half of 128 */
   PASS(pixelIs(over(solidImage(4, 128, 128, 128, 128), 0), 10, 10, 64, 64, 64),
@@ -106,7 +112,7 @@ main(int argc, const char **argv)
   PASS(pixelIs(over(solidImage(4, 128, 128, 128, 255), 0), 10, 10, 128, 128, 128),
     "an opaque gray image over black shows its colour");
 
-  DESTROY(pool);
+  END_SET("image alpha")
   return 0;
 }
 
@@ -115,6 +121,9 @@ main(int argc, const char **argv)
 int
 main(int argc, const char **argv)
 {
+  START_SET("image alpha")
+    SKIP("back is not built with the cairo graphics backend")
+  END_SET("image alpha")
   return 0;
 }
 

--- a/Tests/cairo/imagepixels.m
+++ b/Tests/cairo/imagepixels.m
@@ -57,7 +57,7 @@ draw(NSImage *src)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(pool);
+  START_SET("image pixels")
   NSBitmapImageRep *rep, *out;
   NSImage *src;
   unsigned char *d;
@@ -65,12 +65,18 @@ main(int argc, const char **argv)
 
   if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
     {
-      NSLog(@"no window server available; skipping image pixel tests");
-      DESTROY(pool);
-      return 0;
+      SKIP("no window server available")
     }
 
-  [NSApplication sharedApplication];
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
 
   /* A 2x2 image, bitmap row 0 (top) = red, green; row 1 (bottom) = blue, white.
    * Drawn over the canvas it must keep that layout. */
@@ -112,7 +118,7 @@ main(int argc, const char **argv)
   PASS(pixelIs(out, 10, 10, 0, 255, 255),
     "a 24-bit rgb image without alpha decodes to its colour");
 
-  DESTROY(pool);
+  END_SET("image pixels")
   return 0;
 }
 
@@ -121,6 +127,9 @@ main(int argc, const char **argv)
 int
 main(int argc, const char **argv)
 {
+  START_SET("image pixels")
+    SKIP("back is not built with the cairo graphics backend")
+  END_SET("image pixels")
   return 0;
 }
 

--- a/Tests/cairo/pdfps.m
+++ b/Tests/cairo/pdfps.m
@@ -56,18 +56,24 @@ dataContains(NSData *d, const char *needle)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(pool);
+  START_SET("PDF and PostScript output")
   GSPdfPsTestView *v;
   NSData *pdf, *eps;
 
   if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
     {
-      NSLog(@"no window server available; skipping PDF/PS output tests");
-      DESTROY(pool);
-      return 0;
+      SKIP("no window server available")
     }
 
-  [NSApplication sharedApplication];
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
   v = [[GSPdfPsTestView alloc] initWithFrame: NSMakeRect(0, 0, 100, 100)];
 
   pdf = [v dataWithPDFInsideRect: [v bounds]];
@@ -81,7 +87,7 @@ main(int argc, const char **argv)
        "dataWithEPSInsideRect produces a well-formed EPS document");
 
   [v release];
-  DESTROY(pool);
+  END_SET("PDF and PostScript output")
   return 0;
 }
 
@@ -90,6 +96,9 @@ main(int argc, const char **argv)
 int
 main(int argc, const char **argv)
 {
+  START_SET("PDF and PostScript output")
+    SKIP("back is not built with the cairo graphics backend")
+  END_SET("PDF and PostScript output")
   return 0;
 }
 

--- a/Tests/cairo/render.m
+++ b/Tests/cairo/render.m
@@ -62,19 +62,25 @@ pixelIs(NSBitmapImageRep *rep, int x, int y, int r, int g, int b)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(pool);
+  START_SET("rendering")
   int w = 20, h = 20;
   NSImage *img;
   NSBitmapImageRep *rep;
 
   if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
     {
-      NSLog(@"no window server available; skipping rendering tests");
-      DESTROY(pool);
-      return 0;
+      SKIP("no window server available")
     }
 
-  [NSApplication sharedApplication];
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
 
   /* A solid fill covers the whole image with one colour. */
   img = beginImage(w, h);
@@ -449,7 +455,7 @@ main(int argc, const char **argv)
   PASS(rep != nil && pixelIs(rep, w - 2, h / 2, 255, 255, 255),
        "the mark's original position is left unpainted after rotation");
 
-  DESTROY(pool);
+  END_SET("rendering")
   return 0;
 }
 
@@ -458,6 +464,9 @@ main(int argc, const char **argv)
 int
 main(int argc, const char **argv)
 {
+  START_SET("rendering")
+    SKIP("back is not built with the cairo graphics backend")
+  END_SET("rendering")
   return 0;
 }
 

--- a/Tests/cairo/roundstroke.m
+++ b/Tests/cairo/roundstroke.m
@@ -77,19 +77,25 @@ darkCount(NSBitmapImageRep *rep, int x0, int y0, int x1, int y1)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(pool);
+  START_SET("round stroke")
   int w = 40, h = 40;
   NSImage *img;
   NSBitmapImageRep *rep;
 
   if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
     {
-      NSLog(@"no window server available; skipping round stroke tests");
-      DESTROY(pool);
-      return 0;
+      SKIP("no window server available")
     }
 
-  [NSApplication sharedApplication];
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
 
   /* A round cap paints a half-disc past the endpoint, so a point on the axis
    * just beyond the endpoint is painted, but rounds off the square corner, so a
@@ -146,7 +152,7 @@ main(int argc, const char **argv)
          "a miter join fills the outer corner more than a round join");
   }
 
-  DESTROY(pool);
+  END_SET("round stroke")
   return 0;
 }
 
@@ -155,6 +161,9 @@ main(int argc, const char **argv)
 int
 main(int argc, const char **argv)
 {
+  START_SET("round stroke")
+    SKIP("back is not built with the cairo graphics backend")
+  END_SET("round stroke")
   return 0;
 }
 

--- a/Tests/cairo/shmbuffer.m
+++ b/Tests/cairo/shmbuffer.m
@@ -46,7 +46,6 @@ int
 main(void)
 {
   START_SET("WaylandCairoShmSurface createShmBuffer")
-  ENTER_POOL
   int	i;
   BOOL	ok = YES;
 
@@ -61,7 +60,6 @@ main(void)
     }
   PASS(ok == YES,
     "createShmBuffer rejects a zero-area request without leaking the buffer")
-  LEAVE_POOL
   END_SET("WaylandCairoShmSurface createShmBuffer")
   return 0;
 }

--- a/Tests/cairo/surfacedevice.m
+++ b/Tests/cairo/surfacedevice.m
@@ -38,18 +38,24 @@ deviceForImage(int w, int h, void **device, int *x, int *y)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(pool);
+  START_SET("surface device")
   void *device;
   int x, y;
 
   if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
     {
-      NSLog(@"no window server available; skipping surface device tests");
-      DESTROY(pool);
-      return 0;
+      SKIP("no window server available")
     }
 
-  [NSApplication sharedApplication];
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
 
   device = NULL; x = -1; y = -1;
   deviceForImage(37, 21, &device, &x, &y);
@@ -62,7 +68,7 @@ main(int argc, const char **argv)
   PASS(device != NULL && x == 0 && y == 64,
     "the offset tracks a differently sized image");
 
-  DESTROY(pool);
+  END_SET("surface device")
   return 0;
 }
 
@@ -71,6 +77,9 @@ main(int argc, const char **argv)
 int
 main(int argc, const char **argv)
 {
+  START_SET("surface device")
+    SKIP("back is not built with the cairo graphics backend")
+  END_SET("surface device")
   return 0;
 }
 

--- a/Tests/cairo/waylandavailabledepths.m
+++ b/Tests/cairo/waylandavailabledepths.m
@@ -26,7 +26,6 @@ int
 main(void)
 {
   START_SET("WaylandServer availableDepthsForScreen")
-  ENTER_POOL
 
   GSDisplayServer *server = nil;
 
@@ -90,7 +89,6 @@ main(void)
 	}
     }
 
-  LEAVE_POOL
   END_SET("WaylandServer availableDepthsForScreen")
   return 0;
 }

--- a/Tests/cairo/waylandboundsforscreen.m
+++ b/Tests/cairo/waylandboundsforscreen.m
@@ -28,7 +28,6 @@ int
 main(void)
 {
   START_SET("WaylandServer boundsForScreen")
-  ENTER_POOL
 
   GSDisplayServer *server = nil;
 
@@ -79,7 +78,6 @@ main(void)
 	"boundsForScreen: returns NSZeroRect for a negative screen number")
     }
 
-  LEAVE_POOL
   END_SET("WaylandServer boundsForScreen")
   return 0;
 }

--- a/Tests/cairo/waylandmapwindow.m
+++ b/Tests/cairo/waylandmapwindow.m
@@ -28,7 +28,6 @@ int
 main(void)
 {
   START_SET("WaylandServer window mapping")
-  ENTER_POOL
 
   GSDisplayServer *server = nil;
 
@@ -100,7 +99,6 @@ main(void)
       [win close];
     }
 
-  LEAVE_POOL
   END_SET("WaylandServer window mapping")
   return 0;
 }

--- a/Tests/cairo/waylandscreens.m
+++ b/Tests/cairo/waylandscreens.m
@@ -32,7 +32,6 @@ int
 main(void)
 {
   START_SET("WaylandServer screen queries")
-  ENTER_POOL
 
   GSDisplayServer *server = nil;
 
@@ -123,7 +122,6 @@ main(void)
 	"windowDepthForScreen: reports an 8-bit RGB window depth")
     }
 
-  LEAVE_POOL
   END_SET("WaylandServer screen queries")
   return 0;
 }

--- a/Tests/cairo/waylandunknownwindow.m
+++ b/Tests/cairo/waylandunknownwindow.m
@@ -30,7 +30,6 @@ int
 main(void)
 {
   START_SET("WaylandServer unknown window number")
-  ENTER_POOL
 
   GSDisplayServer *server = nil;
 
@@ -77,7 +76,6 @@ main(void)
 	"window operations on an unknown window number do not crash")
     }
 
-  LEAVE_POOL
   END_SET("WaylandServer unknown window number")
   return 0;
 }

--- a/Tests/cairo/waylandwindowbounds.m
+++ b/Tests/cairo/waylandwindowbounds.m
@@ -40,7 +40,6 @@ int
 main(void)
 {
   START_SET("WaylandServer windowbounds round-trip")
-  ENTER_POOL
 
   GSDisplayServer *server = nil;
 
@@ -77,7 +76,6 @@ main(void)
 	"windowbounds: round-trips a taller frame")
     }
 
-  LEAVE_POOL
   END_SET("WaylandServer windowbounds round-trip")
   return 0;
 }

--- a/Tests/cairo/waylandwindowops.m
+++ b/Tests/cairo/waylandwindowops.m
@@ -29,7 +29,6 @@ int
 main(void)
 {
   START_SET("WaylandServer window operations")
-  ENTER_POOL
 
   GSDisplayServer *server = nil;
 
@@ -125,7 +124,6 @@ main(void)
       [server termwindow: win];
     }
 
-  LEAVE_POOL
   END_SET("WaylandServer window operations")
   return 0;
 }

--- a/Tests/cairo/win32mouse.m
+++ b/Tests/cairo/win32mouse.m
@@ -26,7 +26,6 @@ int
 main(void)
 {
   START_SET("WIN32Server mouse location")
-  ENTER_POOL
 
   GSDisplayServer *server = nil;
 
@@ -81,7 +80,6 @@ main(void)
       SetCursorPos(saved.x, saved.y);
     }
 
-  LEAVE_POOL
   END_SET("WIN32Server mouse location")
   return 0;
 }

--- a/Tests/cairo/win32screens.m
+++ b/Tests/cairo/win32screens.m
@@ -26,7 +26,6 @@ int
 main(void)
 {
   START_SET("WIN32Server screen queries")
-  ENTER_POOL
 
   GSDisplayServer *server = nil;
 
@@ -149,7 +148,6 @@ main(void)
       }
     }
 
-  LEAVE_POOL
   END_SET("WIN32Server screen queries")
   return 0;
 }

--- a/Tests/cairo/win32style.m
+++ b/Tests/cairo/win32style.m
@@ -36,7 +36,6 @@ int
 main(void)
 {
   START_SET("WIN32Server window style mapping")
-  ENTER_POOL
 
   GSDisplayServer *server = nil;
 
@@ -127,7 +126,6 @@ main(void)
       [server setUsesNativeTaskbar: YES];
     }
 
-  LEAVE_POOL
   END_SET("WIN32Server window style mapping")
   return 0;
 }

--- a/Tests/cairo/win32windowops.m
+++ b/Tests/cairo/win32windowops.m
@@ -31,7 +31,6 @@ int
 main(void)
 {
   START_SET("WIN32Server window operations")
-  ENTER_POOL
 
   GSDisplayServer *server = nil;
 
@@ -117,7 +116,6 @@ main(void)
       [server termwindow: win];
     }
 
-  LEAVE_POOL
   END_SET("WIN32Server window operations")
   return 0;
 }

--- a/Tests/cairo/windingrule.m
+++ b/Tests/cairo/windingrule.m
@@ -69,7 +69,7 @@ donutPath(void)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(pool);
+  START_SET("winding rule")
   int w = 20, h = 20;
   NSImage *img;
   NSBitmapImageRep *rep;
@@ -77,12 +77,18 @@ main(int argc, const char **argv)
 
   if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
     {
-      NSLog(@"no window server available; skipping winding rule tests");
-      DESTROY(pool);
-      return 0;
+      SKIP("no window server available")
     }
 
-  [NSApplication sharedApplication];
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
 
   /* Non-zero fill: the inner region is enclosed twice, so it is filled and the
    * hole is painted over. */
@@ -132,7 +138,7 @@ main(int argc, const char **argv)
   PASS(rep != nil && pixelIs(rep, 0, h - 1 - 0, 255, 255, 255),
        "an even-odd clip excludes the area outside the path");
 
-  DESTROY(pool);
+  END_SET("winding rule")
   return 0;
 }
 
@@ -141,6 +147,9 @@ main(int argc, const char **argv)
 int
 main(int argc, const char **argv)
 {
+  START_SET("winding rule")
+    SKIP("back is not built with the cairo graphics backend")
+  END_SET("winding rule")
   return 0;
 }
 

--- a/Tests/cairo/wlglcontext.m
+++ b/Tests/cairo/wlglcontext.m
@@ -27,7 +27,6 @@ int
 main(void)
 {
   START_SET("Wayland EGL OpenGL context")
-  ENTER_POOL
 
   GSDisplayServer *server = nil;
 
@@ -99,7 +98,6 @@ main(void)
 	"a current EGL context reports a GL version string")
     }
 
-  LEAVE_POOL
   END_SET("Wayland EGL OpenGL context")
   return 0;
 }

--- a/Tests/cairo/wlwindowrender.m
+++ b/Tests/cairo/wlwindowrender.m
@@ -38,7 +38,6 @@ int
 main(void)
 {
   START_SET("Wayland window surface rendering")
-  ENTER_POOL
 
   GSDisplayServer *server = nil;
 
@@ -89,7 +88,6 @@ main(void)
       [win close];
     }
 
-  LEAVE_POOL
   END_SET("Wayland window surface rendering")
   return 0;
 }

--- a/Tests/gsc/gsfunction.m
+++ b/Tests/gsc/gsfunction.m
@@ -43,7 +43,6 @@ int
 main(void)
 {
   START_SET("GSFunction type 0")
-  ENTER_POOL
 
   /* --- 1-in 1-out, linear ramp over two samples --- */
   {
@@ -254,7 +253,6 @@ main(void)
     RELEASE(f);
   }
 
-  LEAVE_POOL
   END_SET("GSFunction type 0")
   return 0;
 }

--- a/Tests/gsc/gstate.m
+++ b/Tests/gsc/gstate.m
@@ -52,7 +52,7 @@ maps(id gs, NSPoint in, CGFloat x, CGFloat y)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(pool);
+  START_SET("GSGState CTM")
   id ctxt, gs;
   NSAffineTransform *t;
   NSAffineTransformStruct s;
@@ -60,12 +60,18 @@ main(int argc, const char **argv)
 
   if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
     {
-      NSLog(@"no window server available; skipping GSGState CTM tests");
-      DESTROY(pool);
-      return 0;
+      SKIP("no window server available")
     }
 
-  [NSApplication sharedApplication];
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
   ctxt = [[NSClassFromString(@"GSStreamContext") alloc] initWithContextInfo:
     [NSDictionary dictionaryWithObject:
       [NSTemporaryDirectory() stringByAppendingPathComponent: @"gsc_gstate.ps"]
@@ -74,8 +80,7 @@ main(int argc, const char **argv)
   PASS(gs != nil, "a GSGState is created for the stream context");
   if (gs == nil)
     {
-      DESTROY(pool);
-      return 0;
+      SKIP("gs could not be created")
     }
 
   PASS(maps(gs, NSMakePoint(3, 4), 3, 4),
@@ -132,7 +137,7 @@ main(int argc, const char **argv)
       "GSConcatCTM prepends the given matrix");
   }
 
-  DESTROY(pool);
+  END_SET("GSGState CTM")
   return 0;
 }
 
@@ -141,6 +146,9 @@ main(int argc, const char **argv)
 int
 main(int argc, const char **argv)
 {
+  START_SET("GSGState CTM")
+    SKIP("back is not built with the cairo graphics backend")
+  END_SET("GSGState CTM")
   return 0;
 }
 

--- a/Tests/gsc/gstatealias.m
+++ b/Tests/gsc/gstatealias.m
@@ -37,19 +37,25 @@ eqf(CGFloat a, CGFloat b)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(pool);
+  START_SET("GSGState alias")
   id ctxt, gs;
   NSAffineTransform *t;
   NSPoint p;
 
   if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
     {
-      NSLog(@"no window server available; skipping GSSetCTM alias test");
-      DESTROY(pool);
-      return 0;
+      SKIP("no window server available")
     }
 
-  [NSApplication sharedApplication];
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
   ctxt = [[NSClassFromString(@"GSStreamContext") alloc] initWithContextInfo:
     [NSDictionary dictionaryWithObject:
       [NSTemporaryDirectory() stringByAppendingPathComponent: @"gsc_alias.ps"]
@@ -58,8 +64,7 @@ main(int argc, const char **argv)
   PASS(gs != nil, "a GSGState is created for the stream context");
   if (gs == nil)
     {
-      DESTROY(pool);
-      return 0;
+      SKIP("gs could not be created")
     }
 
   /* The caller changing its transform after the call must not reach into the
@@ -82,7 +87,7 @@ main(int argc, const char **argv)
   PASS(eqf(p.x, 7) && eqf(p.y, 8),
     "the gstate resetting its matrix does not change the caller's transform");
 
-  DESTROY(pool);
+  END_SET("GSGState alias")
   return 0;
 }
 
@@ -91,6 +96,9 @@ main(int argc, const char **argv)
 int
 main(int argc, const char **argv)
 {
+  START_SET("GSGState alias")
+    SKIP("back is not built with the cairo graphics backend")
+  END_SET("GSGState alias")
   return 0;
 }
 

--- a/Tests/gsc/gstatecolor.m
+++ b/Tests/gsc/gstatecolor.m
@@ -45,18 +45,24 @@ eqf(CGFloat a, CGFloat b)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(pool);
+  START_SET("GSGState colour")
   id ctxt, gs;
   CGFloat r, g, b, k, a;
 
   if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
     {
-      NSLog(@"no window server available; skipping GSGState colour tests");
-      DESTROY(pool);
-      return 0;
+      SKIP("no window server available")
     }
 
-  [NSApplication sharedApplication];
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
   ctxt = [[NSClassFromString(@"GSStreamContext") alloc] initWithContextInfo:
     [NSDictionary dictionaryWithObject:
       [NSTemporaryDirectory() stringByAppendingPathComponent: @"gsc_color.ps"]
@@ -65,8 +71,7 @@ main(int argc, const char **argv)
   PASS(gs != nil, "a GSGState is created for the stream context");
   if (gs == nil)
     {
-      DESTROY(pool);
-      return 0;
+      SKIP("gs could not be created")
     }
 
   /* rgb red reads back as itself and converts into the other spaces */
@@ -124,7 +129,7 @@ main(int argc, const char **argv)
   PASS(eqf(r, 1) && eqf(g, 0) && eqf(b, 0.5),
     "rgb components are clamped to zero and one");
 
-  DESTROY(pool);
+  END_SET("GSGState colour")
   return 0;
 }
 
@@ -133,6 +138,9 @@ main(int argc, const char **argv)
 int
 main(int argc, const char **argv)
 {
+  START_SET("GSGState colour")
+    SKIP("back is not built with the cairo graphics backend")
+  END_SET("GSGState colour")
   return 0;
 }
 

--- a/Tests/gsc/gstatepath.m
+++ b/Tests/gsc/gstatepath.m
@@ -65,17 +65,23 @@ hasBBox(id gs, CGFloat llx, CGFloat lly, CGFloat urx, CGFloat ury)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(pool);
+  START_SET("GSGState path")
   id ctxt, gs;
 
   if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
     {
-      NSLog(@"no window server available; skipping GSGState path tests");
-      DESTROY(pool);
-      return 0;
+      SKIP("no window server available")
     }
 
-  [NSApplication sharedApplication];
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
   ctxt = [[NSClassFromString(@"GSStreamContext") alloc] initWithContextInfo:
     [NSDictionary dictionaryWithObject:
       [NSTemporaryDirectory() stringByAppendingPathComponent: @"gsc_path.ps"]
@@ -84,8 +90,7 @@ main(int argc, const char **argv)
   PASS(gs != nil, "a GSGState is created for the stream context");
   if (gs == nil)
     {
-      DESTROY(pool);
-      return 0;
+      SKIP("gs could not be created")
     }
 
   [gs DPSmoveto: 10 : 20];
@@ -131,7 +136,7 @@ main(int argc, const char **argv)
   PASS(hasBBox(gs, 3, 4, 8, 9),
     "the bounding box is reported in user space under a transform");
 
-  DESTROY(pool);
+  END_SET("GSGState path")
   return 0;
 }
 
@@ -140,6 +145,9 @@ main(int argc, const char **argv)
 int
 main(int argc, const char **argv)
 {
+  START_SET("GSGState path")
+    SKIP("back is not built with the cairo graphics backend")
+  END_SET("GSGState path")
   return 0;
 }
 

--- a/Tests/gsc/psescape.m
+++ b/Tests/gsc/psescape.m
@@ -47,23 +47,28 @@ emitShow(Class cls, const char *s)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(pool);
+  START_SET("PostScript escaping")
   Class cls;
 
   if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
     {
-      NSLog(@"no window server available; skipping PostScript escaping tests");
-      DESTROY(pool);
-      return 0;
+      SKIP("no window server available")
     }
 
-  [NSApplication sharedApplication];
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
   cls = NSClassFromString(@"GSStreamContext");
   PASS(cls != Nil, "the GSStreamContext class is available");
   if (cls == Nil)
     {
-      DESTROY(pool);
-      return 0;
+      SKIP("cls could not be created")
     }
 
   {
@@ -90,7 +95,7 @@ main(int argc, const char **argv)
       "show escapes a trailing backslash so the string stays terminated");
   }
 
-  DESTROY(pool);
+  END_SET("PostScript escaping")
   return 0;
 }
 
@@ -99,6 +104,9 @@ main(int argc, const char **argv)
 int
 main(int argc, const char **argv)
 {
+  START_SET("PostScript escaping")
+    SKIP("back is not built with the cairo graphics backend")
+  END_SET("PostScript escaping")
   return 0;
 }
 

--- a/Tests/gsc/streambezier.m
+++ b/Tests/gsc/streambezier.m
@@ -40,7 +40,7 @@ hasLines(NSArray *lines, NSArray *want)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(pool);
+  START_SET("stream bezier")
   Class cls;
   id x;
   NSString *path;
@@ -49,18 +49,23 @@ main(int argc, const char **argv)
 
   if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
     {
-      NSLog(@"no window server available; skipping bezier path test");
-      DESTROY(pool);
-      return 0;
+      SKIP("no window server available")
     }
 
-  [NSApplication sharedApplication];
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
   cls = NSClassFromString(@"GSStreamContext");
   PASS(cls != Nil, "the GSStreamContext class is available");
   if (cls == Nil)
     {
-      DESTROY(pool);
-      return 0;
+      SKIP("cls could not be created")
     }
 
   bp = [NSBezierPath bezierPath];
@@ -99,7 +104,7 @@ main(int argc, const char **argv)
     @"closepath", nil]),
     "GSSendBezierPath emits the path elements in order");
 
-  DESTROY(pool);
+  END_SET("stream bezier")
   return 0;
 }
 
@@ -108,6 +113,9 @@ main(int argc, const char **argv)
 int
 main(int argc, const char **argv)
 {
+  START_SET("stream bezier")
+    SKIP("back is not built with the cairo graphics backend")
+  END_SET("stream bezier")
   return 0;
 }
 

--- a/Tests/gsc/streamimage.m
+++ b/Tests/gsc/streamimage.m
@@ -37,7 +37,7 @@ contains(NSString *s, NSString *needle)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(pool);
+  START_SET("stream image")
   Class cls;
   id x;
   NSString *path, *ps;
@@ -47,18 +47,23 @@ main(int argc, const char **argv)
 
   if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
     {
-      NSLog(@"no window server available; skipping image test");
-      DESTROY(pool);
-      return 0;
+      SKIP("no window server available")
     }
 
-  [NSApplication sharedApplication];
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
   cls = NSClassFromString(@"GSStreamContext");
   PASS(cls != Nil, "the GSStreamContext class is available");
   if (cls == Nil)
     {
-      DESTROY(pool);
-      return 0;
+      SKIP("cls could not be created")
     }
 
   rep = [[NSBitmapImageRep alloc]
@@ -103,7 +108,7 @@ main(int argc, const char **argv)
       "the image hex data is terminated before the setmatrix operator");
   }
 
-  DESTROY(pool);
+  END_SET("stream image")
   return 0;
 }
 
@@ -112,6 +117,9 @@ main(int argc, const char **argv)
 int
 main(int argc, const char **argv)
 {
+  START_SET("stream image")
+    SKIP("back is not built with the cairo graphics backend")
+  END_SET("stream image")
   return 0;
 }
 

--- a/Tests/gsc/streamops.m
+++ b/Tests/gsc/streamops.m
@@ -96,7 +96,7 @@ hasLines(NSArray *lines, NSArray *want)
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(pool);
+  START_SET("stream operators")
   Class cls;
   id x;
   NSString *path, *out;
@@ -107,18 +107,23 @@ main(int argc, const char **argv)
 
   if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
     {
-      NSLog(@"no window server available; skipping operator tests");
-      DESTROY(pool);
-      return 0;
+      SKIP("no window server available")
     }
 
-  [NSApplication sharedApplication];
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      SKIP("It looks like GNUstep backend is not yet installed")
+    }
+  NS_ENDHANDLER
   cls = NSClassFromString(@"GSStreamContext");
   PASS(cls != Nil, "the GSStreamContext class is available");
   if (cls == Nil)
     {
-      DESTROY(pool);
-      return 0;
+      SKIP("cls could not be created")
     }
 
   path = [NSTemporaryDirectory() stringByAppendingPathComponent: @"gsc_ops.ps"];
@@ -233,7 +238,7 @@ main(int argc, const char **argv)
     @"0 0 10 20 2 compositerect", nil]),
     "charpath and the composite operators emit the expected PostScript");
 
-  DESTROY(pool);
+  END_SET("stream operators")
   return 0;
 }
 
@@ -242,6 +247,9 @@ main(int argc, const char **argv)
 int
 main(int argc, const char **argv)
 {
+  START_SET("stream operators")
+    SKIP("back is not built with the cairo graphics backend")
+  END_SET("stream operators")
   return 0;
 }
 

--- a/Tests/winlib/wglcontext.m
+++ b/Tests/winlib/wglcontext.m
@@ -24,7 +24,6 @@ int
 main(void)
 {
   START_SET("win32 WGL OpenGL context")
-  ENTER_POOL
 
   BOOL haveApp = NO;
 
@@ -96,7 +95,6 @@ main(void)
 	"a current WGL context reports a GL version string")
     }
 
-  LEAVE_POOL
   END_SET("win32 WGL OpenGL context")
   return 0;
 }

--- a/Tests/winlib/win32fontenum.m
+++ b/Tests/winlib/win32fontenum.m
@@ -23,7 +23,6 @@ int
 main(void)
 {
   START_SET("win32 font enumeration")
-  ENTER_POOL
 
   GSFontEnumerator *e = nil;
 
@@ -75,7 +74,6 @@ main(void)
       }
     }
 
-  LEAVE_POOL
   END_SET("win32 font enumeration")
   return 0;
 }

--- a/Tests/winlib/win32fontmetrics.m
+++ b/Tests/winlib/win32fontmetrics.m
@@ -31,7 +31,6 @@ int
 main(void)
 {
   START_SET("win32 font metrics")
-  ENTER_POOL
 
   BOOL haveApp = NO;
 
@@ -83,7 +82,6 @@ main(void)
 	"a common glyph is encoded")
     }
 
-  LEAVE_POOL
   END_SET("win32 font metrics")
   return 0;
 }

--- a/Tests/winlib/winlibcapsjoins.m
+++ b/Tests/winlib/winlibcapsjoins.m
@@ -59,7 +59,6 @@ int
 main(void)
 {
   START_SET("winlib line caps and joins")
-  ENTER_POOL
 
   BOOL haveApp = NO;
 
@@ -152,7 +151,6 @@ main(void)
       }
     }
 
-  LEAVE_POOL
   END_SET("winlib line caps and joins")
   return 0;
 }

--- a/Tests/winlib/winlibcomposite.m
+++ b/Tests/winlib/winlibcomposite.m
@@ -72,7 +72,6 @@ int
 main(void)
 {
   START_SET("winlib compositing")
-  ENTER_POOL
 
   BOOL haveApp = NO;
 
@@ -145,7 +144,6 @@ main(void)
 	"compositing an opaque image with source-over paints the image")
     }
 
-  LEAVE_POOL
   END_SET("winlib compositing")
   return 0;
 }

--- a/Tests/winlib/winlibimage.m
+++ b/Tests/winlib/winlibimage.m
@@ -57,7 +57,6 @@ int
 main(void)
 {
   START_SET("winlib image drawing")
-  ENTER_POOL
 
   BOOL haveApp = NO;
 
@@ -126,7 +125,6 @@ main(void)
 	"a 24-bit rgb image without alpha decodes to its colour")
     }
 
-  LEAVE_POOL
   END_SET("winlib image drawing")
   return 0;
 }

--- a/Tests/winlib/winlibimagerotate.m
+++ b/Tests/winlib/winlibimagerotate.m
@@ -54,7 +54,6 @@ int
 main(void)
 {
   START_SET("winlib image rotation")
-  ENTER_POOL
 
   BOOL haveApp = NO;
 
@@ -112,7 +111,6 @@ main(void)
 	"an image drawn under a rotated transform is rotated a quarter turn")
     }
 
-  LEAVE_POOL
   END_SET("winlib image rotation")
   return 0;
 }

--- a/Tests/winlib/winlibrender.m
+++ b/Tests/winlib/winlibrender.m
@@ -60,7 +60,6 @@ int
 main(void)
 {
   START_SET("winlib rendering")
-  ENTER_POOL
 
   BOOL haveApp = NO;
 
@@ -123,7 +122,6 @@ main(void)
 	"outside the bezier rectangle stays red")
     }
 
-  LEAVE_POOL
   END_SET("winlib rendering")
   return 0;
 }

--- a/Tests/winlib/winlibstroke.m
+++ b/Tests/winlib/winlibstroke.m
@@ -56,7 +56,6 @@ int
 main(void)
 {
   START_SET("winlib stroke")
-  ENTER_POOL
 
   BOOL haveApp = NO;
 
@@ -121,7 +120,6 @@ main(void)
 	"the gap after the first dash stays white")
     }
 
-  LEAVE_POOL
   END_SET("winlib stroke")
   return 0;
 }

--- a/Tests/winlib/winlibtext.m
+++ b/Tests/winlib/winlibtext.m
@@ -59,7 +59,6 @@ int
 main(void)
 {
   START_SET("winlib text drawing")
-  ENTER_POOL
 
   BOOL haveApp = NO;
 
@@ -90,7 +89,6 @@ main(void)
 	"a larger point size paints more glyph pixels")
     }
 
-  LEAVE_POOL
   END_SET("winlib text drawing")
   return 0;
 }

--- a/Tests/x11/convert.m
+++ b/Tests/x11/convert.m
@@ -67,8 +67,7 @@ main(void)
   dpy = XOpenDisplay(NULL);
   if (dpy == NULL)
     {
-      NSLog(@"no X display available; skipping RConvertImage round-trip test");
-      return 0;
+      SKIP("no X display available")
     }
 
   memset(&attribs, 0, sizeof(attribs));
@@ -79,7 +78,9 @@ main(void)
   ctx = RCreateContext(dpy, DefaultScreen(dpy), &attribs);
   PASS(ctx != NULL, "RCreateContext succeeds on the display");
   if (ctx == NULL)
-    return 0;
+    {
+      SKIP("no render context could be created")
+    }
 
   trueColor = (ctx->vclass == TrueColor || ctx->vclass == DirectColor);
 

--- a/Tests/x11/rcontext.m
+++ b/Tests/x11/rcontext.m
@@ -58,8 +58,7 @@ main(void)
   dpy = XOpenDisplay(NULL);
   if (dpy == NULL)
     {
-      NSLog(@"no X display available; skipping RCreateContext test");
-      return 0;
+      SKIP("no X display available")
     }
   screen = DefaultScreen(dpy);
 
@@ -67,7 +66,9 @@ main(void)
   ctx = RCreateContext(dpy, screen, NULL);
   PASS(ctx != NULL, "RCreateContext succeeds with default attributes");
   if (ctx == NULL)
-    return 0;
+    {
+      SKIP("no render context could be created")
+    }
 
   PASS(ctx->dpy == dpy, "the context keeps the display it was created for");
   PASS(ctx->screen_number == screen, "the context keeps its screen number");

--- a/Tests/xlib/gsfloor.m
+++ b/Tests/xlib/gsfloor.m
@@ -23,6 +23,8 @@
 
 int main(void)
 {
+  START_SET("GSFloor rounding")
+
   PASS(gs_floor(-0.5) == -1,
        "gs_floor(-0.5) is -1 (rounds down, not toward zero)");
   PASS(gs_floor(-1.5) == -2,
@@ -52,12 +54,16 @@ int main(void)
   PASS(mismatches == 0,
        "gs_floor matches floorf across [-3000, 3000] in steps of 0.25");
 
+  END_SET("GSFloor rounding")
   return 0;
 }
 
 #else
 int main(void)
 {
+  START_SET("GSFloor rounding")
+    SKIP("back is not built with the xlib graphics backend")
+  END_SET("GSFloor rounding")
   return 0;
 }
 #endif


### PR DESCRIPTION
Tests here manage their own autorelease pools. Some open one inside a START_SET, which already makes one; most of the rest have no set at all, so an exception leaves the pool unreleased and the checks that give up early do so with a return.

The redundant inner pools are removed. The tests with no set are wrapped in one and now skip instead of returning, since a return between START_SET and END_SET jumps past the end of the set. That includes the case where the backend cannot start, which used to abort the whole file. The four tests with neither a pool nor a set get one, so they report why they did nothing.

Tests/cairo/gradient.m is left alone because #190 changes it. Two sets could already be left open this way, in x11/convert.m and x11/rcontext.m, so those returns become skips too.

Run on x11 with cairo, art and xlib, on wayland with cairo, and on win32 with winlib, with per-file assertion counts unchanged everywhere: 319 passed on x11 with cairo before and after, 99 passed and 8 failed on winlib before and after. Only skipped sets rise, 24 to 28 on x11 with cairo and 18 to 46 on winlib, being tests that previously reported nothing.
