### PR TITLE
tests: cover the image layer the backend actually builds

### DIFF
--- a/Tests/x11/context.m
+++ b/Tests/x11/context.m
@@ -16,7 +16,8 @@
 #import "Testing.h"
 #include "config.h"
 
-#if defined(BUILD_SERVER) && defined(SERVER_x11) && BUILD_SERVER == SERVER_x11
+#if defined(BUILD_SERVER) && defined(SERVER_x11) \
+  && BUILD_SERVER == SERVER_x11 && defined(USE_WRASTER) && USE_WRASTER
 
 #include <X11/Xlib.h>
 #include "x11/wraster.h"
@@ -49,8 +50,13 @@ int main(void)
 }
 
 #else
+
 int main(void)
 {
+  START_SET("context")
+  SKIP("back is not built with the wraster image code")
+  END_SET("context")
   return 0;
 }
+
 #endif

--- a/Tests/x11/convert.m
+++ b/Tests/x11/convert.m
@@ -79,6 +79,7 @@ main(void)
   PASS(ctx != NULL, "RCreateContext succeeds on the display");
   if (ctx == NULL)
     {
+      XCloseDisplay(dpy);
       SKIP("no render context could be created")
     }
 
@@ -152,6 +153,20 @@ main(void)
 	  PASS(maxError <= 255, "the converted pixels are readable");
 	}
     }
+
+  if (xi != NULL)
+    {
+      XDestroyImage(xi);
+    }
+  if (pixmap != 0)
+    {
+      XFreePixmap(dpy, pixmap);
+    }
+  RReleaseImage(img);
+  /* The context is left to the display close: RDestroyContext lives in
+   * xlibimage.c, which carries its own RCreateContext and so cannot be
+   * compiled in beside context.c. */
+  XCloseDisplay(dpy);
 
   END_SET("convert")
   return 0;

--- a/Tests/x11/convert.m
+++ b/Tests/x11/convert.m
@@ -22,7 +22,8 @@
 #import "Testing.h"
 #include "config.h"
 
-#if defined(BUILD_SERVER) && defined(SERVER_x11) && BUILD_SERVER == SERVER_x11
+#if defined(BUILD_SERVER) && defined(SERVER_x11) \
+  && BUILD_SERVER == SERVER_x11 && defined(USE_WRASTER) && USE_WRASTER
 
 #include <X11/Xlib.h>
 #include "x11/wraster.h"
@@ -177,6 +178,9 @@ main(void)
 int
 main(void)
 {
+  START_SET("convert")
+  SKIP("back is not built with the wraster image code")
+  END_SET("convert")
   return 0;
 }
 

--- a/Tests/x11/raster.m
+++ b/Tests/x11/raster.m
@@ -24,7 +24,8 @@
 #import "Testing.h"
 #include "config.h"
 
-#if defined(BUILD_SERVER) && defined(SERVER_x11) && BUILD_SERVER == SERVER_x11
+#if defined(BUILD_SERVER) && defined(SERVER_x11) \
+  && BUILD_SERVER == SERVER_x11 && defined(USE_WRASTER) && USE_WRASTER
 
 #include <X11/Xlib.h>
 #include "x11/wraster.h"
@@ -116,6 +117,9 @@ main(void)
 int
 main(void)
 {
+  START_SET("raster")
+  SKIP("back is not built with the wraster image code")
+  END_SET("raster")
   return 0;
 }
 

--- a/Tests/x11/rcontext.m
+++ b/Tests/x11/rcontext.m
@@ -20,7 +20,8 @@
 #import "Testing.h"
 #include "config.h"
 
-#if defined(BUILD_SERVER) && defined(SERVER_x11) && BUILD_SERVER == SERVER_x11
+#if defined(BUILD_SERVER) && defined(SERVER_x11) \
+  && BUILD_SERVER == SERVER_x11 && defined(USE_WRASTER) && USE_WRASTER
 
 #include <X11/Xlib.h>
 #include "x11/wraster.h"
@@ -129,6 +130,9 @@ main(void)
 int
 main(void)
 {
+  START_SET("rcontext")
+  SKIP("back is not built with the wraster image code")
+  END_SET("rcontext")
   return 0;
 }
 

