### PR TITLE
Fix: answer -glyphWithName: with a glyph the font can measure

### DIFF
--- a/Source/cairo/CairoFontInfo.m
+++ b/Source/cairo/CairoFontInfo.m
@@ -266,9 +266,32 @@ void set_font_options(cairo_font_options_t *options)
   if (_scaled)
     {
       FT_Face face = cairo_ft_scaled_font_lock_face(_scaled);
+
       if (FT_Has_PS_Glyph_Names(face))
 	{
-	  val = (NSGlyph) FT_Get_Name_Index(face, name);
+	  FT_UInt index = FT_Get_Name_Index(face, name);
+
+	  /* An NSGlyph is a character here, which is what -glyphIsEncoded:,
+	     -advancementForGlyph: and -boundingRectForGlyph: read, so the
+	     named glyph is answered as the character that selects it rather
+	     than as the index the name has in the face. A glyph no character
+	     reaches, an alternate or a ligature, has no answer in that
+	     convention and stays NSNullGlyph. */
+	  if (index != 0)
+	    {
+	      FT_UInt  gindex;
+	      FT_ULong charcode = FT_Get_First_Char(face, &gindex);
+
+	      while (gindex != 0)
+		{
+		  if (gindex == index)
+		    {
+		      val = (NSGlyph)charcode;
+		      break;
+		    }
+		  charcode = FT_Get_Next_Char(face, charcode, &gindex);
+		}
+	    }
 	}
 
       cairo_ft_scaled_font_unlock_face(_scaled);

--- a/Source/winlib/WIN32FontInfo.m
+++ b/Source/winlib/WIN32FontInfo.m
@@ -34,8 +34,37 @@
 
 #include "winlib/WIN32FontInfo.h"
 
+#include <string.h>
+
 int win32_font_weight(LONG tmWeight);
 NSString *win32_font_family(NSString *fontName);
+
+/* The standard glyph names of the Latin set, for -glyphWithName:. The names
+   of the letters and digits are the characters themselves, apart from the
+   digits, so only the ones that differ are listed. */
+static const struct
+{
+  const char *name;
+  unichar     character;
+}
+standardGlyphNames[] =
+{
+  {"space", 0x0020},       {"exclam", 0x0021},      {"quotedbl", 0x0022},
+  {"numbersign", 0x0023},  {"dollar", 0x0024},      {"percent", 0x0025},
+  {"ampersand", 0x0026},   {"quotesingle", 0x0027}, {"parenleft", 0x0028},
+  {"parenright", 0x0029},  {"asterisk", 0x002A},    {"plus", 0x002B},
+  {"comma", 0x002C},       {"hyphen", 0x002D},      {"period", 0x002E},
+  {"slash", 0x002F},       {"zero", 0x0030},        {"one", 0x0031},
+  {"two", 0x0032},         {"three", 0x0033},       {"four", 0x0034},
+  {"five", 0x0035},        {"six", 0x0036},         {"seven", 0x0037},
+  {"eight", 0x0038},       {"nine", 0x0039},        {"colon", 0x003A},
+  {"semicolon", 0x003B},   {"less", 0x003C},        {"equal", 0x003D},
+  {"greater", 0x003E},     {"question", 0x003F},    {"at", 0x0040},
+  {"bracketleft", 0x005B}, {"backslash", 0x005C},   {"bracketright", 0x005D},
+  {"asciicircum", 0x005E}, {"underscore", 0x005F},  {"grave", 0x0060},
+  {"braceleft", 0x007B},   {"bar", 0x007C},         {"braceright", 0x007D},
+  {"asciitilde", 0x007E},  {"quoteleft", 0x2018},   {"quoteright", 0x2019}
+};
 
 /* CreateFontIndirect() picks a face for whatever it is handed, including an
    empty name, so a name has to be checked against the enumerated families
@@ -232,7 +261,40 @@ NSLog(@"No glyph for U%d", c);
 
 - (NSGlyph) glyphWithName: (NSString*)glyphName
 {
-  return 0;
+  unichar c = 0;
+
+  /* A glyph is a character here, which is what -glyphIsEncoded: and
+     -advancementForGlyph: read, so a name is answered as the character it
+     stands for. A name of a single character is that character, and the rest
+     are the standard names of the Latin set. GDI has no call that reads the
+     names a face carries, so a name outside that set has no answer, as a
+     character the font does not carry has none. */
+  if ([glyphName length] == 1)
+    {
+      c = [glyphName characterAtIndex: 0];
+    }
+  else
+    {
+      const char *name = [glyphName UTF8String];
+      unsigned    i;
+
+      for (i = 0; i < sizeof(standardGlyphNames) / sizeof(*standardGlyphNames);
+	   i++)
+	{
+	  if (strcmp(standardGlyphNames[i].name, name) == 0)
+	    {
+	      c = standardGlyphNames[i].character;
+	      break;
+	    }
+	}
+    }
+
+  if (c == 0 || [self glyphIsEncoded: (NSGlyph)c] == NO)
+    {
+      return NSNullGlyph;
+    }
+
+  return (NSGlyph)c;
 }
 
 - (NSPoint) positionOfGlyph: (NSGlyph)curGlyph

