### PR TITLE
Fix: give a context from graphicsContextWithBitmapImageRep: a cairo surface

### DIFF
--- a/Headers/cairo/CairoBitmapSurface.h
+++ b/Headers/cairo/CairoBitmapSurface.h
@@ -1,0 +1,47 @@
+/*
+   Copyright (C) 2026 Free Software Foundation, Inc.
+
+   Author: Todd White <todd.white@thalion.global>
+   Date: August 2026
+
+   This file is part of GNUstep.
+
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2 of the License, or (at your option) any later version.
+
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; see the file COPYING.LIB.
+   If not, see <http://www.gnu.org/licenses/> or write to the
+   Free Software Foundation, 51 Franklin Street, Fifth Floor,
+   Boston, MA 02110-1301, USA.
+*/
+
+#ifndef CairoBitmapSurface_h
+#define CairoBitmapSurface_h
+
+#include "cairo/CairoSurface.h"
+
+@class NSBitmapImageRep;
+
+/* A surface that draws into the bytes of an NSBitmapImageRep.  Cairo keeps
+ * its own buffer, in its own pixel layout, and the drawing is written back to
+ * the representation when the surface is flushed.
+ */
+@interface CairoBitmapSurface : CairoSurface
+{
+  NSBitmapImageRep *_rep;
+}
+
+/* Whether a representation is in a layout this surface can write back to. */
++ (BOOL) handlesBitmap: (NSBitmapImageRep *)rep;
+
+@end
+
+#endif

--- a/Headers/cairo/CairoSurface.h
+++ b/Headers/cairo/CairoSurface.h
@@ -44,6 +44,9 @@
 
 - (void) handleExposeRect: (NSRect)rect;
 
+/* Write out anything the surface is holding back from its destination. */
+- (void) flush;
+
 - (BOOL) isDrawingToScreen;
 
 @end

--- a/Source/cairo/CairoBitmapSurface.m
+++ b/Source/cairo/CairoBitmapSurface.m
@@ -1,0 +1,202 @@
+/*
+   CairoBitmapSurface.m
+
+   Copyright (C) 2026 Free Software Foundation, Inc.
+
+   Author: Todd White <todd.white@thalion.global>
+   Date: August 2026
+
+   This file is part of GNUstep.
+
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2 of the License, or (at your option) any later version.
+
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; see the file COPYING.LIB.
+   If not, see <http://www.gnu.org/licenses/> or write to the
+   Free Software Foundation, 51 Franklin Street, Fifth Floor,
+   Boston, MA 02110-1301, USA.
+*/
+
+#include <AppKit/NSBitmapImageRep.h>
+#include <AppKit/NSGraphics.h>
+
+#include "cairo/CairoBitmapSurface.h"
+
+#include <stdint.h>
+
+/* Cairo holds a pixel as a native word with the alpha in the top byte; a
+ * representation holds it as four bytes with the alpha last.
+ */
+static void
+readRow(const unsigned char *from, uint32_t *to, int wide)
+{
+  int i;
+
+  for (i = 0; i < wide; i++)
+    {
+      to[i] = ((uint32_t)from[3] << 24) | ((uint32_t)from[0] << 16)
+	| ((uint32_t)from[1] << 8) | (uint32_t)from[2];
+      from += 4;
+    }
+}
+
+static void
+writeRow(const uint32_t *from, unsigned char *to, int wide)
+{
+  int i;
+
+  for (i = 0; i < wide; i++)
+    {
+      to[0] = (unsigned char)((from[i] >> 16) & 0xff);
+      to[1] = (unsigned char)((from[i] >> 8) & 0xff);
+      to[2] = (unsigned char)(from[i] & 0xff);
+      to[3] = (unsigned char)((from[i] >> 24) & 0xff);
+      to += 4;
+    }
+}
+
+@implementation CairoBitmapSurface
+
++ (BOOL) handlesBitmap: (NSBitmapImageRep *)rep
+{
+  NSString *space;
+
+  if (rep == nil || [rep isPlanar] || [rep bitmapFormat] != 0)
+    {
+      return NO;
+    }
+  if ([rep bitsPerSample] != 8 || [rep samplesPerPixel] != 4
+    || ![rep hasAlpha] || [rep bitsPerPixel] != 32)
+    {
+      return NO;
+    }
+  space = [rep colorSpaceName];
+  return ([space isEqualToString: NSDeviceRGBColorSpace]
+    || [space isEqualToString: NSCalibratedRGBColorSpace]);
+}
+
+- (id) initWithDevice: (void *)device
+{
+  NSBitmapImageRep *rep = (NSBitmapImageRep *)device;
+
+  if (![[self class] handlesBitmap: rep])
+    {
+      DESTROY(self);
+      return self;
+    }
+
+  _surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32,
+					(int)[rep pixelsWide],
+					(int)[rep pixelsHigh]);
+  if (cairo_surface_status(_surface) != CAIRO_STATUS_SUCCESS)
+    {
+      DESTROY(self);
+      return self;
+    }
+
+  ASSIGN(_rep, rep);
+  gsDevice = device;
+  [self read];
+
+  return self;
+}
+
+- (void) dealloc
+{
+  [self flush];
+  DESTROY(_rep);
+  [super dealloc];
+}
+
+- (NSSize) size
+{
+  return NSMakeSize([_rep pixelsWide], [_rep pixelsHigh]);
+}
+
+- (void) setSize: (NSSize)newSize
+{
+  /* The size is that of the representation, which does not change. */
+}
+
+- (BOOL) isDrawingToScreen
+{
+  return NO;
+}
+
+/* Take up what the representation already holds, so that drawing adds to it
+ * rather than replacing it.
+ */
+- (void) read
+{
+  const unsigned char *from;
+  unsigned char *to;
+  int y;
+  int wide;
+  int high;
+  int stride;
+
+  to = cairo_image_surface_get_data(_surface);
+  if (to == NULL)
+    {
+      return;
+    }
+  from = [_rep bitmapData];
+  if (from == NULL)
+    {
+      return;
+    }
+  wide = (int)[_rep pixelsWide];
+  high = (int)[_rep pixelsHigh];
+  stride = cairo_image_surface_get_stride(_surface);
+  cairo_surface_flush(_surface);
+  for (y = 0; y < high; y++)
+    {
+      readRow(from + y * [_rep bytesPerRow], (uint32_t *)(to + y * stride),
+	wide);
+    }
+  cairo_surface_mark_dirty(_surface);
+}
+
+- (void) flush
+{
+  const unsigned char *from;
+  unsigned char *to;
+  int y;
+  int wide;
+  int high;
+  int stride;
+
+  if (_surface == NULL || _rep == nil)
+    {
+      return;
+    }
+  cairo_surface_flush(_surface);
+  from = cairo_image_surface_get_data(_surface);
+  if (from == NULL)
+    {
+      return;
+    }
+  to = [_rep bitmapData];
+  if (to == NULL)
+    {
+      return;
+    }
+  wide = (int)[_rep pixelsWide];
+  high = (int)[_rep pixelsHigh];
+  stride = cairo_image_surface_get_stride(_surface);
+  for (y = 0; y < high; y++)
+    {
+      writeRow((const uint32_t *)(from + y * stride),
+	to + y * [_rep bytesPerRow], wide);
+    }
+}
+
+@end

