### PR TITLE
Fix: take the window's alpha plane before drawing, not only when the state is made

### DIFF
--- a/Source/xlib/XGGState.m
+++ b/Source/xlib/XGGState.m
@@ -72,6 +72,7 @@ xrRGBToPixel(RContext* context, device_color_t color)
 
 @interface XGGState (Private)
 - (void) _alphaBuffer: (gswindow_device_t *)dest_win;
+- (void) _useAlphaBuffer;
 - (BOOL) _blendRect: (NSRect)aRect;
 - (void) createGraphicContext;
 - (void) copyGraphicContext;
@@ -483,7 +484,25 @@ static Region emptyRegion;
     }
 }
 
-- (void) _compositeGState: (XGGState *) source 
+/* A state takes the window's alpha plane in -setWindowDevice:, but the plane
+   is created on demand and need not have existed then.  Take it before
+   drawing, so that what this state draws is recorded there as well.  The
+   plane is not created here: a window without one is opaque, and drawing an
+   opaque colour into it keeps it that way.
+*/
+- (void) _useAlphaBuffer
+{
+  gswindow_device_t *gs_win = (gswindow_device_t *)windevice;
+
+  if (drawingAlpha == NO && shouldDrawAlpha == YES
+      && gs_win != NULL && gs_win->alpha_buffer != 0)
+    {
+      alpha_buffer = gs_win->alpha_buffer;
+      drawingAlpha = YES;
+    }
+}
+
+- (void) _compositeGState: (XGGState *) source
                  fromRect: (NSRect) fromRect
                   toPoint: (NSPoint) toPoint
                        op: (NSCompositingOperation) op
@@ -880,6 +899,8 @@ static Region emptyRegion;
   CGFloat gray = 0.0;
   BOOL    highlight = NO;
 
+  [self _useAlphaBuffer];
+
   /* Source over is the one operator here whose result depends on the alpha
      of the colour, and no raster function can express that: whatever is
      drawn, the pixel that goes down is the colour itself. */
@@ -918,11 +939,12 @@ static Region emptyRegion;
     case NSCompositeDestinationIn:
     case NSCompositeDestinationAtop:
       /* An opaque destination admits nothing of the source, so it stands as
-         it is. */
-      if (drawingAlpha == NO)
-        return;
-      gcv.function = GXcopy;
-      break;
+         it is.  Where the destination is transparent the source belongs
+         underneath it, which no raster function expresses: a copy would put
+         the source over the whole rectangle instead.  So nothing is drawn.
+         Whether this state records alpha says nothing about the destination
+         and is not consulted here. */
+      return;
     case NSCompositeDestinationOut:
       gcv.function = GXcopy;
       break;
@@ -956,11 +978,24 @@ static Region emptyRegion;
     }
 
   [self setGCValues: gcv withMask: GCFunction];
+  /* The alpha plane records what the colour plane is given, so it takes the
+     same raster function.  Without this a clear leaves the colour at zero
+     and the alpha at the colour's own, and the rectangle reads back opaque.
+     The alpha graphics context is made on demand, so ask for it first. */
+  if (drawingAlpha == YES && gcv.function != GXcopy)
+    {
+      [self setAlphaColor: fillColor.field[AINDEX]];
+      XSetFunction(XDPY, agcntxt, gcv.function);
+    }
   [self DPSrectfill: NSMinX(aRect) : NSMinY(aRect)
         : NSWidth(aRect) : NSHeight(aRect)];
 
   if (gcv.function != GXcopy)
     {
+      if (drawingAlpha == YES)
+        {
+          XSetFunction(XDPY, agcntxt, GXcopy);
+        }
       gcv.function = GXcopy;
       [self setGCValues: gcv withMask: GCFunction];
     }
@@ -982,6 +1017,7 @@ static Region emptyRegion;
       DPS_WARN(DPSinvalidid, @"No Drawable defined for path");
       return;
     }
+  [self _useAlphaBuffer];
   fill_rule = WindingRule;
   switch (type)
     {
@@ -1125,6 +1161,8 @@ static Region emptyRegion;
       [self _doComplexClip: pts : types : count draw: type];
       return;
     }
+
+  [self _useAlphaBuffer];
 
   XGetGeometry (XDPY, draw, &root_rtn, &x, &y, &width, &height,
                 &b_rtn, &d_rtn);
@@ -1451,7 +1489,8 @@ static Region emptyRegion;
       DPS_WARN(DPSinvalidid, @"No Drawable defined for show");
       return;
     }
-  
+  [self _useAlphaBuffer];
+
   if ((cstate & COLOR_FILL) == 0)
     [self setColor: &fillColor state: COLOR_FILL];
 
