### PR TITLE
Fix: compositing, shadows, image scaling and font metrics on the opal backend

### DIFF
--- a/Source/opal/OpalFontInfo.m
+++ b/Source/opal/OpalFontInfo.m
@@ -81,7 +81,9 @@
     }
 
   ascender = [self _fontUnitToUserSpace: CGFontGetAscent(face)];
-  descender = [self _fontUnitToUserSpace: CGFontGetDescent(face)];
+  /* Opal reports the descent as a distance below the baseline, while a font's
+     descender is the signed offset from it. */
+  descender = -[self _fontUnitToUserSpace: CGFontGetDescent(face)];
   xHeight = [self _fontUnitToUserSpace: CGFontGetXHeight(face)];
 
   CGFloat pointSize = matrix[0];
@@ -108,7 +110,7 @@
   //   lineHeight = font_extents.height
   // alternatively: line spacing = (ascent + descent + "external leading")
   // (internal discussion between ivucica and ericwa, 2013-09-17)
-  lineHeight = leading + ascender + descender;
+  lineHeight = leading + ascender - descender;
 
 #if 0
   // Get default font options
@@ -326,18 +328,17 @@ BOOL _cairo_extents_for_NSGlyph(cairo_scaled_font_t *scaled_font, NSGlyph glyph,
 
 - (NSRect) boundingRectForGlyph: (NSGlyph)glyph
 {
-  // Use glyph advance as approximation for bounding rect
   CGGlyph cgGlyph = (CGGlyph)glyph;
-  int advance = 0;
+  CGRect bbox;
+
   if (_faceInfo && [_faceInfo fontFace])
     {
-      CGFontGetGlyphAdvances([_faceInfo fontFace], &cgGlyph, 1, &advance);
-      int unitsPerEm = CGFontGetUnitsPerEm([_faceInfo fontFace]);
-      if (unitsPerEm > 0)
+      if (CGFontGetGlyphBBoxes([_faceInfo fontFace], &cgGlyph, 1, &bbox))
         {
-          CGFloat scale = matrix[0] / (CGFloat)unitsPerEm;
-          CGFloat w = advance * scale;
-          return NSMakeRect(0, descender, w, ascender - descender);
+          return NSMakeRect([self _fontUnitToUserSpace: bbox.origin.x],
+                            [self _fontUnitToUserSpace: bbox.origin.y],
+                            [self _fontUnitToUserSpace: bbox.size.width],
+                            [self _fontUnitToUserSpace: bbox.size.height]);
         }
     }
   return NSMakeRect(0, descender, matrix[0] * 0.6, ascender - descender);

--- a/Source/opal/OpalGState.m
+++ b/Source/opal/OpalGState.m
@@ -33,6 +33,7 @@
 #import <AppKit/NSColor.h>
 #import <AppKit/NSGradient.h>
 #import <AppKit/NSColor.h>
+#import <AppKit/NSShadow.h>
 #import "opal/OpalGState.h"
 #import "opal/OpalSurface.h"
 #import "opal/OpalFontInfo.h"
@@ -80,6 +81,19 @@ _opalBlendModeForOp(NSCompositingOperation op)
       case NSCompositePlusDarker:      return kCGBlendModePlusDarker;
       case NSCompositePlusLighter:     return kCGBlendModePlusLighter;
       default:                         return kCGBlendModeNormal;
+    }
+}
+
+static CGInterpolationQuality
+_opalInterpolationForImageInterpolation(NSImageInterpolation interpolation)
+{
+  switch (interpolation)
+    {
+      case NSImageInterpolationNone: return kCGInterpolationNone;
+      case NSImageInterpolationLow:  return kCGInterpolationLow;
+      case NSImageInterpolationHigh: return kCGInterpolationHigh;
+      case NSImageInterpolationDefault:
+      default:                       return kCGInterpolationDefault;
     }
 }
 
@@ -549,6 +563,64 @@ _opalBlendModeForOp(NSCompositingOperation op)
   [super DPSnewpath];
 }
 