--- a/Tests/x11/rcontext.m
+++ b/Tests/x11/rcontext.m
@@ -67,6 +67,7 @@ main(void)
   PASS(ctx != NULL, "RCreateContext succeeds with default attributes");
   if (ctx == NULL)
     {
+      XCloseDisplay(dpy);
       SKIP("no render context could be created")
     }
 
@@ -114,6 +115,10 @@ main(void)
       PASS(ctx->white == WhitePixel(dpy, screen),
 	   "the default-visual context records the screen's white pixel");
     }
+  /* The contexts are left to the display close: RDestroyContext lives in
+   * xlibimage.c, which carries its own RCreateContext and so cannot be
+   * compiled in beside context.c. */
+  XCloseDisplay(dpy);
 
   END_SET("rcontext")
   return 0;

--- a/Tests/x11/scale.m
+++ b/Tests/x11/scale.m
@@ -18,7 +18,8 @@
 #import "Testing.h"
 #include "config.h"
 
-#if defined(BUILD_SERVER) && defined(SERVER_x11) && BUILD_SERVER == SERVER_x11
+#if defined(BUILD_SERVER) && defined(SERVER_x11) \
+  && BUILD_SERVER == SERVER_x11 && defined(USE_WRASTER) && USE_WRASTER
 
 #include <X11/Xlib.h>
 #include "x11/wraster.h"
@@ -64,6 +65,9 @@ main(void)
 int
 main(void)
 {
+  START_SET("scale")
+  SKIP("back is not built with the wraster image code")
+  END_SET("scale")
   return 0;
 }
 

