### PR TITLE
Fix: draw the string DPSshow was given on the opal backend

### DIFF
--- a/Source/opal/OpalGState.m
+++ b/Source/opal/OpalGState.m
@@ -198,14 +198,10 @@ _opalInterpolationForImageInterpolation(NSImageInterpolation interpolation)
 - (void) DPSshow: (const char *)s
 {
   NSDebugLLog(@"OpalGState", @"%p (%@): %s", self, [self class], __PRETTY_FUNCTION__);
-  CGContextRef cgctx = CGCTX;
 
-  if (cgctx)
+  if (s != NULL)
     {
-      CGContextSaveGState(cgctx);
-      CGContextSetRGBFillColor(cgctx, 0, 1, 0, 1);
-      CGContextFillRect(cgctx, CGRectMake(0, 0, strlen(s) * 12, 12));
-      CGContextRestoreGState(cgctx);
+      [self GSShowText: s : strlen(s)];
     }
 }
 


### PR DESCRIPTION
Fix: draw the string DPSshow was given on the opal backend

-[OpalGState DPSshow:] filled a green rectangle, twelve points high and twelve
points per character wide, instead of drawing the string. The operator is
public through DPSOperators.h and PSOperators.h, so an application calling
PSshow or DPSshow got that rectangle painted in a colour it never set. The
cairo, art, xlib and winlib backends all draw the text.

It now shows the string through -GSShowText::, where the glyph drawing already
lives.

The caveat is that where the glyphs land is the subject of #211; this change
routes the operator to the same drawing everything else uses rather than
altering placement.

Path to the test: Tests/gui/NSGraphicsContext/textOperators.m in libs-gui,
which is new and needs gnustep/libs-gui#883.

Two of its three assertions fail on opal before this change and none after: the
operator painted nothing in the colour that was set, and it painted a mark in a
colour that was never set. cairo, art and xlib pass all three either way. The
whole Tests/gui suite on opal is 4577 passed and 3 failed either way, the three
being the ones #210 and #211 address.
