### PR TITLE
Fix: clip to a path of more than one subpath as one region on the xlib backend

### DIFF
--- a/Source/xlib/XGGState.m
+++ b/Source/xlib/XGGState.m
@@ -922,24 +922,88 @@ static Region emptyRegion;
     }
 }
 
+/* Clip to a path of more than one subpath. X has no polygon with a hole in it,
+   so each subpath becomes a region of its own and they are combined: an
+   even-odd clip takes their symmetric difference, a non-zero clip their union.
+   Clipping to each subpath in turn would intersect them, which leaves a ring
+   admitting only its hole. */
+- (void) _doComplexClip: (XPoint*)pts
+                       : (int*)types
+                       : (int)count
+                   draw: (ctxt_object_t)type
+{
+  Region total = XCreateRegion();
+  int    start = 0;
+  int    i;
+
+  for (i = 1; i <= count; i++)
+    {
+      if (i == count || types[i] == 0)
+        {
+          int n = i - start;
+
+          if (n > 2)
+            {
+              Region sub = XPolygonRegion(&pts[start], n,
+                (type == path_eoclip) ? EvenOddRule : WindingRule);
+              Region combined = XCreateRegion();
+
+              if (type == path_eoclip)
+                {
+                  XXorRegion(total, sub, combined);
+                }
+              else
+                {
+                  XUnionRegion(total, sub, combined);
+                }
+              XDestroyRegion(sub);
+              XDestroyRegion(total);
+              total = combined;
+            }
+          start = i;
+        }
+    }
+
+  if (clipregion)
+    {
+      Region new_region = XCreateRegion();
+
+      XIntersectRegion(clipregion, total, new_region);
+      XDestroyRegion(total);
+      XDestroyRegion(clipregion);
+      clipregion = new_region;
+    }
+  else
+    {
+      clipregion = total;
+    }
+  [self setClipMask];
+}
+
 /* fill a complex path. All coordinates should already have been
    transformed to device coordinates. */
-- (void) _doComplexPath: (XPoint*)pts 
-                       : (int*)types 
+- (void) _doComplexPath: (XPoint*)pts
+                       : (int*)types
                        : (int)count
-                     ll: (XPoint)ll 
-                     ur: (XPoint)ur 
+                     ll: (XPoint)ll
+                     ur: (XPoint)ur
                    draw: (ctxt_object_t)type
 {
   int x, y, i, j, cnt, nseg = 0;
   XSegment segments[count];
   Window root_rtn;
   unsigned int width, height, b_rtn, d_rtn;
-  
+
   COPY_GC_ON_CHANGE;
   if (draw == 0)
     {
       DPS_WARN (DPSinvalidid, @"No Drawable defined for path");
+      return;
+    }
+
+  if (type == path_clip || type == path_eoclip)
+    {
+      [self _doComplexClip: pts : types : count draw: type];
       return;
     }
 
@@ -1099,7 +1163,7 @@ static Region emptyRegion;
           switch(type) 
             {
             case NSMoveToBezierPathElement:
-              if (drawType != path_eofill && drawType != path_fill)
+              if (drawType == path_stroke)
                 {
                   if (i > 1)
                     {
@@ -1138,7 +1202,7 @@ static Region emptyRegion;
               p = last_p;
               ts[i] = 1;
 //              doit = YES;
-              if (drawType != path_eofill && drawType != path_fill)
+              if (drawType == path_stroke)
                 {
                   doit = YES;
                 }


### PR DESCRIPTION
Clipping to a path on the xlib backend emitted each subpath as it was reached and intersected the result with the clip already in place. A ring was therefore clipped to its outer boundary and then to its inner one, so what the clip admitted was the hole rather than the ring, and any drawing in the ring was lost.

A clip is now gathered the way a fill already is, and the subpaths are combined into one region before it is applied: an even-odd clip takes their symmetric difference and a non-zero clip their union, since X has no polygon with a hole in it. A stroke still goes out subpath by subpath, as it draws rather than building a region.

The union stands in for a non-zero clip whose subpaths wind in opposite directions, which region algebra cannot express. Nothing in these tests covers that, and it is closer than the intersection was.

The tests are Tests/gui/NSGraphicsContext/clipping.m and Tests/gui/NSBezierPath/drawingWindingRule.m in libs-gui, run against a backend configured --enable-graphics=xlib.

Four assertions fail before the change and none after. The five gui drawing and font directories go from 965 passed and 14 failed to 969 and 10, with no other assertion moving, and this repository's own suite is unchanged.

Closes #189
