### PR TITLE
Fix: put the text baseline where it was asked for on the opal backend

### DIFF
--- a/Source/opal/OpalGState.m
+++ b/Source/opal/OpalGState.m
@@ -217,7 +217,7 @@ _opalInterpolationForImageInterpolation(NSImageInterpolation interpolation)
   if (cgctx && s && length > 0)
     {
       CGPoint pt = CGContextGetPathCurrentPoint(cgctx);
-      pt.y += [self->font defaultLineHeightForFont] * 0.3;
+      pt.y += [self->font ascender];
       CGContextSetTextPosition(cgctx, pt.x, pt.y);
       CGContextShowText(cgctx, s, length);
     }
@@ -262,8 +262,7 @@ _opalInterpolationForImageInterpolation(NSImageInterpolation interpolation)
         }
 
       CGPoint pt = CGContextGetPathCurrentPoint(cgctx);
-      // Offset Y to account for flipped coordinate system
-      pt.y += [self->font defaultLineHeightForFont] * 0.3;
+      pt.y += [self->font ascender];
       CGContextSetTextPosition(cgctx, pt.x, pt.y);
       CGContextShowGlyphsWithAdvances(cgctx, cgglyphs, (const CGSize *)advances,
                                       length);


### PR DESCRIPTION
Fix: put the text baseline where it was asked for on the opal backend

-[OpalGState GSShowText:] and -GSShowGlyphsWithAdvances: raised the drawing
point by three tenths of the line height before showing the glyphs. That
constant matches no font measure, and it undercompensates, so glyphs landed
above the baseline they were given by an amount that grew with the point size.

They now move down by one ascender, which puts the top of the glyph box at the
top of the line and the baseline where the caller asked for it.

The caveat is that this needs gnustep/libs-opal#59, which makes -ascender the
typographic ascender rather than the top of the glyph bounding box. Without it
the ascender is too large for these fonts and the offset overshoots: a capital
H at 14 points then draws at rows 20 to 29 where cairo draws it at 16 to 25.

Path to the test: Tests/gui/NSAttributedString/headIndentDrawing.m in libs-gui,
the assertion at line 142, which fails on opal alone.

Measured by drawing a capital H at a baseline 30 rows down a 60 row image and
reading back the ink box. Before, opal drew it at rows 9 to 17 at 14 points and
rows 0 to 7 at 28 points, clipped by the top edge; after, rows 16 to 24 and 1
to 20, against cairo at 16 to 25 and 3 to 22. Tests/gui on opal goes from 4577
passed and 3 failed to 4578 and 2, the two left being the pattern colour
gradient covered by #210.