--- a/Source/xlib/GSXftFontInfo.m
+++ b/Source/xlib/GSXftFontInfo.m
@@ -229,12 +229,44 @@
 
 - (NSGlyph) glyphWithName: (NSString*)glyphName
 {
-  // FIXME: There is a mismatch between PS names and X names, that we should 
-  // try to correct here
-  KeySym k = XStringToKeysym([glyphName cString]);
+  FT_Face face;
+  KeySym  k;
+
+  /* A glyph is a character here, which is what -glyphIsEncoded: and
+     -boundingRectForGlyph: read, so a PostScript name is answered as the
+     character that selects the glyph carrying it. The face answers 0 for a
+     name it does not have, and for any face that carries no glyph names at
+     all, and the X names below then have their turn. */
+  face = XftLockFace((XftFont *)font_info);
+  if (face != NULL)
+    {
+      FT_UInt index = FT_Get_Name_Index(face,
+	(FT_String *)[glyphName UTF8String]);
+
+      if (index != 0)
+	{
+	  FT_UInt  gindex;
+	  FT_ULong charcode = FT_Get_First_Char(face, &gindex);
+
+	  while (gindex != 0)
+	    {
+	      if (gindex == index)
+		{
+		  XftUnlockFace((XftFont *)font_info);
+		  return (NSGlyph)charcode;
+		}
+	      charcode = FT_Get_Next_Char(face, charcode, &gindex);
+	    }
+	}
+      XftUnlockFace((XftFont *)font_info);
+    }
+
+  /* The X names cover a face without PostScript names, since a keysym name is
+     the character for the Latin set. */
+  k = XStringToKeysym([glyphName cString]);
 
   if (k == NoSymbol)
-    return 0;
+    return NSNullGlyph;
   else
     return (NSGlyph)k;
 }