@@ -1501,7 +1540,8 @@ static Region emptyRegion;
       DPS_WARN(DPSinvalidid, @"No Drawable defined for show");
       return;
     }
-  
+  [self _useAlphaBuffer];
+
   if ((cstate & COLOR_FILL) == 0)
     [self setColor: &fillColor state: COLOR_FILL];
 
@@ -1729,6 +1769,7 @@ static Region emptyRegion;
       DPS_WARN(DPSinvalidid, @"No Drawable defined for drawing");
       return;
     }
+  [self _useAlphaBuffer];
 
   if (pattern != nil)
     {
@@ -1775,6 +1816,7 @@ NSDebugLLog(@"XGGraphics", @"Fill %@ X rect %d,%d,%d,%d",
       DPS_WARN(DPSinvalidid, @"No Drawable defined for drawing");
       return;
     }
+  [self _useAlphaBuffer];
 
   if ((cstate & COLOR_STROKE) == 0)
     [self setColor: &fillColor state: COLOR_STROKE];

--- a/Tests/xlib/GNUmakefile.preamble
+++ b/Tests/xlib/GNUmakefile.preamble
@@ -1,10 +1,11 @@
 # Extra build settings for the xlib graphics backend tests.
 #
-# These tests include an xlib backend header directly, so they can only build
-# for that backend.  config.make names the graphics backend being built
-# (BUILD_GRAPHICS); the X11, Xft and backend header paths are added only for
-# xlib, and the tests carry a matching source-level guard (via config.h) so
-# they still build -- and skip -- on every other backend.
+# These tests include an xlib backend header directly, or drive the installed
+# backend through AppKit, so they can only build for that backend.
+# config.make names the graphics backend being built (BUILD_GRAPHICS); the
+# X11, Xft, gui and backend header paths are added only for xlib, and the
+# tests carry a matching source-level guard (via config.h) so they still
+# build -- and skip -- on every other backend.
 
 # config.h (used by the source-level guard) sits at the top of the (build) tree.
 ADDITIONAL_INCLUDE_DIRS += -I$(GNUSTEP_BUILD_DIR)/../.. -I../..
@@ -17,5 +18,5 @@ ADDITIONAL_INCLUDE_DIRS += -I$(GNUSTEP_BUILD_DIR)/../../Headers \
                            -I../../Headers \
                            $(shell pkg-config --cflags x11 xft)
 
-ADDITIONAL_TOOL_LIBS += -lm
+ADDITIONAL_TOOL_LIBS += -lm -lgnustep-gui
 endif

--- a/Tests/xlib/alpharecording.m
+++ b/Tests/xlib/alpharecording.m
@@ -1,0 +1,133 @@
+/* What is drawn into an offscreen image has to be recorded in the alpha plane
+ * the window keeps, so that reading the pixels back reports the alpha that was
+ * drawn: an opaque fill reads back opaque, and a cleared rectangle reads back
+ * transparent.
+ *
+ * The plane is created the first time something needs it, which for an image
+ * cache is the clear the drawing starts with, so a graphics state set up
+ * before that has to take the plane before it draws.
+ *
+ * It needs a window server to draw at all, so it skips cleanly when there is
+ * none, and it guards on the xlib graphics backend being the one built.
+ */
+#import <Foundation/NSObject.h>
+#import "Testing.h"
+#include "config.h"
+
+#if defined(BUILD_GRAPHICS) && defined(GRAPHICS_xlib) \
+  && BUILD_GRAPHICS == GRAPHICS_xlib
+
+#import <AppKit/AppKit.h>
+#include <stdlib.h>
+
+#define SIDE 20
+
+/* Draw into an offscreen image and read the centre pixel back. */
+static NSBitmapImageRep *
+drawn(void (^body)(void))
+{
+  NSImage *image;
+  NSBitmapImageRep *rep;
+
+  image = AUTORELEASE([[NSImage alloc]
+    initWithSize: NSMakeSize(SIDE, SIDE)]);
+  [image lockFocus];
+  body();
+  rep = AUTORELEASE([[NSBitmapImageRep alloc]
+    initWithFocusedViewRect: NSMakeRect(0, 0, SIDE, SIDE)]);
+  [image unlockFocus];
+  return rep;
+}
+
+static int
+sample(NSBitmapImageRep *rep, int index)
+{
+  unsigned char *p;
+
+  if (rep == nil || [rep samplesPerPixel] < 4)
+    {
+      return -1;
+    }
+  p = [rep bitmapData] + (SIDE / 2) * [rep bytesPerRow]
+    + (SIDE / 2) * ([rep bitsPerPixel] / 8);
+  return (int)p[index];
+}
+
+int
+main(int argc, const char **argv)
+{
+  START_SET("alpha recording")
+
+  NSBitmapImageRep *rep;
+
+  if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
+    {
+      SKIP("no window server available")
+    }
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      SKIP("It looks like the GNUstep backend is not installed")
+    }
+  NS_ENDHANDLER
+
+  rep = drawn(^{
+    [[NSColor colorWithDeviceRed: 1.0 green: 0.0 blue: 0.0 alpha: 1.0] set];
+    NSRectFill(NSMakeRect(0, 0, SIDE, SIDE));
+  });
+  PASS(rep != nil, "an offscreen image reads back");
+  PASS(sample(rep, 0) == 255 && sample(rep, 1) == 0 && sample(rep, 2) == 0,
+    "an opaque fill reads back as the colour that was drawn");
+  PASS(sample(rep, 3) == 255,
+    "an opaque fill reads back opaque");
+
+  rep = drawn(^{
+    NSRectFillUsingOperation(NSMakeRect(0, 0, SIDE, SIDE), NSCompositeClear);
+  });
+  PASS(sample(rep, 3) == 0,
+    "a cleared rectangle reads back transparent");
+
+  rep = drawn(^{
+    [[NSColor colorWithDeviceRed: 1.0 green: 0.0 blue: 0.0 alpha: 1.0] set];
+    NSRectFill(NSMakeRect(0, 0, SIDE, SIDE));
+    NSRectFillUsingOperation(NSMakeRect(0, 0, SIDE, SIDE), NSCompositeClear);
+  });
+  PASS(sample(rep, 3) == 0,
+    "clearing over an opaque fill reads back transparent");
+
+  rep = drawn(^{
+    NSRectFillUsingOperation(NSMakeRect(0, 0, SIDE, SIDE), NSCompositeClear);
+    [[NSColor colorWithDeviceRed: 1.0 green: 0.0 blue: 0.0 alpha: 1.0] set];
+    NSRectFill(NSMakeRect(0, 0, SIDE, SIDE));
+  });
+  PASS(sample(rep, 3) == 255,
+    "an opaque fill over a cleared rectangle reads back opaque");
+
+  rep = drawn(^{
+    [[NSColor colorWithDeviceRed: 1.0 green: 0.0 blue: 0.0 alpha: 0.5] set];
+    NSRectFill(NSMakeRect(0, 0, SIDE, SIDE));
+  });
+  PASS(sample(rep, 3) > 100 && sample(rep, 3) < 160,
+    "a half transparent fill reads back half transparent");
+
+  END_SET("alpha recording")
+
+  return 0;
+}
+
+#else
+
+int
+main(int argc, const char **argv)
+{
+  START_SET("alpha recording")
+    SKIP("back is not built with the xlib graphics backend")
+  END_SET("alpha recording")
+  return 0;
+}
+
+#endif

