### PR TITLE
Fix: do not probe for window offsets when no window manager is running

### DIFF
--- a/Source/x11/XGServerWindow.m
+++ b/Source/x11/XGServerWindow.m
@@ -791,6 +791,53 @@ _get_next_prop_new_event(Display *display, XEvent *event, char *arg)
   return extents;
 }
 
+static BOOL	wmTestFailed;
+
+static int
+_wmTestErrorHandler(Display *display, XErrorEvent *event)
+{
+  if (event->error_code == BadAccess)
+    {
+      wmTestFailed = YES;
+    }
+  return 0;
+}
+
+/* Is there no window manager running at all?  Only one client at a time may
+   select SubstructureRedirect on the root window and a window manager always
+   does, so being allowed to select it means there is none.  It is given back
+   immediately.  The answer is worked out once.
+*/
+- (BOOL) _noWindowManager
+{
+  static BOOL	checked = NO;
+  static BOOL	none = NO;
+
+  if (checked == NO)
+    {
+      Window		root = DefaultRootWindow(dpy);
+      XWindowAttributes	attributes;
+      int		(*previous)(Display *, XErrorEvent *);
+
+      checked = YES;
+      wmTestFailed = NO;
+      XGetWindowAttributes(dpy, root, &attributes);
+      XSync(dpy, False);
+      previous = XSetErrorHandler(_wmTestErrorHandler);
+      XSelectInput(dpy, root,
+                   attributes.your_event_mask | SubstructureRedirectMask);
+      XSync(dpy, False);
+      XSetErrorHandler(previous);
+      if (wmTestFailed == NO)
+        {
+          XSelectInput(dpy, root, attributes.your_event_mask);
+          XSync(dpy, False);
+          none = YES;
+        }
+    }
+  return none;
+}
+
 - (BOOL) _checkStyle: (unsigned)style
 {
   gswindow_device_t	*window;
@@ -1640,7 +1687,23 @@ _get_next_prop_new_event(Display *display, XEvent *event, char *arg)
 	    XA_CARDINAL, 16, 60, &count);
         }
 
-      if (offsets == 0)
+      if (offsets == 0 && [self _noWindowManager] == YES)
+        {
+          /* Nothing is decorating our windows, so every style has zero
+           * offsets and there is nothing to test for.  They are not stored
+           * on the root window, where a window manager started later would
+           * find them and use them in place of its own.
+           */
+          for (i = 1; i < 16; i++)
+            {
+              generic.offsets[i].l = 0.0;
+              generic.offsets[i].r = 0.0;
+              generic.offsets[i].t = 0.0;
+              generic.offsets[i].b = 0.0;
+              generic.offsets[i].known = YES;
+            }
+        }
+      else if (offsets == 0)
         {
           BOOL	ok = YES;
 


### PR DESCRIPTION
With no window manager running, each of the fifteen window styles is probed with a window placed off screen, which can never become visible and is never reparented, so the loop waiting on it spends a full second and learns nothing. Nothing is cached either, because the offsets are only written to the root window when every style succeeds, so every process repeats the whole thing.

A new `-_noWindowManager` answers whether anything else holds SubstructureRedirect on the root window, which a window manager always does. When there is none the offsets are set to zero, which is what the code already falls back to, and the probe is skipped. They are deliberately not written to the root window, where a window manager started later would find them and use them in place of its own.

Nothing changes when a window manager is running: with the cached property cleared first, the offsets are identical under openbox, metacity and twm.

There is no test, because the behaviour only differs when no window manager is running and the values produced are the ones the fallback already gave.

Tests/gui in libs-gui, against a backend configured --enable-graphics=xlib with no window manager, goes from 88m 17s to 1m 28s, with 4459 passed and 8 failed either way.

Closes #207