--- a/Tests/cairo/glyphname.m
+++ b/Tests/cairo/glyphname.m
@@ -1,0 +1,137 @@
+/* The glyph -[NSFont glyphWithName:] answers has to be one the same font can
+ * measure, which is what -advancementForGlyph: and -boundingRectForGlyph: do
+ * (Source/cairo/CairoFontInfo.m).
+ *
+ * AppKit's contract, measured at 14pt on Helvetica, Times-Roman and the system
+ * font: the advancement of the glyph named "W" equals the width of the string
+ * "W", and the same holds for "i", "eight" against "8" and "zero" against "0".
+ * A name the font does not carry answers NSNullGlyph.
+ *
+ * An NSGlyph is a character on this backend, so the number itself cannot match
+ * the index AppKit reports; what is checked here is the invariant, that the
+ * glyph measures as its character does.
+ *
+ * It guards on the cairo graphics backend and needs a font whose face carries
+ * PostScript glyph names, so it skips when no installed font has them.
+ */
+#import <Foundation/Foundation.h>
+#import "Testing.h"
+#include "config.h"
+
+#if defined(BUILD_GRAPHICS) && defined(GRAPHICS_cairo) \
+  && BUILD_GRAPHICS == GRAPHICS_cairo
+
+#import <AppKit/AppKit.h>
+#include <math.h>
+
+/* The first installed font that answers -glyphWithName:, since not every face
+ * carries PostScript glyph names. */
+static NSFont *
+fontWithGlyphNames(void)
+{
+  NSArray *names = [[NSFontManager sharedFontManager] availableFonts];
+  NSUInteger i;
+
+  for (i = 0; i < [names count]; i++)
+    {
+      NSFont *f = [NSFont fontWithName: [names objectAtIndex: i] size: 14];
+
+      if (f != nil && [f glyphWithName: @"W"] != NSNullGlyph)
+	{
+	  return f;
+	}
+    }
+  return nil;
+}
+
+/* Whether the glyph of that name advances as the string does. */
+static BOOL
+advancesLikeTheString(NSFont *f, NSString *name, NSString *string)
+{
+  NSGlyph g = [f glyphWithName: name];
+
+  if (g == NSNullGlyph)
+    {
+      return NO;
+    }
+  return fabs([f advancementForGlyph: g].width - [f widthOfString: string])
+    < 0.01;
+}
+
+int
+main(void)
+{
+  START_SET("cairo glyphWithName")
+
+  NSFont *font = nil;
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+      font = fontWithGlyphNames();
+    }
+  NS_HANDLER
+    {
+      font = nil;
+    }
+  NS_ENDHANDLER
+
+  if (font == nil)
+    {
+      SKIP("no installed font carries PostScript glyph names")
+    }
+  else
+    {
+      NSGlyph w = [font glyphWithName: @"W"];
+
+      /* An NSGlyph is a character on this backend, so the glyph of a name is
+	 the character that name stands for. Checked directly because two
+	 glyphs can share an advancement and pass the width checks below by
+	 coincidence. */
+      PASS(w == (NSGlyph)'W', "the glyph named W is the character W")
+      PASS([font glyphWithName: @"i"] == (NSGlyph)'i',
+	"the glyph named i is the character i")
+      PASS([font glyphWithName: @"eight"] == (NSGlyph)'8',
+	"the glyph named eight is the character 8")
+      PASS([font glyphWithName: @"zero"] == (NSGlyph)'0',
+	"the glyph named zero is the character 0")
+
+      PASS(advancesLikeTheString(font, @"W", @"W"),
+	"the glyph named W advances as the string W does")
+
+      PASS(advancesLikeTheString(font, @"i", @"i"),
+	"the glyph named i advances as the string i does")
+
+      /* A name that is not the character it stands for. */
+      PASS(advancesLikeTheString(font, @"eight", @"8"),
+	"the glyph named eight advances as the string 8 does")
+
+      PASS(advancesLikeTheString(font, @"zero", @"0"),
+	"the glyph named zero advances as the string 0 does")
+
+      /* The bounding box follows the same convention as the advancement. */
+      PASS(NSEqualRects([font boundingRectForGlyph: w],
+			[font boundingRectForGlyph:
+			  (NSGlyph)[@"W" characterAtIndex: 0]]),
+	"the glyph named W has the bounding rect of the character W")
+
+      PASS([font glyphWithName: @"notaglyphname"] == NSNullGlyph,
+	"a name the font does not carry answers NSNullGlyph")
+    }
+
+  END_SET("cairo glyphWithName")
+  return 0;
+}
+
+#else
+
+int
+main(void)
+{
+  START_SET("cairo glyphWithName")
+    SKIP("back is not built with the cairo graphics backend")
+  END_SET("cairo glyphWithName")
+  return 0;
+}
+
+#endif