--- a/Tests/x11/xlibcontext.m
+++ b/Tests/x11/xlibcontext.m
@@ -1,0 +1,187 @@
+/* Test for RCreateContext() and RDestroyContext() in Source/x11/xlibimage.c.
+ *
+ * xlibimage.c is the plain-Xlib implementation of the wraster subset the X11
+ * backend uses, and it is what a default build compiles: --enable-wraster is
+ * off unless asked for, so USE_WRASTER is 0 and context.c is not built.  This
+ * checks the context it produces: the fields taken from the screen, the
+ * attributes copy (including the two the implementation overrides), and the
+ * channel offsets derived from a TrueColor visual's masks.
+ *
+ * It needs a running X server: it opens the display named by $DISPLAY and
+ * skips cleanly when there is none, so the harness can run it under a headless
+ * server (Xvfb) where one is available.
+ *
+ * The guard is the mirror of the one the wraster tests carry: this builds only
+ * where xlibimage.c is the implementation in use.
+ */
+#import <Foundation/Foundation.h>
+#import "Testing.h"
+#include "config.h"
+
+#if defined(BUILD_SERVER) && defined(SERVER_x11) \
+  && BUILD_SERVER == SERVER_x11 && (!defined(USE_WRASTER) || !USE_WRASTER)
+
+#include <X11/Xlib.h>
+#include "x11/xlibimage.h"
+#include "x11/xlibimage.c"
+
+/* Independent oracle for the lowest-set-bit position, so the offset check does
+ * not merely restate the count_offset() it is meant to verify. */
+static int
+low_bit(unsigned long m)
+{
+  int s = 0;
+
+  if (m == 0)
+    return 0;
+  while ((m & 1) == 0)
+    {
+      s++;
+      m >>= 1;
+    }
+  return s;
+}
+
+int
+main(void)
+{
+  START_SET("xlibcontext")
+  Display		*dpy;
+  int			screen;
+  RContext		*ctx;
+  RContextAttributes	attribs;
+
+  dpy = XOpenDisplay(NULL);
+  if (dpy == NULL)
+    {
+      SKIP("no X display available")
+    }
+  screen = DefaultScreen(dpy);
+
+  /* No attributes: the implementation supplies its own defaults. */
+  ctx = RCreateContext(dpy, screen, NULL);
+  PASS(ctx != NULL, "RCreateContext succeeds with no attributes");
+  if (ctx == NULL)
+    {
+      XCloseDisplay(dpy);
+      SKIP("no render context could be created")
+    }
+
+  PASS(ctx->attribs != NULL, "the context has its own attributes");
+  PASS(ctx->attribs != NULL
+    && ctx->attribs->render_mode == RDitheredRendering,
+    "the default render mode is dithered");
+  PASS(ctx->attribs != NULL && ctx->attribs->colors_per_channel == 4,
+    "the default is four colours per channel");
+  PASS(ctx->attribs != NULL
+    && ctx->attribs->standard_colormap_mode == RUseStdColormap,
+    "the default is to use the standard colormap");
+
+  /* The fields taken straight from the screen. */
+  PASS(ctx->dpy == dpy, "the context keeps the display it was created for");
+  PASS(ctx->screen_number == screen, "the context keeps its screen number");
+  PASS(ctx->visual == DefaultVisual(dpy, screen),
+    "the context uses the screen's default visual");
+  PASS(ctx->depth == DefaultDepth(dpy, screen),
+    "the context uses the screen's default depth");
+  PASS(ctx->cmap == DefaultColormap(dpy, screen),
+    "the context uses the screen's default colormap");
+  PASS(ctx->drawable == RootWindow(dpy, screen),
+    "the context drawable is the root window");
+  PASS(ctx->black == BlackPixel(dpy, screen),
+    "the context records the screen's black pixel");
+  PASS(ctx->white == WhitePixel(dpy, screen),
+    "the context records the screen's white pixel");
+  PASS(ctx->vclass == ctx->visual->class,
+    "the context visual class is the visual's own class");
+  PASS(ctx->copy_gc != NULL, "the context has a copy graphics context");
+
+  /* Fields this implementation does not use are left empty rather than
+   * uninitialised. */
+  PASS(ctx->std_rgb_map == NULL && ctx->std_gray_map == NULL,
+    "no standard colormaps are built");
+  PASS(ctx->ncolors == 0 && ctx->colors == NULL && ctx->pixels == NULL,
+    "no colour table is built");
+  PASS(ctx->hermes_data == NULL, "no Hermes data is attached");
+
+  if (ctx->vclass == TrueColor)
+    {
+      PASS(ctx->red_offset == low_bit(ctx->visual->red_mask),
+        "the red offset is the lowest set bit of the visual's red mask");
+      PASS(ctx->green_offset == low_bit(ctx->visual->green_mask),
+        "the green offset is the lowest set bit of the visual's green mask");
+      PASS(ctx->blue_offset == low_bit(ctx->visual->blue_mask),
+        "the blue offset is the lowest set bit of the visual's blue mask");
+    }
+  else
+    {
+      /* The offsets are derived for a TrueColor visual only, and a context
+       * starts zeroed, so they stay at zero for any other class. */
+      PASS(ctx->red_offset == 0 && ctx->green_offset == 0
+        && ctx->blue_offset == 0,
+        "no channel offsets are derived for a non-TrueColor visual");
+    }
+
+  RDestroyContext(ctx);
+
+  /* Supplied attributes are copied, and the copy is the context's own. */
+  memset(&attribs, 0, sizeof(attribs));
+  attribs.flags = RC_RenderMode | RC_ColorsPerChannel;
+  attribs.render_mode = RBestMatchRendering;
+  attribs.colors_per_channel = 6;
+  ctx = RCreateContext(dpy, screen, &attribs);
+  PASS(ctx != NULL, "RCreateContext succeeds with attributes supplied");
+  if (ctx != NULL)
+    {
+      PASS(ctx->attribs != &attribs,
+        "the context takes a copy rather than keeping the caller's struct");
+      PASS(ctx->attribs->render_mode == RBestMatchRendering,
+        "the supplied render mode is kept");
+      PASS(ctx->attribs->colors_per_channel == 6,
+        "the supplied colours per channel is kept");
+
+      attribs.colors_per_channel = 2;
+      PASS(ctx->attribs->colors_per_channel == 6,
+        "changing the caller's struct afterwards does not change the context");
+
+      RDestroyContext(ctx);
+    }
+
+  /* Shared memory is never used by this implementation, whatever is asked
+   * for, and it says so in the copy it keeps. */
+  memset(&attribs, 0, sizeof(attribs));
+  attribs.flags = RC_UseSharedMemory;
+  attribs.use_shared_memory = True;
+  ctx = RCreateContext(dpy, screen, &attribs);
+  PASS(ctx != NULL, "RCreateContext succeeds when shared memory is asked for");
+  if (ctx != NULL)
+    {
+      PASS(ctx->attribs->use_shared_memory == False,
+        "shared memory is refused however it was asked for");
+      PASS((ctx->attribs->flags & RC_UseSharedMemory) == 0,
+        "the shared memory flag is cleared as well as the value");
+      RDestroyContext(ctx);
+    }
+
+  /* Releasing nothing is allowed. */
+  PASS_RUNS(({ RDestroyContext(NULL); }),
+    "RDestroyContext tolerates a null context");
+
+  XCloseDisplay(dpy);
+
+  END_SET("xlibcontext")
+  return 0;
+}
+
+#else
+
+int
+main(void)
+{
+  START_SET("xlibcontext")
+  SKIP("back is built with the wraster image code, not the plain Xlib layer")
+  END_SET("xlibcontext")
+  return 0;
+}
+
+#endif

