### PR TITLE
tests: free the X resources the x11 tests allocate

### DIFF
--- a/Tests/x11/convert.m
+++ b/Tests/x11/convert.m
@@ -79,6 +79,7 @@ main(void)
   PASS(ctx != NULL, "RCreateContext succeeds on the display");
   if (ctx == NULL)
     {
+      XCloseDisplay(dpy);
       SKIP("no render context could be created")
     }
 
@@ -152,6 +153,20 @@ main(void)
 	  PASS(maxError <= 255, "the converted pixels are readable");
 	}
     }
+
+  if (xi != NULL)
+    {
+      XDestroyImage(xi);
+    }
+  if (pixmap != 0)
+    {
+      XFreePixmap(dpy, pixmap);
+    }
+  RReleaseImage(img);
+  /* The context is left to the display close: RDestroyContext lives in
+   * xlibimage.c, which carries its own RCreateContext and so cannot be
+   * compiled in beside context.c. */
+  XCloseDisplay(dpy);
 
   END_SET("convert")
   return 0;

--- a/Tests/x11/rcontext.m
+++ b/Tests/x11/rcontext.m
@@ -67,6 +67,7 @@ main(void)
   PASS(ctx != NULL, "RCreateContext succeeds with default attributes");
   if (ctx == NULL)
     {
+      XCloseDisplay(dpy);
       SKIP("no render context could be created")
     }
 
@@ -114,6 +115,10 @@ main(void)
       PASS(ctx->white == WhitePixel(dpy, screen),
 	   "the default-visual context records the screen's white pixel");
     }
+  /* The contexts are left to the display close: RDestroyContext lives in
+   * xlibimage.c, which carries its own RCreateContext and so cannot be
+   * compiled in beside context.c. */
+  XCloseDisplay(dpy);
 
   END_SET("rcontext")
   return 0;


### PR DESCRIPTION
tests: free the X resources the x11 tests allocate

Tests/x11/convert.m builds an RImage, converts it to a pixmap and reads that
back with XGetImage, and frees none of the three. It now releases the image
with RReleaseImage, frees the pixmap and destroys the XImage, and closes the
display it opened. Tests/x11/rcontext.m opened a display and never closed it,
and both now close theirs before skipping when no context can be created.

The caveat is what neither test can free. RDestroyContext lives in
xlibimage.c, which carries a second RCreateContext of its own, so it cannot be
compiled in beside the context.c these tests already include. The RContext,
its attributes copy and its graphics context are therefore still outstanding at
exit, and a comment in each file says so. That is the whole of what remains:
context.c:625 for the context, :636 for the attributes and :715 for the GC.

Measured with an AddressSanitizer build of base and gui, running each test
binary directly. convert goes from 2332 bytes leaked to 368, and rcontext stays
at 736, which is its two contexts. Both still trip a leak gate, so this reduces
the problem rather than closing it. The x11 suite is 40 passed either way and
convert still runs its 4 assertions, rcontext its 18.

Worth knowing for anyone measuring: an ASan run needs gdnc started beforehand
with the uninstrumented libraries, or every test that needs a backend skips and
the numbers mean nothing.