--- a/Tests/cairo/glyphname.m
+++ b/Tests/cairo/glyphname.m
@@ -63,18 +63,33 @@ main(void)
 {
   START_SET("cairo glyphWithName")
 
+  NSFont *anyFont = nil;
   NSFont *font = nil;
 
   NS_DURING
     {
       [NSApplication sharedApplication];
+      anyFont = [NSFont userFontOfSize: 14];
       font = fontWithGlyphNames();
     }
   NS_HANDLER
     {
+      anyFont = nil;
       font = nil;
     }
   NS_ENDHANDLER
+
+  if (anyFont == nil)
+    {
+      SKIP("no backend to reach a font with")
+    }
+  else
+    {
+      /* Holds whether or not the face carries glyph names, so it runs
+	 wherever there is a backend at all. */
+      PASS([anyFont glyphWithName: @"notaglyphname"] == NSNullGlyph,
+	"a name no font carries answers NSNullGlyph")
+    }
 
   if (font == nil)
     {
@@ -115,8 +130,6 @@ main(void)
 			  (NSGlyph)[@"W" characterAtIndex: 0]]),
 	"the glyph named W has the bounding rect of the character W")
 
-      PASS([font glyphWithName: @"notaglyphname"] == NSNullGlyph,
-	"a name the font does not carry answers NSNullGlyph")
     }
 
   END_SET("cairo glyphWithName")

--- a/Tests/winlib/glyphname.m
+++ b/Tests/winlib/glyphname.m
@@ -1,0 +1,105 @@
+/* The glyph -[NSFont glyphWithName:] answers has to be one the same font can
+ * measure, which is what -advancementForGlyph: and -boundingRectForGlyph: do
+ * (Source/winlib/WIN32FontInfo.m).
+ *
+ * AppKit's contract, measured at 14pt on Helvetica, Times-Roman and the system
+ * font: the advancement of the glyph named "W" equals the width of the string
+ * "W", and the same holds for "i", for "eight" against "8" and for "zero"
+ * against "0". A name the font does not carry answers NSNullGlyph.
+ *
+ * An NSGlyph is a character on this backend, so the number itself cannot match
+ * the index AppKit reports; what is checked here is the invariant, that the
+ * glyph measures as its character does.
+ *
+ * It guards on the winlib graphics backend and skips when the backend cannot
+ * be reached.
+ */
+#import <Foundation/Foundation.h>
+#import "Testing.h"
+#include "config.h"
+
+#if defined(BUILD_GRAPHICS) && defined(GRAPHICS_winlib) \
+  && BUILD_GRAPHICS == GRAPHICS_winlib
+
+#import <AppKit/AppKit.h>
+#include <math.h>
+
+static BOOL
+advancesLikeTheString(NSFont *f, NSString *name, NSString *string)
+{
+  NSGlyph g = [f glyphWithName: name];
+
+  if (g == NSNullGlyph)
+    {
+      return NO;
+    }
+  return fabs([f advancementForGlyph: g].width - [f widthOfString: string])
+    < 0.01;
+}
+
+int
+main(void)
+{
+  START_SET("winlib glyphWithName")
+
+  NSFont *font = nil;
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+      font = [NSFont userFontOfSize: 14];
+    }
+  NS_HANDLER
+    {
+      font = nil;
+    }
+  NS_ENDHANDLER
+
+  if (font == nil)
+    {
+      SKIP("no win32 gui available")
+    }
+  else
+    {
+      /* An NSGlyph is a character on this backend, so the glyph of a name is
+	 the character that name stands for. Checked directly because two
+	 glyphs can share an advancement and pass the width checks below by
+	 coincidence. */
+      PASS([font glyphWithName: @"W"] == (NSGlyph)'W',
+	"the glyph named W is the character W")
+      PASS([font glyphWithName: @"i"] == (NSGlyph)'i',
+	"the glyph named i is the character i")
+
+      /* A standard name that is not the character it stands for. */
+      PASS([font glyphWithName: @"eight"] == (NSGlyph)'8',
+	"the glyph named eight is the character 8")
+      PASS([font glyphWithName: @"zero"] == (NSGlyph)'0',
+	"the glyph named zero is the character 0")
+      PASS([font glyphWithName: @"space"] == (NSGlyph)' ',
+	"the glyph named space is the character space")
+
+      PASS(advancesLikeTheString(font, @"W", @"W"),
+	"the glyph named W advances as the string W does")
+      PASS(advancesLikeTheString(font, @"eight", @"8"),
+	"the glyph named eight advances as the string 8 does")
+
+      PASS([font glyphWithName: @"notaglyphname"] == NSNullGlyph,
+	"a name the font does not carry answers NSNullGlyph")
+    }
+
+  END_SET("winlib glyphWithName")
+  return 0;
+}
+
+#else
+
+int
+main(void)
+{
+  START_SET("winlib glyphWithName")
+    SKIP("back is not built with the winlib graphics backend")
+  END_SET("winlib glyphWithName")
+  return 0;
+}
+
+#endif

