### PR TITLE
Fix: composite plus darker as the operator is defined, not as saturate

### DIFF
--- a/Source/cairo/CairoGState.m
+++ b/Source/cairo/CairoGState.m
@@ -1260,6 +1260,120 @@ _set_op(cairo_t *ct, NSCompositingOperation op)
     }
 }
 
+#if CAIRO_VERSION >= CAIRO_VERSION_ENCODE(1, 12, 0)
+/* Plus darker adds the two premultiplied colours and takes off the amount by
+   which their alphas overlap: Ra = MIN(1, Sa + Da) and
+   Rp = MAX(0, Sp + Dp - MAX(0, Sa + Da - 1)).  With both opaque that is
+   MAX(0, S + D - 1), which is what the operator is documented as.  Cairo has
+   no operator for it, so the pixels are read, combined and written again.
+   Answers NO when the surface cannot be reached that way, and the caller then
+   falls back.
+*/
+- (BOOL) _plusDarkerRect: (NSRect)aRect
+{
+  cairo_surface_t *target;
+  cairo_surface_t *image;
+  cairo_format_t format;
+  device_color_t c;
+  double x1, y1, x2, y2, ox, oy;
+  int left, top, right, bottom, x, y, stride, width, height;
+  unsigned sr, sg, sb, sa;
+  unsigned char *data;
+
+  target = cairo_get_target(_ct);
+  if (target == NULL || cairo_surface_status(target) != CAIRO_STATUS_SUCCESS)
+    {
+      return NO;
+    }
+
+  /* The clip is already the rectangle, in user space; the surface holds the
+     pixels at its own origin, which the device offset gives. */
+  cairo_clip_extents(_ct, &x1, &y1, &x2, &y2);
+  cairo_user_to_device(_ct, &x1, &y1);
+  cairo_user_to_device(_ct, &x2, &y2);
+  cairo_surface_get_device_offset(target, &ox, &oy);
+  left = (int)floor(MIN(x1, x2) + ox);
+  top = (int)floor(MIN(y1, y2) + oy);
+  right = (int)ceil(MAX(x1, x2) + ox);
+  bottom = (int)ceil(MAX(y1, y2) + oy);
+
+  width = right - left;
+  height = bottom - top;
+  if (width <= 0 || height <= 0)
+    {
+      return NO;
+    }
+
+  /* Take a copy of the destination through cairo itself, rather than writing
+     into the surface behind its back. */
+  image = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width, height);
+  if (cairo_surface_status(image) != CAIRO_STATUS_SUCCESS)
+    {
+      cairo_surface_destroy(image);
+      return NO;
+    }
+  {
+    cairo_t *copy = cairo_create(image);
+
+    cairo_set_operator(copy, CAIRO_OPERATOR_SOURCE);
+    cairo_set_source_surface(copy, target, -(left - ox), -(top - oy));
+    cairo_paint(copy);
+    cairo_destroy(copy);
+  }
+
+  cairo_surface_flush(image);
+  format = CAIRO_FORMAT_ARGB32;
+  stride = cairo_image_surface_get_stride(image);
+  data = cairo_image_surface_get_data(image);
+  if (data == NULL)
+    {
+      cairo_surface_destroy(image);
+      return NO;
+    }
+
+  c = fillColor;
+  gsColorToRGB(&c);
+  sa = (unsigned)(c.field[AINDEX] * 255 + 0.5);
+  sr = (unsigned)(c.field[0] * c.field[AINDEX] * 255 + 0.5);
+  sg = (unsigned)(c.field[1] * c.field[AINDEX] * 255 + 0.5);
+  sb = (unsigned)(c.field[2] * c.field[AINDEX] * 255 + 0.5);
+
+  for (y = 0; y < height; y++)
+    {
+      uint32_t *row = (uint32_t *)(data + y * stride);
+
+      for (x = 0; x < width; x++)
+        {
+          unsigned da = (format == CAIRO_FORMAT_ARGB32)
+            ? ((row[x] >> 24) & 0xff) : 255;
+          unsigned dr = (row[x] >> 16) & 0xff;
+          unsigned dg = (row[x] >> 8) & 0xff;
+          unsigned db = row[x] & 0xff;
+          unsigned over = (sa + da > 255) ? (sa + da - 255) : 0;
+          unsigned ra = MIN(255, sa + da);
+          unsigned rr = (sr + dr > over) ? (sr + dr - over) : 0;
+          unsigned rg = (sg + dg > over) ? (sg + dg - over) : 0;
+          unsigned rb = (sb + db > over) ? (sb + db - over) : 0;
+
+          row[x] = (ra << 24) | (MIN(rr, ra) << 16) | (MIN(rg, ra) << 8)
+            | MIN(rb, ra);
+        }
+    }
+  cairo_surface_mark_dirty(image);
+
+  /* Put the combined pixels back where they came from. */
+  cairo_save(_ct);
+  cairo_identity_matrix(_ct);
+  cairo_set_operator(_ct, CAIRO_OPERATOR_SOURCE);
+  cairo_set_source_surface(_ct, image, left - ox, top - oy);
+  cairo_paint(_ct);
+  cairo_restore(_ct);
+  cairo_surface_destroy(image);
+
+  return YES;
+}
+#endif
+
 - (void) compositerect: (NSRect)aRect op: (NSCompositingOperation)op
 {
   if (_ct)
@@ -1291,7 +1405,16 @@ _set_op(cairo_t *ct, NSCompositingOperation op)
       [path transformUsingAffineTransform: ctm];
       [self _setPath];
       cairo_clip(_ct);
-      cairo_paint(_ct);
+#if CAIRO_VERSION >= CAIRO_VERSION_ENCODE(1, 12, 0)
+      if (NSCompositePlusDarker == op && [self _plusDarkerRect: aRect] == YES)
+        {
+          /* The pixels were combined directly. */
+        }
+      else
+#endif
+        {
+          cairo_paint(_ct);
+        }
       cairo_restore(_ct);
       path = oldPath;
     }

