### PR TITLE
Fix: do not let an exception leave the win32 window procedure

### DIFF
--- a/Source/win32/WIN32Server.m
+++ b/Source/win32/WIN32Server.m
@@ -3058,12 +3058,30 @@ LRESULT CALLBACK MainWndProc(HWND hwnd, UINT uMsg,
 			     WPARAM wParam, LPARAM lParam)
 {
   WIN32Server	*ctxt = (WIN32Server *)GSCurrentServer();
-  
+  LRESULT	result;
+
   if(_enableCallbacks == NO)
     {
       return (LRESULT)NULL;
     }
 
-  return [ctxt windowEventProc: hwnd : uMsg : wParam : lParam];
+  /* Windows calls a window procedure from inside the kernel, and the stack
+   * cannot be unwound back through that call, so an exception must not be
+   * allowed to leave here.  One that does stops the process responding
+   * rather than reporting anything.  Report it instead and answer as we do
+   * for a message we did not handle.
+   */
+  NS_DURING
+    {
+      result = [ctxt windowEventProc: hwnd : uMsg : wParam : lParam];
+    }
+  NS_HANDLER
+    {
+      NSLog(@"Exception handling window message %d: %@", uMsg, localException);
+      result = DefWindowProcW(hwnd, uMsg, wParam, lParam);
+    }
+  NS_ENDHANDLER
+
+  return result;
 }
 


### PR DESCRIPTION
MainWndProc sends every message straight to -windowEventProc:::: and returns what it gives back. Windows calls a window procedure from inside the kernel, and the stack cannot be unwound back through that call, so an exception raised while a message is handled reaches no handler: the process stops responding rather than reporting anything.

The call is now made inside NS_DURING. An exception is logged with the message number and the window procedure answers DefWindowProcW, which is what -windowEventProc:::: itself returns for a message it did not handle.

The case that showed this up is a window ordered front where the home directory does not resolve, so the user's Library search path is empty. ShowWindow delivers WM_ACTIVATEAPP synchronously, reaching -[NSApplication activateIgnoringOtherApps:] and then +[NSWorkspace initialize], which raises NSRangeException from objectAtIndex: on that empty array.

That machine still does not work, and this is not meant to fix it: a later uncaught exception opens the exception panel. There is no automated test, since provoking it needs a home directory that does not resolve.

Verified on a win32 winlib build: the exception is reported and the process continues, where before it hung. Tests/winlib is unchanged at 99 passed and 8 failed.