--- a/Tests/xlib/GNUmakefile.preamble
+++ b/Tests/xlib/GNUmakefile.preamble
@@ -1,16 +1,21 @@
 # Extra build settings for the xlib graphics backend tests.
 #
-# These tests include an xlib backend header directly, so they can only build
-# for that backend.  config.make names the graphics backend being built
+# Some of these tests include an xlib backend header directly, so they can only
+# build for that backend.  config.make names the graphics backend being built
 # (BUILD_GRAPHICS); the X11, Xft and backend header paths are added only for
 # xlib, and the tests carry a matching source-level guard (via config.h) so
-# they still build -- and skip -- on every other backend.
+# they still build -- and skip -- on every other backend.  The ones that drive
+# AppKit need the gui library, which every backend but headless has.
 
 # config.h (used by the source-level guard) sits at the top of the (build) tree.
 ADDITIONAL_INCLUDE_DIRS += -I$(GNUSTEP_BUILD_DIR)/../.. -I../..
 
 -include $(GNUSTEP_BUILD_DIR)/../../config.make
 -include ../../config.make
+
+ifneq ($(BUILD_GRAPHICS),headless)
+ADDITIONAL_TOOL_LIBS += -lgnustep-gui
+endif
 
 ifeq ($(BUILD_GRAPHICS),xlib)
 ADDITIONAL_INCLUDE_DIRS += -I$(GNUSTEP_BUILD_DIR)/../../Headers \

