### PR TITLE
tests: let the set own the autorelease pool

### DIFF
--- a/Tests/cairo/bitmapcontextflush.m
+++ b/Tests/cairo/bitmapcontextflush.m
@@ -19,15 +19,14 @@
 int
 main(int argc, const char **argv)
 {
-  CREATE_AUTORELEASE_POOL(pool);
   NSBitmapImageRep *rep;
   NSGraphicsContext *ctxt;
 
+  START_SET("bitmap context flush")
+
   if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
     {
-      NSLog(@"no window server available; skipping bitmap context flush test");
-      DESTROY(pool);
-      return 0;
+      SKIP("no window server available")
     }
 
   [NSApplication sharedApplication];
@@ -56,7 +55,8 @@ main(int argc, const char **argv)
   PASS([NSGraphicsContext currentContext] != ctxt,
        "flushing a bitmap context leaves the graphics state stack in step");
 
-  DESTROY(pool);
+  END_SET("bitmap context flush")
+
   return 0;
 }
 

--- a/Tests/winlib/win32fontlookup.m
+++ b/Tests/winlib/win32fontlookup.m
@@ -23,7 +23,6 @@ int
 main(void)
 {
   START_SET("win32 font lookup")
-  ENTER_POOL
 
   GSFontEnumerator *e = nil;
 
@@ -89,7 +88,6 @@ main(void)
       }
     }
 
-  LEAVE_POOL
   END_SET("win32 font lookup")
   return 0;
 }

--- a/Tests/winlib/winlibreadrect.m
+++ b/Tests/winlib/winlibreadrect.m
@@ -34,7 +34,6 @@ int
 main(void)
 {
   START_SET("winlib read back")
-  ENTER_POOL
 
   BOOL haveApp = NO;
 
@@ -93,7 +92,6 @@ main(void)
 	"reading part of a drawing gives that part, not the top of it")
     }
 
-  LEAVE_POOL
   END_SET("winlib read back")
 
   return 0;


### PR DESCRIPTION
tests: let the set own the autorelease pool

Three test files still manage an autorelease pool themselves, where START_SET
already creates one and END_SET releases it.

Tests/cairo/bitmapcontextflush.m had no START_SET at all. It created a pool of
its own and, with no window server, skipped by logging a line and returning,
which the test framework reports as nothing at all. It is now a set and skips
with SKIP, so the skip is reported.

Tests/winlib/win32fontlookup.m and Tests/winlib/winlibreadrect.m open an
ENTER_POOL as the first statement inside their set, which already has a pool.
Removing it leaves the set's own pool to do the work.

On x11 with cairo the whole Tests suite is 251 passed, 26 skipped sets and 0
failed builds before and after. Run with no DISPLAY, bitmapcontextflush exits 0
both ways, and now reports "Skipped set: bitmapcontextflush.m 29 ... no window
server available" where it used to print an untracked log line. The two winlib
files were measured on Windows, since there is no Windows job in CI: Tests/winlib
is 46 passed and 4 failed either way, the four being pre-existing font lookup
failures on master.