--- a/Source/cairo/CairoContext.m
+++ b/Source/cairo/CairoContext.m
@@ -32,6 +32,7 @@
 
 #include "cairo/CairoContext.h"
 #include "cairo/CairoSurface.h"
+#include "cairo/CairoBitmapSurface.h"
 #include "cairo/CairoPSSurface.h"
 #include "cairo/CairoPDFSurface.h"
 #include "cairo/CairoFontInfo.h"
@@ -113,7 +114,28 @@
   self = [super initWithContextInfo: info];
   if (self)
     {
+      id dest;
+
       [self setImageInterpolation: NSImageInterpolationDefault];
+
+      /* A context drawing into a bitmap representation gets a surface over
+       * that representation.  Only a window destination is handled further
+       * up, and without a surface nothing this context draws goes anywhere.
+       */
+      dest = [info objectForKey: NSGraphicsContextDestinationAttributeName];
+      if ((dest != nil) && [dest isKindOfClass: [NSBitmapImageRep class]])
+        {
+          CairoSurface *surface;
+
+          surface = [[CairoBitmapSurface alloc] initWithDevice: dest];
+          if (surface != nil)
+            {
+              [CGSTATE GSSetSurface: surface
+                                   : 0
+                                   : (int)[(NSBitmapImageRep *)dest pixelsHigh]];
+              RELEASE(surface);
+            }
+        }
     }
   return self;
 }
@@ -127,6 +149,14 @@
 
 - (void) flushGraphics
 {
+  CairoSurface *surface = nil;
+
+  /* A surface that keeps the drawing in a buffer of its own writes it out
+   * to its destination here.
+   */
+  [CGSTATE GSCurrentSurface: &surface : NULL : NULL];
+  [surface flush];
+
   // FIXME: Why is this here? When is it called?
   // Comments added 07/20/2013 to address the above question after
   // further debugging cairo/MSwindows non-retained backing store type:
@@ -149,9 +179,6 @@
       XFlush([(XGServer *)server xDisplay]);
     }
 #elif BUILD_SERVER == SERVER_win32