--- a/Tests/x11/xlibximage.m
+++ b/Tests/x11/xlibximage.m
@@ -1,0 +1,147 @@
+/* Test for the image and colour calls in Source/x11/xlibimage.c.
+ *
+ * xlibimage.c is what a default build compiles for the X11 backend, since
+ * --enable-wraster is off unless asked for.  This covers the calls the backend
+ * makes on it: RCreateXImage builds an image to draw into, RGetXImage reads a
+ * drawable back, RPutXImage writes one out again and RDestroyXImage releases
+ * it, while RGetClosestXColor turns an RColor into a pixel for the visual.
+ *
+ * The round trip is the point: a known colour is put into a pixmap, read back,
+ * written into a second pixmap and read again, and the pixels must survive.
+ *
+ * It needs a running X server: it opens the display named by $DISPLAY and
+ * skips cleanly when there is none, so the harness can run it under a headless
+ * server (Xvfb) where one is available.
+ */
+#import <Foundation/Foundation.h>
+#import "Testing.h"
+#include "config.h"
+
+#if defined(BUILD_SERVER) && defined(SERVER_x11) \
+  && BUILD_SERVER == SERVER_x11 && (!defined(USE_WRASTER) || !USE_WRASTER)
+
+#include <X11/Xlib.h>
+#include "x11/xlibimage.h"
+#include "x11/xlibimage.c"
+
+int
+main(void)
+{
+  START_SET("xlibximage")
+  Display	*dpy;
+  int		screen;
+  RContext	*ctx;
+  RXImage	*img;
+  RXImage	*readBack;
+  Pixmap	src = 0;
+  Pixmap	dst = 0;
+  XColor	xc;
+  RColor	colour;
+  unsigned int	w = 8, h = 8;
+
+  dpy = XOpenDisplay(NULL);
+  if (dpy == NULL)
+    {
+      SKIP("no X display available")
+    }
+  screen = DefaultScreen(dpy);
+
+  ctx = RCreateContext(dpy, screen, NULL);
+  PASS(ctx != NULL, "a context can be created");
+  if (ctx == NULL)
+    {
+      XCloseDisplay(dpy);
+      SKIP("no render context could be created")
+    }
+
+  /* A colour for the visual. */
+  colour.red = 255;
+  colour.green = 0;
+  colour.blue = 0;
+  colour.alpha = 255;
+  memset(&xc, 0, sizeof(xc));
+  PASS(RGetClosestXColor(ctx, &colour, &xc) == True,
+    "a colour can be resolved for the visual");
+  PASS(xc.red == (255 << 8) && xc.green == 0 && xc.blue == 0,
+    "the returned XColor carries the components it was asked for");
+  PASS((xc.flags & (DoRed | DoGreen | DoBlue)) == (DoRed | DoGreen | DoBlue),
+    "the returned XColor asks for all three components");
+
+  /* An image to draw into. */
+  img = RCreateXImage(ctx, ctx->depth, w, h);
+  PASS(img != NULL && img->image != NULL, "an image can be created");
+  if (img != NULL && img->image != NULL)
+    {
+      PASS(img->image->width == (int)w && img->image->height == (int)h,
+        "the image has the size it was asked for");
+      PASS(img->image->depth == ctx->depth,
+        "the image has the depth it was asked for");
+      PASS(img->image->data != NULL, "the image has somewhere to put pixels");
+    }
+
+  /* Fill a pixmap with the colour, read it back, and check the pixels. */
+  src = XCreatePixmap(dpy, ctx->drawable, w, h, ctx->depth);
+  PASS(src != 0, "a pixmap can be created to draw into");
+  if (src != 0)
+    {
+      XSetForeground(dpy, ctx->copy_gc, xc.pixel);
+      XFillRectangle(dpy, src, ctx->copy_gc, 0, 0, w, h);
+      XSync(dpy, False);
+
+      readBack = RGetXImage(ctx, src, 0, 0, w, h);
+      PASS(readBack != NULL && readBack->image != NULL,
+        "the pixmap can be read back into an image");
+      if (readBack != NULL && readBack->image != NULL)
+        {
+          PASS(readBack->image->width == (int)w
+            && readBack->image->height == (int)h,
+            "the image read back has the size that was asked for");
+          PASS(XGetPixel(readBack->image, w / 2, h / 2) == xc.pixel,
+            "the pixel read back is the one that was drawn");
+
+          /* Write it into a second pixmap and read that, so the put is
+           * covered as well as the get. */
+          dst = XCreatePixmap(dpy, ctx->drawable, w, h, ctx->depth);
+          if (dst != 0)
+            {
+              RXImage *again;
+
+              RPutXImage(ctx, dst, ctx->copy_gc, readBack, 0, 0, 0, 0, w, h);
+              XSync(dpy, False);
+              again = RGetXImage(ctx, dst, 0, 0, w, h);
+              PASS(again != NULL && again->image != NULL
+                && XGetPixel(again->image, w / 2, h / 2) == xc.pixel,
+                "a written image reads back with the same pixel");
+              RDestroyXImage(ctx, again);
+              XFreePixmap(dpy, dst);
+            }
+          RDestroyXImage(ctx, readBack);
+        }
+      XFreePixmap(dpy, src);
+    }
+
+  RDestroyXImage(ctx, img);
+
+  /* Releasing nothing is allowed. */
+  PASS_RUNS(({ RDestroyXImage(ctx, NULL); }),
+    "RDestroyXImage tolerates a null image");
+
+  RDestroyContext(ctx);
+  XCloseDisplay(dpy);
+
+  END_SET("xlibximage")
+  return 0;
+}
+
+#else
+
+int
+main(void)
+{
+  START_SET("xlibximage")
+  SKIP("back is built with the wraster image code, not the plain Xlib layer")
+  END_SET("xlibximage")
+  return 0;
+}
+
+#endif


