### PR TITLE
Fix: answer NSZeroRect for a window number that is not a window

### DIFF
--- a/Source/win32/WIN32Server.m
+++ b/Source/win32/WIN32Server.m
@@ -2089,7 +2089,13 @@ LRESULT CALLBACK windowEnumCallback(HWND hwnd, LPARAM lParam)
 {
   RECT r;
 
-  GetWindowRect((HWND)winNum, &r);
+  /* A window number that is not a window leaves the rectangle unwritten, so
+   * without this it is whatever the stack held that gets converted and
+   * returned as the window's bounds. */
+  if (!GetWindowRect((HWND)winNum, &r))
+    {
+      return NSZeroRect;
+    }
   return MSScreenRectToGS(r);
 }
 


### PR DESCRIPTION
Closes #196.

`-[WIN32Server windowbounds:]` called GetWindowRect without checking whether it succeeded. It does not write the rectangle when it fails, so a window number that is not a window was answered with whatever the stack held, converted through MSScreenRectToGS as if it were a frame. Measured before the change: a real window reported {100, 100, 200, 150} and every unknown number reported {-2.13744e+09, -31799, 29460, 0}, while the same handle after termwindow: reported {0, 960, 0, 0}.

It now answers NSZeroRect when the call fails, which is what XGServer and WaylandServer already answer for a window they do not know.

The two other unchecked GetWindowRect calls are left alone: in -placewindow:: the rectangle decides whether the winlib backing bitmap is rebuilt, and in the findWindowAt: enumeration callback it is passed to PtInRect. Both are reached with a handle that came from elsewhere and neither has a case that provokes it, so there is nothing here to show they are wrong.

The assertion that fails without this is in #195, which is the test side of the same thing.

Measured on win32 with UCRT64, whole suite before and after: 136 passed with 1 failed, then 137 passed with none, the skipped sets unchanged at 18. The one assertion that moves is the unknown window number; nothing else in art, cairo, gsc, server, winlib, x11 or xlib changes.
