### PR TITLE
Fix: composite a rect with the colour that was set on the xlib backend

### DIFF
--- a/Source/xlib/XGGState.m
+++ b/Source/xlib/XGGState.m
@@ -780,13 +780,8 @@ static Region emptyRegion;
 - (void) compositerect: (NSRect)aRect
                     op: (NSCompositingOperation)op
 {
-  CGFloat gray;
-
-  [self DPScurrentgray: &gray];
-  if (fabs(gray - 0.667) < 0.005)
-    [self DPSsetgray: 0.333];
-  else    
-    [self DPSsetrgbcolor: 0.121 : 0.121 : 0];
+  CGFloat gray = 0.0;
+  BOOL    highlight = NO;
 
   /* FIXME: Really need alpha dithering to do this right - combine with
      XGBitmapImageRep code? */
@@ -812,15 +807,15 @@ static Region emptyRegion;
       gcv.function = GXcopy;
       break;
     case NSCompositeDestinationOver:
-      gcv.function = GXcopy;
-      break;
     case NSCompositeDestinationIn:
+    case NSCompositeDestinationAtop:
+      /* An opaque destination admits nothing of the source, so it stands as
+         it is. */
+      if (drawingAlpha == NO)
+        return;
       gcv.function = GXcopy;
       break;
     case NSCompositeDestinationOut:
-      gcv.function = GXcopy;
-      break;
-    case NSCompositeDestinationAtop:
       gcv.function = GXcopy;
       break;
     case NSCompositeXOR:
@@ -830,17 +825,30 @@ static Region emptyRegion;
       gcv.function = GXcopy;
       break;
     case GSCompositeHighlight:
+      highlight = YES;
       gcv.function = GXxor;
       break;
     case NSCompositePlusLighter:
-      gcv.function = GXcopy;
+      /* X has no addition, so the nearest a core drawable offers is a
+         bitwise or of the two pixel values. */
+      gcv.function = GXor;
       break;
     default:
       gcv.function = GXcopy;
       break;
     }
+
+  if (highlight)
+    {
+      [self DPScurrentgray: &gray];
+      if (fabs(gray - 0.667) < 0.005)
+        [self DPSsetgray: 0.333];
+      else
+        [self DPSsetrgbcolor: 0.121 : 0.121 : 0];
+    }
+
   [self setGCValues: gcv withMask: GCFunction];
-  [self DPSrectfill: NSMinX(aRect) : NSMinY(aRect) 
+  [self DPSrectfill: NSMinX(aRect) : NSMinY(aRect)
         : NSWidth(aRect) : NSHeight(aRect)];
 
   if (gcv.function != GXcopy)
@@ -848,7 +856,10 @@ static Region emptyRegion;
       gcv.function = GXcopy;
       [self setGCValues: gcv withMask: GCFunction];
     }
-  [self DPSsetgray: gray];
+  if (highlight)
+    {
+      [self DPSsetgray: gray];
+    }
 }
 
 /* Paint the current path using Xlib calls. All coordinates should already


### PR DESCRIPTION
-compositerect:op: in the xlib backend replaces the current colour with a fixed dark grey before painting anything, so a rectangle composited with any operation comes out that grey rather than the colour that was set. Destination over paints the source over a destination that admits none of it, and plus lighter is a plain copy.

The grey now applies only to the highlight case it came from. Destination over, destination in and destination atop return without drawing when the destination has no alpha. Plus lighter uses a bitwise or, which is as close to addition as a core X drawable gets.

The half transparent fill also named in #188 is not addressed here. The xlib backend keeps colour and alpha in separate drawables and does not blend them when it fills, so that one needs a change of a different size.

The test is Tests/gui/NSGraphicsContext/compositeOperators.m in libs-gui, run against a backend configured --enable-graphics=xlib.

Four of its five assertions fail before the change and none after. The five gui drawing and font directories go from 965 passed and 14 failed to 969 and 10, with no other assertion moving, and this repository's own suite reports 118 passed and 43 skipped sets either way.