--- a/Tests/xlib/alpharecording.m
+++ b/Tests/xlib/alpharecording.m
@@ -22,9 +22,34 @@
 
 #define SIDE 20
 
-/* Draw into an offscreen image and read the centre pixel back. */
+enum
+{
+  OpaqueFill,
+  Cleared,
+  FillThenClear,
+  ClearThenFill,
+  HalfFill
+};
+
+static void
+fill(CGFloat alpha)
+{
+  [[NSColor colorWithDeviceRed: 1.0
+                         green: 0.0
+                          blue: 0.0
+                         alpha: alpha] set];
+  NSRectFill(NSMakeRect(0, 0, SIDE, SIDE));
+}
+
+static void
+clear(void)
+{
+  NSRectFillUsingOperation(NSMakeRect(0, 0, SIDE, SIDE), NSCompositeClear);
+}
+
+/* Draw one of the cases into an offscreen image and read the pixels back. */
 static NSBitmapImageRep *
-drawn(void (^body)(void))
+drawn(int which)
 {
   NSImage *image;
   NSBitmapImageRep *rep;
@@ -32,7 +57,26 @@ drawn(void (^body)(void))
   image = AUTORELEASE([[NSImage alloc]
     initWithSize: NSMakeSize(SIDE, SIDE)]);
   [image lockFocus];
-  body();
+  switch (which)
+    {
+      case OpaqueFill:
+        fill(1.0);
+        break;
+      case Cleared:
+        clear();
+        break;
+      case FillThenClear:
+        fill(1.0);
+        clear();
+        break;
+      case ClearThenFill:
+        clear();
+        fill(1.0);
+        break;
+      case HalfFill:
+        fill(0.5);
+        break;
+    }
   rep = AUTORELEASE([[NSBitmapImageRep alloc]
     initWithFocusedViewRect: NSMakeRect(0, 0, SIDE, SIDE)]);
   [image unlockFocus];
@@ -75,42 +119,23 @@ main(int argc, const char **argv)
     }
   NS_ENDHANDLER
 