-  CairoSurface *surface = nil;
-
-  [CGSTATE GSCurrentSurface: &surface : NULL : NULL];
   if ((surface != nil) && ([surface surface] != NULL))
     {
       // Non-retained backing store types currently unsupported on MSWindows...

--- a/Source/cairo/CairoSurface.m
+++ b/Source/cairo/CairoSurface.m
@@ -69,6 +69,10 @@
 {
 }
 
+- (void) flush
+{
+}
+
 - (BOOL) isDrawingToScreen
 {
   return YES;

--- a/Source/cairo/GNUmakefile
+++ b/Source/cairo/GNUmakefile
@@ -30,6 +30,7 @@ SUBPROJECT_NAME=cairo
 
 # The Objective-C source files to be compiled
 cairo_OBJC_FILES = CairoSurface.m \
+  CairoBitmapSurface.m \
   CairoFontInfo.m \
   CairoGState.m \
   CairoContext.m \

--- a/Tests/cairo/bitmapcontextdraw.m
+++ b/Tests/cairo/bitmapcontextdraw.m
@@ -1,0 +1,195 @@
+/* Drawing into a graphics context made for an NSBitmapImageRep has to reach
+ * the bytes of that representation.  The bitmap is a 32 bit device RGB one
+ * with premultiplied alpha last, which is the layout the cairo backend can
+ * carry directly.
+ *
+ * The context takes the same coordinates as any other: the origin is at the
+ * bottom left, so the first row of the bitmap is the top of the drawing.
+ *
+ * It needs a running window server to load the backend at all, so it skips
+ * cleanly when there is none, and it guards on the cairo graphics backend.
+ */
+#import <Foundation/NSObject.h>
+#import "Testing.h"
+#include "config.h"
+
+#if defined(BUILD_GRAPHICS) && defined(GRAPHICS_cairo) \
+  && BUILD_GRAPHICS == GRAPHICS_cairo
+
+#import <AppKit/AppKit.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define WIDE 8
+#define HIGH 8
+
+static NSBitmapImageRep *
+makeRep(void)
+{
+  return AUTORELEASE([[NSBitmapImageRep alloc]
+    initWithBitmapDataPlanes: NULL
+                  pixelsWide: WIDE
+                  pixelsHigh: HIGH
+               bitsPerSample: 8
+             samplesPerPixel: 4
+                    hasAlpha: YES
+                    isPlanar: NO
+              colorSpaceName: NSDeviceRGBColorSpace
+                 bytesPerRow: 0
+                bitsPerPixel: 0]);
+}
+
+static unsigned char *
+pixel(NSBitmapImageRep *rep, int x, int y)
+{
+  return [rep bitmapData] + y * [rep bytesPerRow] + x * 4;
+}
+
+static void
+clearRep(NSBitmapImageRep *rep)
+{
+  memset([rep bitmapData], 0, [rep bytesPerRow] * [rep pixelsHigh]);
+}
+
+static void
+fillRect(NSBitmapImageRep *rep, NSColor *colour, NSRect rect)
+{
+  NSGraphicsContext *ctxt;
+
+  ctxt = [NSGraphicsContext graphicsContextWithBitmapImageRep: rep];
+  [NSGraphicsContext saveGraphicsState];
+  [NSGraphicsContext setCurrentContext: ctxt];
+  [colour set];
+  NSRectFill(rect);
+  [ctxt flushGraphics];
+  [NSGraphicsContext restoreGraphicsState];
+}
+
+static BOOL
+isColour(unsigned char *p, int r, int g, int b, int a)
+{
+  return (abs((int)p[0] - r) <= 1 && abs((int)p[1] - g) <= 1
+    && abs((int)p[2] - b) <= 1 && abs((int)p[3] - a) <= 1);
+}
+
+int
+main(int argc, const char **argv)
+{
+  START_SET("bitmap context drawing")
+
+  NSBitmapImageRep *rep;
+  NSGraphicsContext *ctxt;
+  BOOL allRed;
+  BOOL topClear;
+  BOOL bottomRed;
+  int x;
+  int y;
+
+  if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
+    {
+      SKIP("no window server available")
+    }
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      SKIP("It looks like the GNUstep backend is not installed")
+    }
+  NS_ENDHANDLER
+
+  rep = makeRep();
+  ctxt = [NSGraphicsContext graphicsContextWithBitmapImageRep: rep];
+  PASS(ctxt != nil, "a graphics context can be made for a bitmap");
+
+  /* An opaque fill over the whole representation. */
+  clearRep(rep);
+  fillRect(rep, [NSColor redColor], NSMakeRect(0, 0, WIDE, HIGH));
+  allRed = YES;
+  for (y = 0; y < HIGH; y++)
+    {
+      for (x = 0; x < WIDE; x++)
+        {
+          if (!isColour(pixel(rep, x, y), 255, 0, 0, 255))
+            {
+              allRed = NO;
+            }
+        }
+    }
+  PASS(allRed, "an opaque fill reaches every pixel of the bitmap");
+
+  /* The bottom half in context coordinates is the last rows of the bitmap. */
+  clearRep(rep);
+  fillRect(rep, [NSColor redColor], NSMakeRect(0, 0, WIDE, HIGH / 2));
+  topClear = YES;
+  bottomRed = YES;
+  for (y = 0; y < HIGH / 2; y++)
+    {
+      if (!isColour(pixel(rep, 0, y), 0, 0, 0, 0))
+        {
+          topClear = NO;
+        }
+    }
+  for (y = HIGH / 2; y < HIGH; y++)
+    {
+      if (!isColour(pixel(rep, 0, y), 255, 0, 0, 255))
+        {
+          bottomRed = NO;
+        }
+    }
+  PASS(topClear, "the first rows of the bitmap are above the drawing");
+  PASS(bottomRed, "a fill at the origin lands in the last rows of the bitmap");
+
+  /* And the left half is the first columns. */
+  clearRep(rep);
+  fillRect(rep, [NSColor redColor], NSMakeRect(0, 0, WIDE / 2, HIGH));
+  PASS(isColour(pixel(rep, 0, 0), 255, 0, 0, 255),
+    "a fill at the origin lands in the first columns of the bitmap");
+  PASS(isColour(pixel(rep, WIDE - 1, 0), 0, 0, 0, 0),
+    "the last columns of the bitmap are beyond the drawing");
+
+  /* What lands in the bitmap is premultiplied, as the format says. */
+  clearRep(rep);
+  fillRect(rep, [NSColor colorWithDeviceRed: 1.0
+                                      green: 0.0
+                                       blue: 0.0
+                                      alpha: 0.5],
+           NSMakeRect(0, 0, WIDE, HIGH));
+  PASS(isColour(pixel(rep, 0, 0), 128, 0, 0, 128),
+    "a half transparent fill is stored premultiplied");
+
+  /* A second context for the same bitmap draws over what is already there. */
+  clearRep(rep);
+  fillRect(rep, [NSColor redColor], NSMakeRect(0, 0, WIDE, HIGH));
+  fillRect(rep, [NSColor greenColor], NSMakeRect(0, 0, WIDE / 2, HIGH / 2));
+  PASS(isColour(pixel(rep, 0, HIGH - 1), 0, 255, 0, 255),
+    "a second context draws into the same bitmap");
+  PASS(isColour(pixel(rep, WIDE - 1, 0), 255, 0, 0, 255),
+    "a second context keeps what the first one drew");
+
+  /* The representation reads back the colour it was given. */
+  clearRep(rep);
+  fillRect(rep, [NSColor redColor], NSMakeRect(0, 0, WIDE, HIGH));
+  PASS([[[rep colorAtX: 0 y: 0] colorUsingColorSpaceName: NSDeviceRGBColorSpace]
+    isEqual: [NSColor colorWithDeviceRed: 1.0 green: 0.0 blue: 0.0 alpha: 1.0]],
+    "the representation reads back the colour that was drawn");
+
+  END_SET("bitmap context drawing")
+
+  return 0;
+}
+
+#else
+
+int
+main(int argc, const char **argv)
+{
+  START_SET("bitmap context drawing")
+    SKIP("back is not built with the cairo graphics backend")
+  END_SET("bitmap context drawing")
+  return 0;
+}
+
+#endif


### PR DESCRIPTION
`+[NSGraphicsContext graphicsContextWithBitmapImageRep:]` returns a CairoContext
with no surface, because `-[GSContext initWithContextInfo:]` only acts on a
window destination. Anything drawn into that context is dropped.

CairoBitmapSurface draws into a cairo image surface and writes the pixels back
to the representation on `-flushGraphics`. It reads the representation first, so
a second context for the same bitmap adds to what is already there. Cairo holds
a pixel as a native word with the alpha in the top byte, the representation as
four bytes with the alpha last.

Only a 32 bit non planar bitmap in device or calibrated RGB with premultiplied
alpha last gets a surface; any other layout is as it was. On macOS the drawing
reaches the representation without a flush; here it needs one.

Tests/cairo/bitmapcontextdraw.m, run under a display with
`gnustep-tests Tests/cairo/bitmapcontextdraw.m`.

That file fails 7 of its 10 assertions against master and passes 10 here. Tests/
goes from 255 passed 0 failed to 265 passed 0 failed, with the same 31 skipped
sets.

Closes #184
