### PR TITLE
Fix: composite with the operator that was asked for, not always source over

### DIFF
--- a/Source/xlib/XGBitmap.m
+++ b/Source/xlib/XGBitmap.m
@@ -142,6 +142,13 @@ _pixmap_combine_alpha(RContext *context,
     {
       VARIABLES_DECLARATION;
       unsigned	row;
+      /* The operators that leave the destination alone where the source is
+         fully transparent; the rest have to be computed for every pixel. */
+      BOOL keepsDestination = (op == NSCompositeSourceOver
+	|| op == NSCompositeHighlight || op == NSCompositeSourceAtop
+	|| op == NSCompositeDestinationOver || op == NSCompositeDestinationOut
+	|| op == NSCompositeXOR || op == NSCompositePlusLighter
+	|| op == NSCompositePlusDarker);
 
       switch (drawMechanism)
 	{
@@ -175,7 +182,8 @@ _pixmap_combine_alpha(RContext *context,
 	    {
 	      unsigned	sr, sg, sb, sa; // source
 	      unsigned	dr, dg, db, da; // dest
-	      unsigned	ialpha;
+	      unsigned	fs, fd;         // the two Porter Duff coefficients
+	      unsigned	ws, wd, ra;
 
 	      // Get the source pixel information
 	      pixel = XGetPixel(source_im->image, srect.x+col, srect.y+row);
@@ -190,26 +198,16 @@ _pixmap_combine_alpha(RContext *context,
 	      else
 		sa = _amask;
 
-	      if (sa == 0)	// dest wouldn't be changed
-		continue;
+	      if (sa == 0 && keepsDestination)
+		continue;		// dest wouldn't be changed
 
 	      if (fraction < 1.0)
 		sa *= fraction;
-
-	      sr *= sa;
-	      sg *= sa;
-	      sb *= sa;
-
-      	      ialpha = (_amask - sa);
 
 	      // Now get dest pixel
 	      pixel = XGetPixel(dest_im->image, col, row);
 	      PixelToRGB(pixel, dr, dg, db);
 
-      	      dr *= ialpha;
-      	      dg *= ialpha;
-      	      db *= ialpha;
-	      
 	      if (dest_alpha)
 		{
 		  pixel = XGetPixel(dest_alpha->image, col, row);
@@ -218,25 +216,79 @@ _pixmap_combine_alpha(RContext *context,
 	      else  // no alpha channel, background is opaque
 		da = _amask;
 
-	      dr = (sr + dr) / _amask;
-	      dg = (sg + dg) / _amask;
-	      db = (sb + db) / _amask;
+	      /* What each operator keeps of the source and of the
+	         destination, as a share of the alpha unit. */
+	      fs = _amask;
+	      fd = 0;
+	      switch (op)
+		{
+		  case NSCompositeClear:		fs = 0; fd = 0; break;
+		  case NSCompositeCopy:			fs = _amask; fd = 0; break;
+		  case NSCompositeSourceOver:
+		  case NSCompositeHighlight:
+		    fs = _amask; fd = _amask - sa; break;
+		  case NSCompositeSourceIn:		fs = da; fd = 0; break;
+		  case NSCompositeSourceOut:		fs = _amask - da; fd = 0; break;
+		  case NSCompositeSourceAtop:		fs = da; fd = _amask - sa; break;
+		  case NSCompositeDestinationOver:	fs = _amask - da; fd = _amask; break;
+		  case NSCompositeDestinationIn:	fs = 0; fd = sa; break;
+		  case NSCompositeDestinationOut:	fs = 0; fd = _amask - sa; break;
+		  case NSCompositeDestinationAtop:	fs = _amask - da; fd = sa; break;
+		  case NSCompositeXOR:			fs = _amask - da; fd = _amask - sa; break;
+		  case NSCompositePlusLighter:
+		  case NSCompositePlusDarker:
+		    fs = _amask; fd = _amask; break;
+		  default:
+		    fs = _amask; fd = _amask - sa; break;
+		}
 
-	      // calc final alpha
-	      if (sa == _amask || da == _amask)
-		da = _amask;
+	      /* The share each side contributes, in alpha units. */
+	      ws = (fs * sa) / _amask;
+	      wd = (fd * da) / _amask;
+
+	      if (NSCompositePlusDarker == op)
+		{
+		  /* Add the premultiplied colours and take off the amount by
+		     which the two alphas overlap, which with both opaque is
+		     MAX(0, source + destination - 1). */
+		  unsigned over = (sa + da > _amask) ? (sa + da - _amask) : 0;
+		  unsigned or_ = (over * _rmask) / _amask;
+		  unsigned og = (over * _gmask) / _amask;
+		  unsigned ob = (over * _bmask) / _amask;
+
+		  sr = (sr * sa) / _amask;
+		  sg = (sg * sa) / _amask;
+		  sb = (sb * sa) / _amask;
+		  dr = (dr * da) / _amask;
+		  dg = (dg * da) / _amask;
+		  db = (db * da) / _amask;
+		  sr = (sr + dr > or_) ? (sr + dr - or_) : 0;
+		  sg = (sg + dg > og) ? (sg + dg - og) : 0;
+		  sb = (sb + db > ob) ? (sb + db - ob) : 0;
+		  ra = MIN(_amask, sa + da);
+		  dr = ra ? MIN(_rmask, (sr * _amask) / ra) : 0;
+		  dg = ra ? MIN(_gmask, (sg * _amask) / ra) : 0;
+		  db = ra ? MIN(_bmask, (sb * _amask) / ra) : 0;
+		}
 	      else
-		da = sa + ((da * ialpha) / _amask);
+		{
+		  /* The colour is kept without its alpha, so the two shares
+		     are combined and the result divided by the alpha it ends
+		     up with. */
+		  unsigned nr = ws * sr + wd * dr;
+		  unsigned ng = ws * sg + wd * dg;
+		  unsigned nb = ws * sb + wd * db;
 
-	      CLAMP(dr);
-	      CLAMP(dg);
-	      CLAMP(db);
-	      CLAMP(da);
+		  ra = MIN(_amask, ws + wd);
+		  dr = ra ? MIN(_rmask, nr / ra) : 0;
+		  dg = ra ? MIN(_gmask, ng / ra) : 0;
+		  db = ra ? MIN(_bmask, nb / ra) : 0;
+		}
 
 	      RGBToPixel(dr, dg, db, pixel);
 	      XPutPixel(dest_im->image, col, row, pixel);
 	      if (dest_alpha)
-		XPutPixel(dest_alpha->image, col, row, da << _ashift);
+		XPutPixel(dest_alpha->image, col, row, ra << _ashift);
 	    }
 	}
     }

--- a/Source/xlib/XGGState.m
+++ b/Source/xlib/XGGState.m
@@ -73,7 +73,7 @@ xrRGBToPixel(RContext* context, device_color_t color)
 @interface XGGState (Private)
 - (void) _alphaBuffer: (gswindow_device_t *)dest_win;
 - (void) _useAlphaBuffer;
-- (BOOL) _blendRect: (NSRect)aRect;
+- (BOOL) _blendRect: (NSRect)aRect op: (NSCompositingOperation)op;
 - (void) createGraphicContext;
 - (void) copyGraphicContext;
 - (void) setAlphaColor: (float)color;
@@ -801,7 +801,7 @@ static Region emptyRegion;
    colour's alpha through.  The pixels have to be read back, combined and
    written again, which is only possible where they are kept, so this
    answers NO when there is nothing to read and the caller falls back. */
-- (BOOL) _blendRect: (NSRect)aRect
+- (BOOL) _blendRect: (NSRect)aRect op: (NSCompositingOperation)op
 {
   gswindow_device_t *dest_win = (gswindow_device_t *)windevice;
   XRectangle	    bounds;
@@ -877,7 +877,7 @@ static Region emptyRegion;
 
   _pixmap_combine_alpha((RContext *)context, source_im, NULL,
                         dest_im, dest_alpha, from,
-                        NSCompositeSourceOver, drawMechanism,
+                        op, drawMechanism,
                         fillColor.field[AINDEX]);
 
   RPutXImage((RContext *)context, draw, xgcntxt, dest_im, 0, 0,
@@ -901,15 +901,34 @@ static Region emptyRegion;
 
   [self _useAlphaBuffer];
 
-  /* Source over is the one operator here whose result depends on the alpha
-     of the colour, and no raster function can express that: whatever is
-     drawn, the pixel that goes down is the colour itself. */
-  if ((op == NSCompositeSourceOver || op == NSCompositeHighlight)
-      && fillColor.field[AINDEX] < 1.0
-      && pattern == nil
-      && [self _blendRect: aRect] == YES)
+  /* A raster function can only express a copy and a clear.  It happens to
+     give the right answer for the other operators when both the colour and
+     the destination are opaque, because the result is then either the colour
+     or the destination untouched; the operators that make a pixel
+     transparent are not among them.  Everything else has to combine the
+     colour with what is already there, one pixel at a time, and the result
+     needs an alpha plane to be recorded in. */
+  if (pattern == nil
+      && op != NSCompositeClear
+      && op != NSCompositeCopy
+      && op != GSCompositeHighlight
+      && !(fillColor.field[AINDEX] >= 1.0 && drawingAlpha == NO
+        && (op == NSCompositeSourceOver || op == NSCompositeHighlight
+          || op == NSCompositeSourceIn || op == NSCompositeSourceAtop
+          || op == NSCompositeDestinationOver
+          || op == NSCompositeDestinationIn
+          || op == NSCompositeDestinationAtop)))
     {
-      return;
+      gswindow_device_t *gs_win = (gswindow_device_t *)windevice;
+
+      if (gs_win != NULL)
+        {
+          [self _alphaBuffer: gs_win];
+        }
+      if ([self _blendRect: aRect op: op] == YES)
+        {
+          return;
+        }
     }
 
   /* FIXME: Really need alpha dithering to do this right - combine with

--- a/Source/xlib/XGGState.m
+++ b/Source/xlib/XGGState.m
@@ -72,6 +72,7 @@ xrRGBToPixel(RContext* context, device_color_t color)
 
 @interface XGGState (Private)
 - (void) _alphaBuffer: (gswindow_device_t *)dest_win;
+- (void) _useAlphaBuffer;
 - (BOOL) _blendRect: (NSRect)aRect;
 - (void) createGraphicContext;
 - (void) copyGraphicContext;
@@ -483,7 +484,25 @@ static Region emptyRegion;
     }
 }
 
-- (void) _compositeGState: (XGGState *) source 
+/* A state takes the window's alpha plane in -setWindowDevice:, but the plane
+   is created on demand and need not have existed then.  Take it before
+   drawing, so that what this state draws is recorded there as well.  The
+   plane is not created here: a window without one is opaque, and drawing an
+   opaque colour into it keeps it that way.
+*/
+- (void) _useAlphaBuffer
+{
+  gswindow_device_t *gs_win = (gswindow_device_t *)windevice;
+
+  if (drawingAlpha == NO && shouldDrawAlpha == YES
+      && gs_win != NULL && gs_win->alpha_buffer != 0)
+    {
+      alpha_buffer = gs_win->alpha_buffer;
+      drawingAlpha = YES;
+    }
+}
+
+- (void) _compositeGState: (XGGState *) source
                  fromRect: (NSRect) fromRect
                   toPoint: (NSPoint) toPoint
                        op: (NSCompositingOperation) op
@@ -880,6 +899,8 @@ static Region emptyRegion;
   CGFloat gray = 0.0;
   BOOL    highlight = NO;
 
+  [self _useAlphaBuffer];
+
   /* Source over is the one operator here whose result depends on the alpha
      of the colour, and no raster function can express that: whatever is
      drawn, the pixel that goes down is the colour itself. */
@@ -918,11 +939,12 @@ static Region emptyRegion;
     case NSCompositeDestinationIn:
     case NSCompositeDestinationAtop:
       /* An opaque destination admits nothing of the source, so it stands as
-         it is. */
-      if (drawingAlpha == NO)
-        return;
-      gcv.function = GXcopy;
-      break;
+         it is.  Where the destination is transparent the source belongs
+         underneath it, which no raster function expresses: a copy would put
+         the source over the whole rectangle instead.  So nothing is drawn.
+         Whether this state records alpha says nothing about the destination
+         and is not consulted here. */
+      return;
     case NSCompositeDestinationOut:
       gcv.function = GXcopy;
       break;
@@ -956,11 +978,24 @@ static Region emptyRegion;
     }
 
   [self setGCValues: gcv withMask: GCFunction];
+  /* The alpha plane records what the colour plane is given, so it takes the
+     same raster function.  Without this a clear leaves the colour at zero
+     and the alpha at the colour's own, and the rectangle reads back opaque.
+     The alpha graphics context is made on demand, so ask for it first. */
+  if (drawingAlpha == YES && gcv.function != GXcopy)
+    {
+      [self setAlphaColor: fillColor.field[AINDEX]];
+      XSetFunction(XDPY, agcntxt, gcv.function);
+    }
   [self DPSrectfill: NSMinX(aRect) : NSMinY(aRect)
         : NSWidth(aRect) : NSHeight(aRect)];
 
   if (gcv.function != GXcopy)
     {
+      if (drawingAlpha == YES)
+        {
+          XSetFunction(XDPY, agcntxt, GXcopy);
+        }
       gcv.function = GXcopy;
       [self setGCValues: gcv withMask: GCFunction];
     }
@@ -982,6 +1017,7 @@ static Region emptyRegion;
       DPS_WARN(DPSinvalidid, @"No Drawable defined for path");
       return;
     }
+  [self _useAlphaBuffer];
   fill_rule = WindingRule;
   switch (type)
     {
@@ -1125,6 +1161,8 @@ static Region emptyRegion;
       [self _doComplexClip: pts : types : count draw: type];
       return;
     }
+
+  [self _useAlphaBuffer];
 
   XGetGeometry (XDPY, draw, &root_rtn, &x, &y, &width, &height,
                 &b_rtn, &d_rtn);
@@ -1451,7 +1489,8 @@ static Region emptyRegion;
       DPS_WARN(DPSinvalidid, @"No Drawable defined for show");
       return;
     }
-  
+  [self _useAlphaBuffer];
+
   if ((cstate & COLOR_FILL) == 0)
     [self setColor: &fillColor state: COLOR_FILL];
 
@@ -1501,7 +1540,8 @@ static Region emptyRegion;
       DPS_WARN(DPSinvalidid, @"No Drawable defined for show");
       return;
     }
-  
+  [self _useAlphaBuffer];
+
   if ((cstate & COLOR_FILL) == 0)
     [self setColor: &fillColor state: COLOR_FILL];
 
@@ -1729,6 +1769,7 @@ static Region emptyRegion;
       DPS_WARN(DPSinvalidid, @"No Drawable defined for drawing");
       return;
     }
+  [self _useAlphaBuffer];
 
   if (pattern != nil)
     {
@@ -1775,6 +1816,7 @@ NSDebugLLog(@"XGGraphics", @"Fill %@ X rect %d,%d,%d,%d",
       DPS_WARN(DPSinvalidid, @"No Drawable defined for drawing");
       return;
     }
+  [self _useAlphaBuffer];
 
   if ((cstate & COLOR_STROKE) == 0)
     [self setColor: &fillColor state: COLOR_STROKE];

--- a/Tests/xlib/GNUmakefile.preamble
+++ b/Tests/xlib/GNUmakefile.preamble
@@ -1,10 +1,11 @@
 # Extra build settings for the xlib graphics backend tests.
 #
-# These tests include an xlib backend header directly, so they can only build
-# for that backend.  config.make names the graphics backend being built
-# (BUILD_GRAPHICS); the X11, Xft and backend header paths are added only for
-# xlib, and the tests carry a matching source-level guard (via config.h) so
-# they still build -- and skip -- on every other backend.
+# These tests include an xlib backend header directly, or drive the installed
+# backend through AppKit, so they can only build for that backend.
+# config.make names the graphics backend being built (BUILD_GRAPHICS); the
+# X11, Xft, gui and backend header paths are added only for xlib, and the
+# tests carry a matching source-level guard (via config.h) so they still
+# build -- and skip -- on every other backend.
 
 # config.h (used by the source-level guard) sits at the top of the (build) tree.
 ADDITIONAL_INCLUDE_DIRS += -I$(GNUSTEP_BUILD_DIR)/../.. -I../..
@@ -17,5 +18,5 @@ ADDITIONAL_INCLUDE_DIRS += -I$(GNUSTEP_BUILD_DIR)/../../Headers \
                            -I../../Headers \
                            $(shell pkg-config --cflags x11 xft)
 
-ADDITIONAL_TOOL_LIBS += -lm
+ADDITIONAL_TOOL_LIBS += -lm -lgnustep-gui
 endif

--- a/Tests/xlib/alpharecording.m
+++ b/Tests/xlib/alpharecording.m
@@ -1,0 +1,133 @@
+/* What is drawn into an offscreen image has to be recorded in the alpha plane
+ * the window keeps, so that reading the pixels back reports the alpha that was
+ * drawn: an opaque fill reads back opaque, and a cleared rectangle reads back
+ * transparent.
+ *
+ * The plane is created the first time something needs it, which for an image
+ * cache is the clear the drawing starts with, so a graphics state set up
+ * before that has to take the plane before it draws.
+ *
+ * It needs a window server to draw at all, so it skips cleanly when there is
+ * none, and it guards on the xlib graphics backend being the one built.
+ */
+#import <Foundation/NSObject.h>
+#import "Testing.h"
+#include "config.h"
+
+#if defined(BUILD_GRAPHICS) && defined(GRAPHICS_xlib) \
+  && BUILD_GRAPHICS == GRAPHICS_xlib
+
+#import <AppKit/AppKit.h>
+#include <stdlib.h>
+
+#define SIDE 20
+
+/* Draw into an offscreen image and read the centre pixel back. */
+static NSBitmapImageRep *
+drawn(void (^body)(void))
+{
+  NSImage *image;
+  NSBitmapImageRep *rep;
+
+  image = AUTORELEASE([[NSImage alloc]
+    initWithSize: NSMakeSize(SIDE, SIDE)]);
+  [image lockFocus];
+  body();
+  rep = AUTORELEASE([[NSBitmapImageRep alloc]
+    initWithFocusedViewRect: NSMakeRect(0, 0, SIDE, SIDE)]);
+  [image unlockFocus];
+  return rep;
+}
+
+static int
+sample(NSBitmapImageRep *rep, int index)
+{
+  unsigned char *p;
+
+  if (rep == nil || [rep samplesPerPixel] < 4)
+    {
+      return -1;
+    }
+  p = [rep bitmapData] + (SIDE / 2) * [rep bytesPerRow]
+    + (SIDE / 2) * ([rep bitsPerPixel] / 8);
+  return (int)p[index];
+}
+
+int
+main(int argc, const char **argv)
+{
+  START_SET("alpha recording")
+
+  NSBitmapImageRep *rep;
+
+  if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
+    {
+      SKIP("no window server available")
+    }
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      SKIP("It looks like the GNUstep backend is not installed")
+    }
+  NS_ENDHANDLER
+
+  rep = drawn(^{
+    [[NSColor colorWithDeviceRed: 1.0 green: 0.0 blue: 0.0 alpha: 1.0] set];
+    NSRectFill(NSMakeRect(0, 0, SIDE, SIDE));
+  });
+  PASS(rep != nil, "an offscreen image reads back");
+  PASS(sample(rep, 0) == 255 && sample(rep, 1) == 0 && sample(rep, 2) == 0,
+    "an opaque fill reads back as the colour that was drawn");
+  PASS(sample(rep, 3) == 255,
+    "an opaque fill reads back opaque");
+
+  rep = drawn(^{
+    NSRectFillUsingOperation(NSMakeRect(0, 0, SIDE, SIDE), NSCompositeClear);
+  });
+  PASS(sample(rep, 3) == 0,
+    "a cleared rectangle reads back transparent");
+
+  rep = drawn(^{
+    [[NSColor colorWithDeviceRed: 1.0 green: 0.0 blue: 0.0 alpha: 1.0] set];
+    NSRectFill(NSMakeRect(0, 0, SIDE, SIDE));
+    NSRectFillUsingOperation(NSMakeRect(0, 0, SIDE, SIDE), NSCompositeClear);
+  });
+  PASS(sample(rep, 3) == 0,
+    "clearing over an opaque fill reads back transparent");
+
+  rep = drawn(^{
+    NSRectFillUsingOperation(NSMakeRect(0, 0, SIDE, SIDE), NSCompositeClear);
+    [[NSColor colorWithDeviceRed: 1.0 green: 0.0 blue: 0.0 alpha: 1.0] set];
+    NSRectFill(NSMakeRect(0, 0, SIDE, SIDE));
+  });
+  PASS(sample(rep, 3) == 255,
+    "an opaque fill over a cleared rectangle reads back opaque");
+
+  rep = drawn(^{
+    [[NSColor colorWithDeviceRed: 1.0 green: 0.0 blue: 0.0 alpha: 0.5] set];
+    NSRectFill(NSMakeRect(0, 0, SIDE, SIDE));
+  });
+  PASS(sample(rep, 3) > 100 && sample(rep, 3) < 160,
+    "a half transparent fill reads back half transparent");
+
+  END_SET("alpha recording")
+
+  return 0;
+}
+
+#else
+
+int
+main(int argc, const char **argv)
+{
+  START_SET("alpha recording")
+    SKIP("back is not built with the xlib graphics backend")
+  END_SET("alpha recording")
+  return 0;
+}
+
+#endif

--- a/Tests/xlib/alpharecording.m
+++ b/Tests/xlib/alpharecording.m
@@ -22,9 +22,34 @@
 
 #define SIDE 20
 
-/* Draw into an offscreen image and read the centre pixel back. */
+enum
+{
+  OpaqueFill,
+  Cleared,
+  FillThenClear,
+  ClearThenFill,
+  HalfFill
+};
+
+static void
+fill(CGFloat alpha)
+{
+  [[NSColor colorWithDeviceRed: 1.0
+                         green: 0.0
+                          blue: 0.0
+                         alpha: alpha] set];
+  NSRectFill(NSMakeRect(0, 0, SIDE, SIDE));
+}
+
+static void
+clear(void)
+{
+  NSRectFillUsingOperation(NSMakeRect(0, 0, SIDE, SIDE), NSCompositeClear);
+}
+
+/* Draw one of the cases into an offscreen image and read the pixels back. */
 static NSBitmapImageRep *
-drawn(void (^body)(void))
+drawn(int which)
 {
   NSImage *image;
   NSBitmapImageRep *rep;
@@ -32,7 +57,26 @@ drawn(void (^body)(void))
   image = AUTORELEASE([[NSImage alloc]
     initWithSize: NSMakeSize(SIDE, SIDE)]);
   [image lockFocus];
-  body();
+  switch (which)
+    {
+      case OpaqueFill:
+        fill(1.0);
+        break;
+      case Cleared:
+        clear();
+        break;
+      case FillThenClear:
+        fill(1.0);
+        clear();
+        break;
+      case ClearThenFill:
+        clear();
+        fill(1.0);
+        break;
+      case HalfFill:
+        fill(0.5);
+        break;
+    }
   rep = AUTORELEASE([[NSBitmapImageRep alloc]
     initWithFocusedViewRect: NSMakeRect(0, 0, SIDE, SIDE)]);
   [image unlockFocus];
@@ -75,42 +119,23 @@ main(int argc, const char **argv)
     }
   NS_ENDHANDLER
 
-  rep = drawn(^{
-    [[NSColor colorWithDeviceRed: 1.0 green: 0.0 blue: 0.0 alpha: 1.0] set];
-    NSRectFill(NSMakeRect(0, 0, SIDE, SIDE));
-  });
+  rep = drawn(OpaqueFill);
   PASS(rep != nil, "an offscreen image reads back");
   PASS(sample(rep, 0) == 255 && sample(rep, 1) == 0 && sample(rep, 2) == 0,
     "an opaque fill reads back as the colour that was drawn");
   PASS(sample(rep, 3) == 255,
     "an opaque fill reads back opaque");
 
-  rep = drawn(^{
-    NSRectFillUsingOperation(NSMakeRect(0, 0, SIDE, SIDE), NSCompositeClear);
-  });
-  PASS(sample(rep, 3) == 0,
+  PASS(sample(drawn(Cleared), 3) == 0,
     "a cleared rectangle reads back transparent");
 
-  rep = drawn(^{
-    [[NSColor colorWithDeviceRed: 1.0 green: 0.0 blue: 0.0 alpha: 1.0] set];
-    NSRectFill(NSMakeRect(0, 0, SIDE, SIDE));
-    NSRectFillUsingOperation(NSMakeRect(0, 0, SIDE, SIDE), NSCompositeClear);
-  });
-  PASS(sample(rep, 3) == 0,
+  PASS(sample(drawn(FillThenClear), 3) == 0,
     "clearing over an opaque fill reads back transparent");
 
-  rep = drawn(^{
-    NSRectFillUsingOperation(NSMakeRect(0, 0, SIDE, SIDE), NSCompositeClear);
-    [[NSColor colorWithDeviceRed: 1.0 green: 0.0 blue: 0.0 alpha: 1.0] set];
-    NSRectFill(NSMakeRect(0, 0, SIDE, SIDE));
-  });
-  PASS(sample(rep, 3) == 255,
+  PASS(sample(drawn(ClearThenFill), 3) == 255,
     "an opaque fill over a cleared rectangle reads back opaque");
 
-  rep = drawn(^{
-    [[NSColor colorWithDeviceRed: 1.0 green: 0.0 blue: 0.0 alpha: 0.5] set];
-    NSRectFill(NSMakeRect(0, 0, SIDE, SIDE));
-  });
+  rep = drawn(HalfFill);
   PASS(sample(rep, 3) > 100 && sample(rep, 3) < 160,
     "a half transparent fill reads back half transparent");
 

--- a/Tests/xlib/alpharecording.m
+++ b/Tests/xlib/alpharecording.m
@@ -115,6 +115,7 @@ main(int argc, const char **argv)
     }
   NS_HANDLER
     {
+      NSLog(@"the application did not start: %@", localException);
       SKIP("It looks like the GNUstep backend is not installed")
     }
   NS_ENDHANDLER

--- a/Tests/xlib/compositeops.m
+++ b/Tests/xlib/compositeops.m
@@ -1,0 +1,145 @@
+/* The compositing operators, checked by reading the pixels back.  An opaque
+ * blue is composited over an opaque red destination and over a cleared one,
+ * and each operator keeps the source, the destination, or neither.
+ *
+ * The colours here are opaque, where the backend's own convention for storing
+ * a partly transparent colour does not come into it, and every value below is
+ * what AppKit answers for the same drawing.
+ *
+ * It needs a window server to draw at all, so it skips cleanly when there is
+ * none, and it guards on the xlib graphics backend.
+ */
+#import <Foundation/NSObject.h>
+#import "Testing.h"
+#include "config.h"
+
+#if defined(BUILD_GRAPHICS) && defined(GRAPHICS_xlib) \
+  && BUILD_GRAPHICS == GRAPHICS_xlib
+
+#import <AppKit/AppKit.h>
+#include <stdlib.h>
+
+#define SIDE 20
+
+/* Fill the destination if there is one, composite blue over it with OP, and
+ * read the centre pixel back. */
+static NSBitmapImageRep *
+composite(BOOL opaqueDestination, NSCompositingOperation op)
+{
+  NSImage *image;
+  NSBitmapImageRep *rep;
+
+  image = AUTORELEASE([[NSImage alloc]
+    initWithSize: NSMakeSize(SIDE, SIDE)]);
+  [image lockFocus];
+  NSRectFillUsingOperation(NSMakeRect(0, 0, SIDE, SIDE), NSCompositeClear);
+  if (opaqueDestination)
+    {
+      [[NSColor colorWithDeviceRed: 1 green: 0 blue: 0 alpha: 1] set];
+      NSRectFillUsingOperation(NSMakeRect(0, 0, SIDE, SIDE), NSCompositeCopy);
+    }
+  [[NSColor colorWithDeviceRed: 0 green: 0 blue: 1 alpha: 1] set];
+  NSRectFillUsingOperation(NSMakeRect(0, 0, SIDE, SIDE), op);
+  rep = AUTORELEASE([[NSBitmapImageRep alloc]
+    initWithFocusedViewRect: NSMakeRect(0, 0, SIDE, SIDE)]);
+  [image unlockFocus];
+  return rep;
+}
+
+static BOOL
+isPixel(NSBitmapImageRep *rep, int r, int g, int b, int a)
+{
+  unsigned char *p;
+
+  if (rep == nil || [rep samplesPerPixel] < 4)
+    {
+      return NO;
+    }
+  p = [rep bitmapData] + (SIDE / 2) * [rep bytesPerRow]
+    + (SIDE / 2) * ([rep bitsPerPixel] / 8);
+  return (abs((int)p[0] - r) <= 2 && abs((int)p[1] - g) <= 2
+    && abs((int)p[2] - b) <= 2 && abs((int)p[3] - a) <= 2);
+}
+
+int
+main(int argc, const char **argv)
+{
+  START_SET("composite operators")
+
+  if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
+    {
+      SKIP("no window server available")
+    }
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      NSLog(@"the application did not start: %@", localException);
+      SKIP("It looks like the GNUstep backend is not installed")
+    }
+  NS_ENDHANDLER
+
+  /* Over an opaque destination. */
+  PASS(isPixel(composite(YES, NSCompositeCopy), 0, 0, 255, 255),
+    "copy replaces the destination");
+  PASS(isPixel(composite(YES, NSCompositeSourceOver), 0, 0, 255, 255),
+    "source over shows an opaque source");
+  PASS(isPixel(composite(YES, NSCompositeSourceIn), 0, 0, 255, 255),
+    "source in shows the source where the destination is opaque");
+  PASS(isPixel(composite(YES, NSCompositeSourceOut), 0, 0, 0, 0),
+    "source out shows nothing where the destination is opaque");
+  PASS(isPixel(composite(YES, NSCompositeSourceAtop), 0, 0, 255, 255),
+    "source atop shows the source over an opaque destination");
+  PASS(isPixel(composite(YES, NSCompositeDestinationOver), 255, 0, 0, 255),
+    "destination over keeps an opaque destination");
+  PASS(isPixel(composite(YES, NSCompositeDestinationIn), 255, 0, 0, 255),
+    "destination in keeps the destination under an opaque source");
+  PASS(isPixel(composite(YES, NSCompositeDestinationOut), 0, 0, 0, 0),
+    "destination out erases the destination under an opaque source");
+  PASS(isPixel(composite(YES, NSCompositeDestinationAtop), 255, 0, 0, 255),
+    "destination atop keeps the destination under an opaque source");
+  PASS(isPixel(composite(YES, NSCompositeXOR), 0, 0, 0, 0),
+    "exclusive or of two opaque pixels leaves nothing");
+  PASS(isPixel(composite(YES, NSCompositePlusDarker), 0, 0, 0, 255),
+    "plus darker of blue over red is black");
+  PASS(isPixel(composite(YES, NSCompositePlusLighter), 255, 0, 255, 255),
+    "plus lighter adds the source to the destination");
+  PASS(isPixel(composite(YES, NSCompositeClear), 0, 0, 0, 0),
+    "clear erases the destination");
+
+  /* Over a cleared destination. */
+  PASS(isPixel(composite(NO, NSCompositeSourceOver), 0, 0, 255, 255),
+    "source over a cleared destination shows the source");
+  PASS(isPixel(composite(NO, NSCompositeSourceIn), 0, 0, 0, 0),
+    "source in shows nothing where the destination is transparent");
+  PASS(isPixel(composite(NO, NSCompositeSourceOut), 0, 0, 255, 255),
+    "source out shows the source where the destination is transparent");
+  PASS(isPixel(composite(NO, NSCompositeDestinationOver), 0, 0, 255, 255),
+    "destination over a cleared destination shows the source");
+  PASS(isPixel(composite(NO, NSCompositeDestinationIn), 0, 0, 0, 0),
+    "destination in leaves a cleared destination cleared");
+  PASS(isPixel(composite(NO, NSCompositeDestinationAtop), 0, 0, 255, 255),
+    "destination atop a cleared destination shows the source");
+  PASS(isPixel(composite(NO, NSCompositeXOR), 0, 0, 255, 255),
+    "exclusive or over a cleared destination shows the source");
+
+  END_SET("composite operators")
+
+  return 0;
+}
+
+#else
+
+int
+main(int argc, const char **argv)
+{
+  START_SET("composite operators")
+    SKIP("back is not built with the xlib graphics backend")
+  END_SET("composite operators")
+  return 0;
+}
+
+#endif


### PR DESCRIPTION
`_pixmap_combine_alpha` takes an operator and never read it, so every caller
got source over, and `-compositerect:op:` had only the raster functions, which
express a copy and a clear. Nine of the thirteen operators answered something
else: six copied the source, and the three destination operators drew nothing
onto a transparent destination.

The combine now works out what each operator keeps of the source and of the
destination, and divides by the alpha the pixel ends up with, since the
drawable holds the colour without its alpha. Plus darker adds the two
premultiplied colours and takes off the alpha overlap.

`-compositerect:op:` goes through the combine except where a raster function
is exact, and creates the alpha plane for an operator that can make a pixel
transparent. The path for a display without direct colour still composites
source over.

Tests/xlib/compositeops.m, run under a display. Every value in it is what
AppKit answers for the same drawing.

Tests/ goes from 152 passed 0 failed to 172 passed 0 failed, same 45 skipped
sets; Tests/gui is 4613 passed 0 failed either way. The set skips on the x11
xlib CI job, where the application does not start. Stacked on #219.