--- a/Tests/cairo/plusdarker.m
+++ b/Tests/cairo/plusdarker.m
@@ -1,0 +1,136 @@
+/* NSCompositePlusDarker adds the two premultiplied colours and takes off the
+ * amount by which their alphas overlap, so with both opaque it is
+ * MAX(0, source + destination - 1).  Grey 0.8 over grey 0.6 is the case that
+ * tells it apart from a darken blend: this operator gives 0.4, a darken blend
+ * would give 0.6.
+ *
+ * It needs a window server to draw at all, so it skips cleanly when there is
+ * none, and it guards on the cairo graphics backend.
+ */
+#import <Foundation/NSObject.h>
+#import "Testing.h"
+#include "config.h"
+
+#if defined(BUILD_GRAPHICS) && defined(GRAPHICS_cairo) \
+  && BUILD_GRAPHICS == GRAPHICS_cairo
+
+#import <AppKit/AppKit.h>
+#include <stdlib.h>
+
+#define SIDE 20
+
+/* Fill the destination, composite the source over it, read the centre back. */
+static NSBitmapImageRep *
+composite(NSColor *dest, NSColor *source, NSCompositingOperation op)
+{
+  NSImage *image;
+  NSBitmapImageRep *rep;
+
+  image = AUTORELEASE([[NSImage alloc]
+    initWithSize: NSMakeSize(SIDE, SIDE)]);
+  [image lockFocus];
+  NSRectFillUsingOperation(NSMakeRect(0, 0, SIDE, SIDE), NSCompositeClear);
+  if (dest != nil)
+    {
+      [dest set];
+      NSRectFillUsingOperation(NSMakeRect(0, 0, SIDE, SIDE), NSCompositeCopy);
+    }
+  [source set];
+  NSRectFillUsingOperation(NSMakeRect(0, 0, SIDE, SIDE), op);
+  rep = AUTORELEASE([[NSBitmapImageRep alloc]
+    initWithFocusedViewRect: NSMakeRect(0, 0, SIDE, SIDE)]);
+  [image unlockFocus];
+  return rep;
+}
+
+static NSColor *
+grey(CGFloat g, CGFloat a)
+{
+  return [NSColor colorWithDeviceRed: g green: g blue: g alpha: a];
+}
+
+static NSColor *
+rgb(CGFloat r, CGFloat g, CGFloat b, CGFloat a)
+{
+  return [NSColor colorWithDeviceRed: r green: g blue: b alpha: a];
+}
+
+/* The bytes come back premultiplied, and a destination fill rounds to the
+ * nearest byte, so allow two. */
+static BOOL
+isPixel(NSBitmapImageRep *rep, int r, int g, int b, int a)
+{
+  unsigned char *p;
+
+  if (rep == nil || [rep samplesPerPixel] < 4)
+    {
+      return NO;
+    }
+  p = [rep bitmapData] + (SIDE / 2) * [rep bytesPerRow]
+    + (SIDE / 2) * ([rep bitsPerPixel] / 8);
+  return (abs((int)p[0] - r) <= 2 && abs((int)p[1] - g) <= 2
+    && abs((int)p[2] - b) <= 2 && abs((int)p[3] - a) <= 2);
+}
+
+int
+main(int argc, const char **argv)
+{
+  START_SET("plus darker")
+
+  if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
+    {
+      SKIP("no window server available")
+    }
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      NSLog(@"the application did not start: %@", localException);
+      SKIP("It looks like the GNUstep backend is not installed")
+    }
+  NS_ENDHANDLER
+
+  PASS(isPixel(composite(grey(0.6, 1.0), grey(0.8, 1.0), NSCompositePlusDarker),
+      102, 102, 102, 255),
+    "plus darker of 0.8 over 0.6 is 0.4, not the darker of the two");
+
+  PASS(isPixel(composite(grey(0.6, 1.0), grey(0.4, 1.0), NSCompositePlusDarker),
+      0, 0, 0, 255),
+    "plus darker takes anything at or below 1 in total down to black");
+
+  PASS(isPixel(composite(rgb(1, 0, 0, 1), rgb(0, 0, 1, 1),
+      NSCompositePlusDarker), 0, 0, 0, 255),
+    "plus darker of blue over red is black");
+
+  PASS(isPixel(composite(nil, rgb(0, 0, 1, 1), NSCompositePlusDarker),
+      0, 0, 255, 255),
+    "plus darker over a cleared destination shows the source");
+
+  PASS(isPixel(composite(rgb(1, 0, 0, 1), rgb(0, 0, 1, 0.5),
+      NSCompositePlusDarker), 127, 0, 0, 255),
+    "a half transparent source takes off half the overlap");
+
+  PASS(isPixel(composite(grey(0.2, 1.0), grey(0.3, 1.0),
+      NSCompositePlusLighter), 128, 128, 128, 255),
+    "plus lighter adds the two");
+
+  END_SET("plus darker")
+
+  return 0;
+}
+
+#else
+
+int
+main(int argc, const char **argv)
+{
+  START_SET("plus darker")
+    SKIP("back is not built with the cairo graphics backend")
+  END_SET("plus darker")
+  return 0;
+}
+
+#endif


### PR DESCRIPTION
`NSCompositePlusDarker` is mapped onto `CAIRO_OPERATOR_SATURATE` in `_set_op`,
under a note that cairo has no match for it. Saturate leaves an opaque
destination as it is, so the operator did nothing where it should darken: blue
over red answered red, and grey 0.8 over grey 0.6 answered 0.6.

The operator adds the two premultiplied colours and takes off the amount by
which their alphas overlap, so with both opaque it is
MAX(0, source + destination - 1). Cairo has no operator for that, so
`-compositerect:op:` copies the destination out, combines it with the fill
colour and paints it back.

Measured against AppKit over nine destination and source alpha combinations,
the results agree to within the byte the destination fill rounds to. The pixel
path needs cairo 1.12 and falls back to the old mapping if the destination
cannot be copied. The image and graphics state paths keep the old mapping.

Tests/cairo/plusdarker.m, run under a display with
`gnustep-tests Tests/cairo/plusdarker.m`.

It fails 4 of its 6 assertions against master and passes 6 here. Tests/ goes
from 257 passed 4 failed to 261 passed 0 failed, same 31 skipped sets.
Tests/gui from libs-gui is 4613 passed 0 failed either way.