-  rep = drawn(^{
-    [[NSColor colorWithDeviceRed: 1.0 green: 0.0 blue: 0.0 alpha: 1.0] set];
-    NSRectFill(NSMakeRect(0, 0, SIDE, SIDE));
-  });
+  rep = drawn(OpaqueFill);
   PASS(rep != nil, "an offscreen image reads back");
   PASS(sample(rep, 0) == 255 && sample(rep, 1) == 0 && sample(rep, 2) == 0,
     "an opaque fill reads back as the colour that was drawn");
   PASS(sample(rep, 3) == 255,
     "an opaque fill reads back opaque");
 
-  rep = drawn(^{
-    NSRectFillUsingOperation(NSMakeRect(0, 0, SIDE, SIDE), NSCompositeClear);
-  });
-  PASS(sample(rep, 3) == 0,
+  PASS(sample(drawn(Cleared), 3) == 0,
     "a cleared rectangle reads back transparent");
 
-  rep = drawn(^{
-    [[NSColor colorWithDeviceRed: 1.0 green: 0.0 blue: 0.0 alpha: 1.0] set];
-    NSRectFill(NSMakeRect(0, 0, SIDE, SIDE));
-    NSRectFillUsingOperation(NSMakeRect(0, 0, SIDE, SIDE), NSCompositeClear);
-  });
-  PASS(sample(rep, 3) == 0,
+  PASS(sample(drawn(FillThenClear), 3) == 0,
     "clearing over an opaque fill reads back transparent");
 
-  rep = drawn(^{
-    NSRectFillUsingOperation(NSMakeRect(0, 0, SIDE, SIDE), NSCompositeClear);
-    [[NSColor colorWithDeviceRed: 1.0 green: 0.0 blue: 0.0 alpha: 1.0] set];
-    NSRectFill(NSMakeRect(0, 0, SIDE, SIDE));
-  });
-  PASS(sample(rep, 3) == 255,
+  PASS(sample(drawn(ClearThenFill), 3) == 255,
     "an opaque fill over a cleared rectangle reads back opaque");
 
-  rep = drawn(^{
-    [[NSColor colorWithDeviceRed: 1.0 green: 0.0 blue: 0.0 alpha: 0.5] set];
-    NSRectFill(NSMakeRect(0, 0, SIDE, SIDE));
-  });
+  rep = drawn(HalfFill);
   PASS(sample(rep, 3) > 100 && sample(rep, 3) < 160,
     "a half transparent fill reads back half transparent");
 

--- a/Tests/xlib/alpharecording.m
+++ b/Tests/xlib/alpharecording.m
@@ -115,6 +115,7 @@ main(int argc, const char **argv)
     }
   NS_HANDLER
     {
+      NSLog(@"the application did not start: %@", localException);
       SKIP("It looks like the GNUstep backend is not installed")
     }
   NS_ENDHANDLER


### PR DESCRIPTION
A graphics state takes the window's alpha plane in `-setWindowDevice:`, but the
plane is created on demand and need not exist then, and the state keeps
drawingAlpha NO for the rest of its life. Everything it draws goes unrecorded.
An opaque fill into an offscreen image reads back with an alpha of zero, where
cairo, art and opal all give 255.

Each drawing operation now takes the plane if the window has one. It is not
created there: a window without one is opaque.

Two things follow from more states holding the plane. `-compositerect:op:` read
drawingAlpha as meaning the destination has transparency, and for destination
over, in and atop fell through to a copy, which paints the source over the
whole rectangle. Those three now leave the destination as it is, which is what
they already did in every reachable case. The alpha plane also takes the
colour plane's raster function, so a clear records transparency rather than
the colour's own alpha.

Tests/xlib/alpharecording.m, run under a display with
`gnustep-tests Tests/xlib/alpharecording.m`.

It fails 2 of its 7 assertions against master and passes 7 here. Tests/ goes
from 150 passed 2 failed to 152 passed 0 failed, same 45 skipped sets. Tests/gui
is 4613 passed 0 failed either way. Those numbers are from an xlib build under
Xvfb. The set skips on the x11 xlib CI job, where the application does not
start; no test in that job drives AppKit today.

Closes #209
