### PR TITLE
tests: one GSDisplayServer contract test for every server

### DIFF
--- a/Tests/GNUmakefile
+++ b/Tests/GNUmakefile
@@ -43,12 +43,14 @@ include $(GNUSTEP_MAKEFILES)/common.make
 
 # Backend regression tests use the gnustep-make test framework.  Each backend
 # keeps its tests in a subdirectory named for its Source/ directory (cairo,
-# x11, ...), marked by a TestInfo file.  Discover every such subdirectory and
-# run them all, so a new backend's tests are picked up automatically with no
-# change to this makefile.  Each test additionally guards itself -- in its
-# source (via config.h) and its GNUmakefile.preamble (via config.make) -- on
-# the backend actually built, so 'make check' works for any configuration:
-# tests for backends that are not built skip themselves cleanly.
+# x11, ...), marked by a TestInfo file, and tests that hold for every backend
+# rather than for one of them live in server/.  Discover every such
+# subdirectory and run them all, so a new backend's tests are picked up
+# automatically with no change to this makefile.  A test written for one
+# backend additionally guards itself -- in its source (via config.h) and its
+# GNUmakefile.preamble (via config.make) -- on the backend actually built, so
+# 'make check' works for any configuration: tests for backends that are not
+# built skip themselves cleanly.
 TEST_SUBDIRS := $(sort $(patsubst %/TestInfo,%,$(wildcard */TestInfo)))
 
 all::

--- a/Tests/server/GNUmakefile.preamble
+++ b/Tests/server/GNUmakefile.preamble
@@ -1,0 +1,5 @@
+# Extra build settings for the generic display server tests.
+
+# The tests drive the server through the GSDisplayServer interface, which the
+# gui library declares, so they link it whichever backend is built.
+ADDITIONAL_TOOL_LIBS += -lgnustep-gui