### PR DESCRIPTION
tests: cover the image layer the backend actually builds

Tests/x11/{context,convert,raster,rcontext,scale}.m compile the wraster sources
in directly and guard only on the server being x11, so they build and run in a
default configuration as well. A default build has USE_WRASTER=0 and contains
the plain-Xlib layer from xlibimage.c instead, so those five were testing an
implementation the backend beside them does not ship, and convert.m, raster.m
and scale.m exercise an RImage API such a build has none of. They now guard on
USE_WRASTER as well, and report a skip rather than returning quietly.

That left the default layer with no coverage at all, so two tests are added for
it. xlibcontext.m checks the context RCreateContext builds: the fields taken
from the screen, the attributes copy being the context's own, the channel
offsets against an independent lowest-set-bit oracle, and the two attributes the
implementation overrides whatever the caller asks. xlibximage.m checks the image
calls the backend makes, taking a colour through RGetClosestXColor into a
pixmap, reading it back with RGetXImage, writing it into a second pixmap with
RPutXImage and reading that, so the put is covered as well as the get.

The caveat is that this is a straight split by configuration: no test covers
both layers, because the two do not offer the same API.

This is stacked on #215, which touches two of the same files.

Path to the tests: Tests/x11, run in both configurations.

Configured with --enable-graphics=cairo, the suite is 44 passed and 5 skipped
sets by default, and 40 passed and 2 skipped sets with --enable-wraster, the 40
being what the five wraster tests reported before this change. No failed builds
either way.
