### PR TITLE
Fix: draw nothing for a gradient stop with no colour components on the opal backend

### DIFF
--- a/Source/opal/OpalGState.m
+++ b/Source/opal/OpalGState.m
@@ -1322,7 +1322,16 @@ static CGGradientRef OpalCreateGradientFromNSGradient(NSGradient *gradient)
       [gradient getColor: &color location: &location atIndex: i];
       NSColor *rgb = [color colorUsingColorSpaceName: NSCalibratedRGBColorSpace];
       if (rgb == nil)
-        rgb = [NSColor blackColor];
+        {
+          /* A stop may hold a colour with no components to read, a pattern
+           * for one.  There is no colour to interpolate towards, so draw
+           * nothing rather than substituting one: the same answer GSGState
+           * gives, where _setColorFromGradient: returns NO and the band is
+           * left undrawn. */
+          free(components);
+          free(locations);
+          return NULL;
+        }
       components[i*4+0] = [rgb redComponent];
       components[i*4+1] = [rgb greenComponent];
       components[i*4+2] = [rgb blueComponent];


### PR DESCRIPTION
Fix: draw nothing for a gradient stop with no colour components on the opal backend

A gradient stop may hold a colour with no components to read, a pattern for
one. OpalCreateGradientFromNSGradient substituted [NSColor blackColor] for a
stop that would not convert, then read its red component. That colour is in
the white colour space, so the read raised and nothing was drawn.

The function now builds no gradient when a stop cannot be reduced to
components, which leaves the drawing undone rather than raising. That is the
answer the generic path already gives: -[GSGState _setColorFromGradient:at:]
returns NO and the band is left undrawn, which is why every backend other than
opal passes this test.

The caveat is that a gradient with a pattern stop draws nothing at all on
opal, rather than the pattern; what AppKit paints there is not established.

opal is the only backend that overrides -drawGradient:.

Path to the test: Tests/gui/NSGradient/drawingPatternColour.m in libs-gui, both
assertions. They need gnustep/libs-gui#882 as well, without which the
conversion raises before this code is reached. With both, Tests/gui on opal
goes from 4577 passed and 3 failed to 4579 and 1; cairo stays at 4580 and 0.