--- a/Tests/server/servercontract.m
+++ b/Tests/server/servercontract.m
@@ -1,0 +1,268 @@
+/* The GSDisplayServer contract, checked against whichever display server the
+ * backend was built with.
+ *
+ * Every server answers the same questions about its screens, its windows and
+ * the pointer, so this is written once here rather than once per server: it
+ * takes the current server, asks only what the interface promises, and skips
+ * when no server can be reached.  Where servers legitimately differ the check
+ * is written as the contract rather than as one server's answer -- window
+ * decorations are the example, since a server that does not draw them reports
+ * no insets, while one that does reports insets that are not negative.
+ */
+#import <Foundation/Foundation.h>
+#import "Testing.h"
+
+#import <AppKit/AppKit.h>
+#import <GNUstepGUI/GSDisplayServer.h>
+
+int
+main(void)
+{
+  START_SET("display server contract")
+
+  GSDisplayServer *server = nil;
+  NSArray *screens;
+  unsigned count;
+  unsigned i;
+  BOOL ok;
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+      server = GSCurrentServer();
+      if (nil == server)
+	{
+	  server = [GSDisplayServer serverWithAttributes: nil];
+	}
+    }
+  NS_HANDLER
+    {
+      server = nil;
+    }
+  NS_ENDHANDLER
+
+  if (nil == server)
+    {
+      SKIP("no display server available")
+    }
+
+  screens = [server screenList];
+  count = [screens count];
+  if (0 == count)
+    {
+      SKIP("the display server reports no screen")
+    }
+
+  /* A server that does not implement the screen queries has nothing here to
+   * answer for; ask it one and skip the set when it refuses. */
+  ok = YES;
+  NS_DURING
+    {
+      (void)[server availableDepthsForScreen:
+	[[screens objectAtIndex: 0] intValue]];
+    }
+  NS_HANDLER
+    {
+      ok = NO;
+    }
+  NS_ENDHANDLER
+  if (NO == ok)
+    {
+      SKIP("the display server does not implement the screen queries")
+    }
+
+  /* ---- screens ---- */
+
+  PASS(count > 0, "screenList returns at least one screen")
+
+  ok = YES;
+  for (i = 0; i < count; i++)
+    {
+      if (![[screens objectAtIndex: i] isKindOfClass: [NSNumber class]])
+	{
+	  ok = NO;
+	}
+    }
+  PASS(ok == YES, "screenList holds NSNumber screen identifiers")
+
+  /* A listed screen has an extent. */
+  ok = YES;
+  for (i = 0; i < count; i++)
+    {
+      NSRect b = [server boundsForScreen: [[screens objectAtIndex: i] intValue]];
+
+      if (b.size.width <= 0.0 || b.size.height <= 0.0)
+	{
+	  ok = NO;
+	}
+    }
+  PASS(ok == YES, "boundsForScreen: reports a positive size for every screen")
+
+  /* Asking twice gives the same answer. */
+  {
+    int s = [[screens objectAtIndex: 0] intValue];
+
+    PASS(NSEqualRects([server boundsForScreen: s],
+                      [server boundsForScreen: s]) == YES,
+      "boundsForScreen: is stable across repeated queries")
+  }
+
+  /* A screen that is not there has no bounds, whichever way it is named. */
+  PASS(NSEqualRects([server boundsForScreen: 999999], NSZeroRect) == YES,
+    "boundsForScreen: returns NSZeroRect for a screen that is not present")
+  PASS(NSEqualRects([server boundsForScreen: -1], NSZeroRect) == YES,
+    "boundsForScreen: returns NSZeroRect for a negative screen number")
+
+  /* Every screen has an RGB depth. */
+  ok = YES;
+  for (i = 0; i < count; i++)
+    {
+      NSWindowDepth d
+	= [server windowDepthForScreen: [[screens objectAtIndex: i] intValue]];
+
+      if (NSBitsPerSampleFromDepth(d) <= 0
+	|| NSNumberOfColorComponents(NSColorSpaceFromDepth(d)) != 3)
+	{
+	  ok = NO;
+	}
+    }
+  PASS(ok == YES, "windowDepthForScreen: reports an RGB window depth")
+
+  /* The depth list is zero-terminated and holds the screen's own depth. */
+  {
+    int s = [[screens objectAtIndex: 0] intValue];
+    NSWindowDepth want = [server windowDepthForScreen: s];
+    const NSWindowDepth *depths = [server availableDepthsForScreen: s];
+    BOOL terminated = NO;
+    BOOL found = NO;
+    int j;
+
+    PASS(depths != NULL, "availableDepthsForScreen: returns a depth list")
+    if (depths != NULL)
+      {
+	for (j = 0; j < 64; j++)
+	  {
+	    if (0 == depths[j])
+	      {
+		terminated = YES;
+		break;
+	      }
+	    if (depths[j] == want)
+	      {
+		found = YES;
+	      }
+	  }
+      }
+    PASS(terminated == YES, "availableDepthsForScreen: list is zero-terminated")
+    PASS(found == YES,
+      "availableDepthsForScreen: list includes the screen depth")
+  }
+
+  /* ---- windows ---- */
+
+  {
+    int s = [[screens objectAtIndex: 0] intValue];
+    NSRect frame = NSMakeRect(100, 100, 200, 150);
+    int win;
+    int win2;
+
+    win = [server window: frame
+			 : NSBackingStoreBuffered
+			 : NSTitledWindowMask
+			 : s];
+    PASS(win > 0, "window:::: returns a positive window number")
+
+    win2 = [server window: frame
+			  : NSBackingStoreBuffered
+			  : NSTitledWindowMask
+			  : s];
+    PASS(win2 > 0 && win2 != win, "a second window gets a distinct number")
+
+    /* The size asked for is the size reported.  The origin is not checked:
+     * a server that cannot place its own windows is free to put it
+     * elsewhere. */
+    {
+      NSRect b = [server windowbounds: win];
+
+      PASS(b.size.width == frame.size.width
+	&& b.size.height == frame.size.height,
+	"windowbounds: reports the requested size")
+      PASS(NSEqualRects(b, [server windowbounds: win]) == YES,
+	"windowbounds: is stable across repeated queries")
+    }
+
+    /* The level set is the level read back. */
+    [server setwindowlevel: NSFloatingWindowLevel : win];
+    PASS([server windowlevel: win] == NSFloatingWindowLevel,
+      "windowlevel: reads back a set floating level")
+    [server setwindowlevel: NSNormalWindowLevel : win];
+    PASS([server windowlevel: win] == NSNormalWindowLevel,
+      "windowlevel: reads back a set normal level")
+
+    /* Decoration insets are never negative, and a server that does not draw
+     * decorations reports none at all. */
+    {
+      float l = -1.0, r = -1.0, t = -1.0, b = -1.0;
+
+      [server styleoffsets: &l : &r : &t : &b : NSTitledWindowMask];
+      PASS(l >= 0.0 && r >= 0.0 && t >= 0.0 && b >= 0.0,
+	"styleoffsets::::: reports insets that are not negative")
+      if (NO == [server handlesWindowDecorations])
+	{
+	  PASS(l == 0.0 && r == 0.0 && t == 0.0 && b == 0.0,
+	    "styleoffsets::::: reports no insets when the server does not"
+	    " decorate")
+	}
+    }
+
+    /* A window asked for with no area still has an extent. */
+    {
+      int z = [server window: NSMakeRect(0, 0, 0, 0)
+			    : NSBackingStoreBuffered
+			    : NSTitledWindowMask
+			    : s];
+      NSRect zb = [server windowbounds: z];
+
+      PASS(zb.size.width > 0.0 && zb.size.height > 0.0,
+	"a zero-area frame yields a window with a positive size")
+      [server termwindow: z];
+    }
+
+    /* A window number the server does not know has no level and no bounds,
+     * and is not an error to ask about. */
+    PASS([server windowlevel: 999999] == 0,
+      "windowlevel: on an unknown window number returns 0")
+    PASS(NSEqualRects([server windowbounds: 999999], NSZeroRect) == YES,
+      "windowbounds: on an unknown window number returns NSZeroRect")
+    PASS_RUNS(({
+	[server setwindowlevel: NSNormalWindowLevel : 999999];
+	[server windowdevice: 999999];
+	[server termwindow: 999999];
+      }),
+      "window operations on an unknown window number do not raise")
+
+    [server termwindow: win2];
+    [server termwindow: win];
+  }
+
+  /* ---- pointer ---- */
+
+  {
+    int s = [[screens objectAtIndex: 0] intValue];
+    NSRect b = [server boundsForScreen: s];
+    NSPoint p = [server mouselocation];
+    int onWin = 0;
+    NSPoint q = [server mouseLocationOnScreen: s window: &onWin];
+
+    PASS(p.x >= 0.0 && p.y >= 0.0
+      && p.x <= b.size.width && p.y <= b.size.height,
+      "mouselocation reports a point on the screen")
+    PASS(q.x >= 0.0 && q.y >= 0.0
+      && q.x <= b.size.width && q.y <= b.size.height,
+      "mouseLocationOnScreen:window: reports a point on the screen")
+  }
+
+  END_SET("display server contract")
+
+  return 0;
+}


### PR DESCRIPTION
The third rule in #167: the same GSDisplayServer questions are asked once per server, in each backend's own directory, so every set of them runs against one server only. This is one test of the interface, in a new Tests/server/, with no build guard: it takes the current server, asks what the interface promises, and skips when there is none.

Screens (the list, the identifiers, bounds and their stability, an absent or negative screen, the window depth and the depth list), windows (a positive and unique number, the size reported back, the level round-trip, decoration insets, a zero-area frame, and an unknown window number) and the pointer.

Where servers differ legitimately the check is written as the contract rather than as one server's answer: insets are never negative, and a server that does not draw decorations reports none.

x11 with cairo, art, xlib and opal all pass 23 of 23, wayland 24 of 24 (it takes the undecorated branch as well). Headless skips: HeadlessServer does not override -availableDepthsForScreen: and raises, so the set asks it first and skips when it refuses.

win32 fails one: -windowbounds: on an unknown window number. WIN32Server.m calls GetWindowRect without checking whether it failed, so the RECT is left uninitialised and the answer is whatever was on the stack.

The suite goes 319 passed in 65 binaries to 342 in 66, with the skipped sets unchanged and no failed builds. The per-server copies are not removed here.
