### PR TITLE
Fix: read the GDI pitch flag the way GDI defines it

### DIFF
--- a/Source/winlib/WIN32FontInfo.m
+++ b/Source/winlib/WIN32FontInfo.m
@@ -526,7 +526,11 @@ NSLog(@"No glyph for U%d", c);
   DeleteDC(hdc);
 
   // Fill the ivars
-  isFixedPitch = TMPF_FIXED_PITCH & metric.tmPitchAndFamily;
+  /* TMPF_FIXED_PITCH is set for a font of VARIABLE pitch, which is the
+     opposite of what the name says. Courier New and Consolas report the bit
+     clear and advance W and i alike; Tahoma and Arial report it set and do
+     not. */
+  isFixedPitch = (TMPF_FIXED_PITCH & metric.tmPitchAndFamily) == 0;
   isBaseFont = NO;
   ascender = metric.tmAscent;
   //NSLog(@"Resulted in height %d and ascent %d", metric.tmHeight, metric.tmAscent);

--- a/Tests/winlib/fixedpitch.m
+++ b/Tests/winlib/fixedpitch.m
@@ -1,0 +1,90 @@
+/* Whether a font reports the pitch it actually has
+ * (Source/winlib/WIN32FontInfo.m).
+ *
+ * GDI reports the pitch in TEXTMETRIC.tmPitchAndFamily, where the bit named
+ * TMPF_FIXED_PITCH is set for a font of VARIABLE pitch, the opposite of what
+ * the name says. Measured at 14pt: Courier New and Consolas report the bit
+ * clear and advance W and i alike, Tahoma and Arial report it set and advance
+ * them differently.
+ *
+ * A font that advances every glyph by the same amount is fixed pitch, which is
+ * what -isFixedPitch answers, so the two are checked against each other rather
+ * than against a face name.
+ *
+ * It guards on the winlib graphics backend and skips when the backend cannot
+ * be reached.
+ */
+#import <Foundation/Foundation.h>
+#import "Testing.h"
+#include "config.h"
+
+#if defined(BUILD_GRAPHICS) && defined(GRAPHICS_winlib) \
+  && BUILD_GRAPHICS == GRAPHICS_winlib
+
+#import <AppKit/AppKit.h>
+#include <math.h>
+
+/* Whether the font advances a wide and a narrow character alike, which is
+   what being fixed pitch means. */
+static BOOL
+advancesAlike(NSFont *f)
+{
+  return fabs([f widthOfString: @"W"] - [f widthOfString: @"i"]) < 0.01;
+}
+
+int
+main(void)
+{
+  START_SET("winlib fixed pitch")
+
+  NSFont *fixed = nil;
+  NSFont *variable = nil;
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+      fixed = [NSFont userFixedPitchFontOfSize: 14.0];
+      variable = [NSFont systemFontOfSize: 14.0];
+    }
+  NS_HANDLER
+    {
+      fixed = nil;
+      variable = nil;
+    }
+  NS_ENDHANDLER
+
+  if (fixed == nil || variable == nil)
+    {
+      SKIP("no win32 gui available")
+    }
+  else
+    {
+      /* The two fonts are what they are meant to be, so that the checks below
+	 mean something. */
+      PASS(advancesAlike(fixed),
+	"the user fixed pitch font advances W and i alike")
+      PASS(advancesAlike(variable) == NO,
+	"the system font advances W and i differently")
+
+      PASS([fixed isFixedPitch] == YES,
+	"a font that advances every glyph alike reports isFixedPitch")
+      PASS([variable isFixedPitch] == NO,
+	"a font that does not reports isFixedPitch NO")
+    }
+
+  END_SET("winlib fixed pitch")
+  return 0;
+}
+
+#else
+
+int
+main(void)
+{
+  START_SET("winlib fixed pitch")
+    SKIP("back is not built with the winlib graphics backend")
+  END_SET("winlib fixed pitch")
+  return 0;
+}
+
+#endif


### PR DESCRIPTION
A font reports the wrong pitch on winlib. WIN32FontInfo reads the GDI text
metric as `isFixedPitch = TMPF_FIXED_PITCH & metric.tmPitchAndFamily`, and that
bit is set for a font of VARIABLE pitch, the opposite of what its name says.

Measured at 14pt with GetCharABCWidths: Courier New and Consolas report the bit
clear and advance W and i alike, while Tahoma and Arial report it set and
advance them 14 against 2. So Courier New answered NO to the isFixedPitch
question and Tahoma answered YES.

The test asks the font itself rather than naming a face: a font whose W and i
advance alike is fixed pitch, and the reported flag has to agree with that.

What it fixes beyond the flag: NSSecureTextFieldCell substitutes the user
fixed pitch font when it is handed a variable font, and decides that from the
same flag, so on Windows it substituted nothing. Tests/gui/NSSecureTextField
in libs-gui goes from 14 passed 1 failed to 15 passed 0 failed with this.

Tests/winlib/fixedpitch.m is new. The winlib set is 52 passed 2 failed against
master and 54 passed 0 failed here. No CI job builds winlib, so the checks
here do not exercise any of it.
