### PR TITLE
Fix: composite a rect with clear, destination over and plus lighter on the winlib backend

### DIFF
--- a/Source/winlib/WIN32GState.m
+++ b/Source/winlib/WIN32GState.m
@@ -414,6 +414,29 @@ BOOL alpha_blend_source_over(HDC destDC,
   switch (op)
     {
       case   NSCompositeClear:
+	{
+	  HDC hDC;
+	  RECT rect = GSViewRectToWin(self, aRect);
+
+	  hDC = [self getHDC];
+	  if (!hDC)
+	    {
+	      return;
+	    }
+
+	  PatBlt(hDC, rect.left, rect.top, rect.right - rect.left,
+		 rect.bottom - rect.top, BLACKNESS);
+	  [self releaseHDC: hDC];
+	  break;
+	}
+      case   NSCompositeDestinationOver:
+      case   NSCompositeDestinationIn:
+      case   NSCompositeDestinationAtop:
+	/* A GDI surface carries no alpha of its own, so the destination admits
+	   nothing of the source and stands as it is. */
+	break;
+      case   NSCompositePlusLighter:
+	[self _orRect: aRect];
 	break;
       case   GSCompositeHighlight:
 	{
@@ -437,13 +460,9 @@ BOOL alpha_blend_source_over(HDC destDC,
       case   NSCompositeSourceIn:
       case   NSCompositeSourceOut:
       case   NSCompositeSourceAtop:
-      case   NSCompositeDestinationOver:
-      case   NSCompositeDestinationIn:
       case   NSCompositeDestinationOut:
-      case   NSCompositeDestinationAtop:
       case   NSCompositeXOR:
       case   NSCompositePlusDarker:
-      case   NSCompositePlusLighter:
       default:
 	if ((op == NSCompositeSourceOver) && (fillColor.field[AINDEX] < 1.0))
 	  {
@@ -456,6 +475,54 @@ BOOL alpha_blend_source_over(HDC destDC,
 	  }
 	break;
     }
+}
+
+/* Add the fill colour to what is already there. GDI has no addition, so the
+   colour goes on a bitmap of its own and is combined from there with a
+   bitwise or, which is as close as a raster operation gets. */
+- (void) _orRect: (NSRect)aRect
+{
+  RECT   rect = GSViewRectToWin(self, aRect);
+  int    w = rect.right - rect.left;
+  int    h = rect.bottom - rect.top;
+  HDC    hDC;
+  HDC    memDC;
+  HBITMAP bitmap;
+  HGDIOBJ old;
+  HBRUSH brush;
+  RECT   from = { 0, 0, w, h };
+
+  if (w <= 0 || h <= 0)
+    {
+      return;
+    }
+
+  hDC = [self getHDC];
+  if (!hDC)
+    {
+      return;
+    }
+
+  memDC = CreateCompatibleDC(hDC);
+  if (memDC)
+    {
+      bitmap = CreateCompatibleBitmap(hDC, w, h);
+      if (bitmap)
+	{
+	  old = SelectObject(memDC, bitmap);
+	  brush = CreateSolidBrush(wfcolor);
+	  FillRect(memDC, &from, brush);
+	  DeleteObject(brush);
+
+	  BitBlt(hDC, rect.left, rect.top, w, h, memDC, 0, 0, SRCPAINT);
+
+	  SelectObject(memDC, old);
+	  DeleteObject(bitmap);
+	}
+      DeleteDC(memDC);
+    }
+
+  [self releaseHDC: hDC];
 }
 
 /* Paint a rectangle of the fill colour over what is already there, letting


### PR DESCRIPTION
On the winlib backend -compositerect:op: made clear a no-op, so a rectangle composited with it kept whatever was underneath, and it let destination over and plus lighter fall through to a plain fill, so both painted the source over the destination.

Clear now blacks the rectangle out, which is what a GDI surface carrying no alpha of its own can express. Destination over, destination in and destination atop leave an opaque destination as it is. Plus lighter puts the colour on a bitmap of its own and combines it with a bitwise or, GDI having no addition.

The bitwise or is an approximation: it is exact for the primaries and low for two partial values that should saturate. The xlib backend makes the same one in gnustep/libs-back#199.

The test is Tests/gui/NSGraphicsContext/compositeOperators.m in libs-gui, run on Windows against a backend configured --enable-graphics=winlib.

Three of its five assertions fail before the change and none after. The five gui drawing and font directories go from 973 passed and 6 failed to 976 and 3, the three left being two pre-existing NSImage/customImageRep failures and a half-transparent image blend, and this repository's own suite is unchanged.