--- a/Tests/xlib/glyphname.m
+++ b/Tests/xlib/glyphname.m
@@ -1,0 +1,123 @@
+/* The glyph -[NSFont glyphWithName:] answers has to be one the same font can
+ * measure, which is what -advancementForGlyph: and -boundingRectForGlyph: do
+ * (Source/xlib/GSXftFontInfo.m).
+ *
+ * AppKit's contract, measured at 14pt on Helvetica, Times-Roman and the system
+ * font: the advancement of the glyph named "W" equals the width of the string
+ * "W", and the same holds for "i", for "eight" against "8" and for "zero"
+ * against "0". A name the font does not carry answers NSNullGlyph.
+ *
+ * An NSGlyph is a character on this backend, so the number itself cannot match
+ * the index AppKit reports; what is checked here is the invariant, that the
+ * glyph measures as its character does.
+ *
+ * It guards on the xlib graphics backend, and needs the backend loaded, so it
+ * skips where there is no display to reach.
+ */
+#import <Foundation/Foundation.h>
+#import "Testing.h"
+#include "config.h"
+
+#if defined(BUILD_GRAPHICS) && defined(GRAPHICS_xlib) \
+  && BUILD_GRAPHICS == GRAPHICS_xlib
+
+#import <AppKit/AppKit.h>
+#include <math.h>
+
+/* The first installed font that answers -glyphWithName:. */
+static NSFont *
+fontWithGlyphNames(void)
+{
+  NSArray *names = [[NSFontManager sharedFontManager] availableFonts];
+  NSUInteger i;
+
+  for (i = 0; i < [names count]; i++)
+    {
+      NSFont *f = [NSFont fontWithName: [names objectAtIndex: i] size: 14];
+
+      if (f != nil && [f glyphWithName: @"W"] != NSNullGlyph)
+	{
+	  return f;
+	}
+    }
+  return nil;
+}
+
+static BOOL
+advancesLikeTheString(NSFont *f, NSString *name, NSString *string)
+{
+  NSGlyph g = [f glyphWithName: name];
+
+  if (g == NSNullGlyph)
+    {
+      return NO;
+    }
+  return fabs([f advancementForGlyph: g].width - [f widthOfString: string])
+    < 0.01;
+}
+
+int
+main(void)
+{
+  START_SET("xlib glyphWithName")
+
+  NSFont *font = nil;
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+      font = fontWithGlyphNames();
+    }
+  NS_HANDLER
+    {
+      font = nil;
+    }
+  NS_ENDHANDLER
+
+  if (font == nil)
+    {
+      SKIP("no display to reach the backend with")
+    }
+  else
+    {
+      /* An NSGlyph is a character on this backend, so the glyph of a name is
+	 the character that name stands for. Checked directly because two
+	 glyphs can share an advancement and pass the width checks below by
+	 coincidence. */
+      PASS([font glyphWithName: @"W"] == (NSGlyph)'W',
+	"the glyph named W is the character W")
+      PASS([font glyphWithName: @"i"] == (NSGlyph)'i',
+	"the glyph named i is the character i")
+
+      /* A PostScript name that is not the character it stands for. The X
+	 keysym names this used to be limited to have no name for a digit. */
+      PASS([font glyphWithName: @"eight"] == (NSGlyph)'8',
+	"the glyph named eight is the character 8")
+      PASS([font glyphWithName: @"zero"] == (NSGlyph)'0',
+	"the glyph named zero is the character 0")
+
+      PASS(advancesLikeTheString(font, @"W", @"W"),
+	"the glyph named W advances as the string W does")
+      PASS(advancesLikeTheString(font, @"eight", @"8"),
+	"the glyph named eight advances as the string 8 does")
+
+      PASS([font glyphWithName: @"notaglyphname"] == NSNullGlyph,
+	"a name the font does not carry answers NSNullGlyph")
+    }
+
+  END_SET("xlib glyphWithName")
+  return 0;
+}
+
+#else
+
+int
+main(void)
+{
+  START_SET("xlib glyphWithName")
+    SKIP("back is not built with the xlib graphics backend")
+  END_SET("xlib glyphWithName")
+  return 0;
+}
+
+#endif


### PR DESCRIPTION
A glyph from -glyphWithName: has to be one the same font can measure, which is
what -advancementForGlyph: and -boundingRectForGlyph: do. cairo, xlib and
winlib answer one it cannot.

cairo answers FT_Get_Name_Index, a face index, while its own extents read an
NSGlyph as a character: the name W gives 56, which advances 8 against
the W's 13. xlib answers XStringToKeysym, which has no name for a digit,
so the name of 8 gives 0. winlib returns 0 for every name.

An NSGlyph is a character on each. cairo and xlib now walk the face's
character map for the name's index, xlib keeping the keysym where a face has
no PostScript names; winlib maps the standard Latin names.

AppKit, on Helvetica, Times-Roman and the system font at 14pt: the glyph named
W advances as the string W does, and so do i and the digit names.

Against master the new sets fail: cairo 57 passed 7 failed, xlib 11 and 3,
winlib 51 and 7; here 64, 14 and 58 with none failed. The checks reach a
single assertion: no job builds winlib, the xlib job has no display, and no
runner has a font with PostScript glyph names.

Closes #193
