### PR TITLE
Fix: offset the string drawing the other way on the opal backend

### DIFF
--- a/Source/opal/OpalGState.m
+++ b/Source/opal/OpalGState.m
@@ -213,7 +213,11 @@ _opalInterpolationForImageInterpolation(NSImageInterpolation interpolation)
   if (cgctx && s && length > 0)
     {
       CGPoint pt = CGContextGetPathCurrentPoint(cgctx);
-      pt.y += [self->font ascender];
+      /* The opposite sign from -GSShowGlyphsWithAdvances:: below, and
+       * not a mistake: CGContextShowText compensates for the flipped
+       * coordinate system itself, where CGContextShowGlyphsWithAdvances
+       * does not. */
+      pt.y -= [self->font ascender];
       CGContextSetTextPosition(cgctx, pt.x, pt.y);
       CGContextShowText(cgctx, s, length);
     }


### PR DESCRIPTION
Fix: offset the string drawing the other way on the opal backend

#211 moved both of the backend's text entry points down by one ascender. That
is right for -GSShowGlyphsWithAdvances::, which reaches
CGContextShowGlyphsWithAdvances, and wrong for -GSShowText::, which reaches
CGContextShowText. That call compensates for the flipped coordinate system
itself, so adding an ascender there raises the string by two of them rather
than putting it on the baseline it was given.

#212 then routed -DPSshow: through -GSShowText::, and that is what made the
error visible: a string drawn through the operator landed above the top of the
drawing and nothing was painted at all. Neither change shows it alone, which is
why it appeared only once both had merged.

The caveat is that the two entry points now carry opposite signs, which looks
odd until the two Opal calls are compared. The comment says so.

Path to the test: Tests/gui/NSGraphicsContext/textOperators.m in libs-gui, the
assertion at line 75.

Measured by drawing a string through DPSshow: at three baselines in a 40 row
image and reading the ink back, against the cairo backend:

| baseline | cairo | opal before | opal after |
|---|---|---|---|
| 4 | rows 26 to 35 | rows 0 to 8 | rows 25 to 34 |
| 16 | rows 14 to 23 | nothing drawn | rows 13 to 22 |
| 28 | rows 2 to 11 | nothing drawn | rows 1 to 10 |

The glyph path is untouched, at rows 11 to 20 against cairo's 12 to 21 either
way. Tests/gui on opal goes from 4610 passed and 3 failed to 4611 and 2, the
two left being the pattern colour gradient in #210.