+/* Renders the current path offset by the active shadow, in the shadow colour,
+   before the path itself is drawn. Blur is not applied. Painting consumes the
+   context's path, so it is taken and put back around the shadow. */
+- (void) _drawShadowForOperation: (ctxt_object_t)drawType
+{
+  CGContextRef cgctx = CGCTX;
+  NSColor *shadowColor;
+  NSSize soffset;
+  CGPathRef saved;
+  CGFloat r, g, b, a;
+
+  if (_shadow == nil || cgctx == NULL)
+    {
+      return;
+    }
+  shadowColor = [[_shadow shadowColor]
+    colorUsingColorSpaceName: NSDeviceRGBColorSpace];
+  if (shadowColor == nil)
+    {
+      return;
+    }
+  [shadowColor getRed: &r green: &g blue: &b alpha: &a];
+  soffset = [_shadow shadowOffset];
+
+  saved = CGContextCopyPath(cgctx);
+  if (saved == NULL)
+    {
+      return;
+    }
+
+  CGContextSaveGState(cgctx);
+  CGContextTranslateCTM(cgctx, soffset.width, soffset.height);
+  CGContextBeginPath(cgctx);
+  CGContextAddPath(cgctx, saved);
+  if (drawType == path_stroke)
+    {
+      CGContextSetRGBStrokeColor(cgctx, r, g, b, a);
+      CGContextStrokePath(cgctx);
+    }
+  else
+    {
+      CGContextSetRGBFillColor(cgctx, r, g, b, a);
+      if (drawType == path_eofill)
+        {
+          CGContextEOFillPath(cgctx);
+        }
+      else
+        {
+          CGContextFillPath(cgctx);
+        }
+    }
+  CGContextRestoreGState(cgctx);
+
+  CGContextBeginPath(cgctx);
+  CGContextAddPath(cgctx, saved);
+  CGPathRelease(saved);
+}
+
 - (void) DPSeofill
 {
   NSDebugLLog(@"OpalGState", @"%p (%@): %s", self, [self class], __PRETTY_FUNCTION__);
@@ -556,6 +628,7 @@ _opalBlendModeForOp(NSCompositingOperation op)
 
   if (cgctx)
     {
+      [self _drawShadowForOperation: path_eofill];
       CGContextEOFillPath(cgctx);
     }
   [super DPSnewpath];
@@ -568,6 +641,7 @@ _opalBlendModeForOp(NSCompositingOperation op)
 
   if (cgctx)
     {
+      [self _drawShadowForOperation: path_fill];
       CGContextFillPath(cgctx);
     }
   [super DPSnewpath];
@@ -717,6 +791,7 @@ _opalBlendModeForOp(NSCompositingOperation op)
 
   if (cgctx)
     {
+      [self _drawShadowForOperation: path_stroke];
       CGContextStrokePath(cgctx);
     }
   [super DPSnewpath];
@@ -892,6 +967,8 @@ _opalBlendModeForOp(NSCompositingOperation op)
 
       CGContextSaveGState(cgctx);
       CGContextConcatCTM(cgctx, cgAT);
+      CGContextSetInterpolationQuality(cgctx,
+        _opalInterpolationForImageInterpolation([drawcontext imageInterpolation]));
 
       CGColorSpaceRef colorSpace = CGColorSpaceCreateWithName(colorSpaceName);
       NSData *nsData = [NSData dataWithBytesNoCopy: (void*)*data
@@ -953,6 +1030,8 @@ _opalBlendModeForOp(NSCompositingOperation op)
   // Apply compositing operation and alpha
   CGContextSetBlendMode(destCGContext, _opalBlendModeForOp(op));
   CGContextSetAlpha(destCGContext, delta);
+  CGContextSetInterpolationQuality(destCGContext,
+    _opalInterpolationForImageInterpolation([drawcontext imageInterpolation]));
   CGContextDrawImage(destCGContext, destCGRect, subImage);
 
   OPContextSetCairoDeviceOffset(CGCTX, -offset.x,
@@ -1024,6 +1103,8 @@ doesn't support to use the receiver cairo target as the source. */
   CGContextSaveGState(destCGContext);
   CGContextSetBlendMode(destCGContext, _opalBlendModeForOp(op));
   CGContextSetAlpha(destCGContext, delta);
+  CGContextSetInterpolationQuality(destCGContext,
+    _opalInterpolationForImageInterpolation([drawcontext imageInterpolation]));
   CGContextDrawImage(destCGContext, destCGRect, subImage);
   CGContextRestoreGState(destCGContext);
   CGImageRelease(subImage);
@@ -1066,7 +1147,8 @@ doesn't support to use the receiver cairo target as the source. */
       CGContextSetBlendMode(cgctx, _opalBlendModeForOp(op));
       CGContextFillRect(cgctx,
                         CGRectMake(aRect.origin.x,
-                                   [_opalSurface size].height -  aRect.origin.y,
+                                   [_opalSurface size].height - aRect.origin.y
+                                     - aRect.size.height,
                                    aRect.size.width, aRect.size.height));
       CGContextRestoreGState(cgctx);
     }


### PR DESCRIPTION
On the opal backend a rectangle composited with any operation was painted one height above where it belonged, so for a rectangle covering the surface nothing was painted at all. A shape drawn with a shadow set on the context cast none, because fill, even-odd fill and stroke went straight to the context and never reached a shadow step. The image interpolation set on the graphics context never reached the drawing context. A font's descender came out positive, and the bounding rectangle of a glyph was its advancement stretched from descender to ascender rather than an ink box.

The flip now allows for the height, the three path operations paint the context's own path offset in the shadow colour first, the interpolation is passed at each point an image is drawn, the descent is negated to give a signed descender, and Opal's own per-glyph bounding box is used.

The interpolation half needs gnustep/libs-opal#58, which also carries the blend mode and transform fixes the compositing and rotation assertions need.

The tests are Tests/gui/NSGraphicsContext, NSBezierPath, NSImage, NSShadow and NSFont in libs-gui, run against a backend configured --enable-graphics=opal.

Those five directories go from 967 passed and 12 failed to 979 passed and none failed, and this repository's own suite reports 111 passed and 44 skipped sets either way.
