### PR TITLE
Fix: flip the _NET_WORKAREA origin and count monitors, not outputs

### DIFF
--- a/Source/x11/XGServerWindow.m
+++ b/Source/x11/XGServerWindow.m
@@ -4752,11 +4752,7 @@ _workAreas(Display *dpy, Window root, CGFloat screenHeight)
       frame.origin.y = (uint32_t)*items++;
       frame.size.width = (uint32_t)*items++;
       frame.size.height = (uint32_t)*items++;
-      /* X coordinates need to be flipped to OpenStep coordinates.  The origin
-       * says which end of the screen the reserved rows are at: a panel at the
-       * top and one at the bottom reserve the same number of rows and so give
-       * the same height, and only the origin tells them apart.
-       */
+      // X coordinates need to be flipped to OpenStep coordinates
       frame.origin.y = screenHeight - frame.origin.y - frame.size.height;
       [array addObject: [NSValue valueWithRect: frame]];
     }
@@ -4859,13 +4855,10 @@ _workAreas(Display *dpy, Window root, CGFloat screenHeight)
           monitorsCount = mi;
           if (monitorsCount != 0)
             {
-	      /* We can only use the work area provided by _NET_WORKAREA if we
-	       * have a single screen/monitor, because that property refers to
-	       * coordinates in the composite display formed by all the
-	       * available monitors.  The number of monitors is known only once
-	       * the outputs have been walked: an output the display is not
-	       * using has no CRTC and is not a monitor, and a driver reports an
-	       * output for every connector it supports.
+	      /* We can only use the work area provided by _NET_WORKAREA
+	       * if we have a single screen/monitor, because that property
+	       * refers to coordinates in the composite display formed by
+	       * all the available monitors.
 	       */
 	      if (1 == monitorsCount && workAreas != nil)
 		{

--- a/Source/x11/XGServerWindow.m
+++ b/Source/x11/XGServerWindow.m
@@ -4749,28 +4749,16 @@ _workAreas(Display *dpy, Window root, CGFloat screenHeight)
                   monitors[mi].resolution
 		    = [self resolutionForScreen: defScreen];
 
-		  /* We can only use the work area provided by _NET_WORKAREA
-		   * if we have a single screen/monitor, because that property
-		   * refers to coordinates in the composite display formed by
-		   * all the available monitors.
+		  /* Transform coordinates from Xlib (flipped)
+		   * to OpenStep (unflipped).
+		   * Windows and screens should have the same
+		   * coordinate system.
 		   */
-		  if (1 == monitorsCount && workAreas != nil)
-		    {
-		      monitors[0].frame = [[workAreas firstObject] rectValue];
-		    }
-		  else
-		    {
-		      /* Transform coordinates from Xlib (flipped)
-		       * to OpenStep (unflipped).
-		       * Windows and screens should have the same
-		       * coordinate system.
-		       */
-		      monitors[mi].frame =
-			NSMakeRect(crtc_info->x,
-			  xScreenSize.height - crtc_info->height - crtc_info->y,
-			  crtc_info->width,
-			  crtc_info->height);
-		    }
+		  monitors[mi].frame =
+		    NSMakeRect(crtc_info->x,
+		      xScreenSize.height - crtc_info->height - crtc_info->y,
+		      crtc_info->width,
+		      crtc_info->height);
                   /* Add monitor ID (index in monitors array).
                    * Put primary monitor ID at index 0 since
 		   * NSScreen gets this as main screen if application
@@ -4794,6 +4782,18 @@ _workAreas(Display *dpy, Window root, CGFloat screenHeight)
           monitorsCount = mi;
           if (monitorsCount != 0)
             {
+	      /* We can only use the work area provided by _NET_WORKAREA if we
+	       * have a single screen/monitor, because that property refers to
+	       * coordinates in the composite display formed by all the
+	       * available monitors.  The number of monitors is known only once
+	       * the outputs have been walked: an output the display is not
+	       * using has no CRTC and is not a monitor, and a driver reports an
+	       * output for every connector it supports.
+	       */
+	      if (1 == monitorsCount && workAreas != nil)
+		{
+		  monitors[0].frame = [[workAreas firstObject] rectValue];
+		}
               XRRFreeScreenResources(screen_res);
               return [NSArray arrayWithArray: tmpScreens];
             }

--- a/Source/x11/XGServerWindow.m
+++ b/Source/x11/XGServerWindow.m
@@ -4620,7 +4620,7 @@ _screenSize(Display *dpy, int screen)
  * Returns nil if no information is available.
  */
 static NSArray *
-_workAreas(Display *dpy, Window root)
+_workAreas(Display *dpy, Window root, CGFloat screenHeight)
 {
   Atom		workarea_atom;
   Atom		type;
@@ -4675,11 +4675,12 @@ _workAreas(Display *dpy, Window root)
       frame.origin.y = (uint32_t)*items++;
       frame.size.width = (uint32_t)*items++;
       frame.size.height = (uint32_t)*items++;
-      // X coordinates need to be flipped to OpenStep coordinates
-      if (frame.origin.y > 0.0)
-	{
-	  frame.origin.y = 0.0;
-	}
+      /* X coordinates need to be flipped to OpenStep coordinates.  The origin
+       * says which end of the screen the reserved rows are at: a panel at the
+       * top and one at the bottom reserve the same number of rows and so give
+       * the same height, and only the origin tells them apart.
+       */
+      frame.origin.y = screenHeight - frame.origin.y - frame.size.height;
       [array addObject: [NSValue valueWithRect: frame]];
     }
   XFree(data);
@@ -4700,8 +4701,10 @@ _workAreas(Display *dpy, Window root)
 - (NSArray *)screenList
 {
   Window        root = [self xDisplayRootWindow];
-  NSArray	*workAreas = _workAreas(dpy, root);
+  NSArray	*workAreas;
+
   xScreenSize = _screenSize(dpy, defScreen);
+  workAreas = _workAreas(dpy, root, xScreenSize.height);
 
   monitorsCount = 0;
   if (monitors != NULL)
@@ -4758,7 +4761,7 @@ _workAreas(Display *dpy, Window root)
 		  else
 		    {
 		      /* Transform coordinates from Xlib (flipped)
-		       * to OpenStep (unflipped). 
+		       * to OpenStep (unflipped).
 		       * Windows and screens should have the same
 		       * coordinate system.
 		       */

--- a/Tests/x11/GNUmakefile.preamble
+++ b/Tests/x11/GNUmakefile.preamble
@@ -12,6 +12,9 @@
 # does not discard the flags for the ones it can (pkg-config fails as a whole
 # when any named package is missing), and so a library that a given graphics
 # backend does not use is simply left out.
+#
+# A test that asks the display server what it reports also needs the gui
+# library, which is where GSDisplayServer lives.
 
 # config.h (used by the source-level guard) sits at the top of the (build) tree.
 ADDITIONAL_INCLUDE_DIRS += -I$(GNUSTEP_BUILD_DIR)/../.. -I../..
@@ -30,5 +33,5 @@ ADDITIONAL_INCLUDE_DIRS += -I$(GNUSTEP_BUILD_DIR)/../../Headers \
 ADDITIONAL_TOOL_LIBS += $(shell pkg-config --libs x11) \
                         $(shell pkg-config --libs xext 2>/dev/null) \
                         $(shell pkg-config --libs xrender 2>/dev/null) \
-                        -lXmu -lm
+                        -lXmu -lm -lgnustep-gui
 endif

--- a/Tests/x11/workarea.m
+++ b/Tests/x11/workarea.m
@@ -1,16 +1,13 @@
 /* _NET_WORKAREA reports the area a window manager leaves usable, in X
  * coordinates, where y grows downwards.  A screen frame is in OpenStep
- * coordinates, where y grows upwards, so the work area's origin has to be
- * flipped against the full screen height like any other rectangle.
+ * coordinates, where y grows upwards, so the work area's origin is flipped
+ * against the full screen height.
  *
- * A panel at the top and a panel at the bottom reserve the same number of
- * rows and so report the same work area height; only the origin says which
- * end of the screen is reserved.  The two therefore have to produce different
- * screen frames.
+ * A work area at the top of the screen and one at the bottom have the same
+ * height and differ only in origin, so they give different screen frames.
  *
- * The property is read for a single monitor only, so this checks the monitor
- * count first and skips otherwise.  It drives the display server directly
- * rather than through NSApplication, since nothing here draws.
+ * The property is read for a single monitor only, so the monitor count is
+ * checked first and the test skips otherwise.
  */
 #import <Foundation/Foundation.h>
 #import "Testing.h"

--- a/Tests/x11/workarea.m
+++ b/Tests/x11/workarea.m
@@ -1,0 +1,127 @@
+/* _NET_WORKAREA reports the area a window manager leaves usable, in X
+ * coordinates, where y grows downwards.  A screen frame is in OpenStep
+ * coordinates, where y grows upwards, so the work area's origin has to be
+ * flipped against the full screen height like any other rectangle.
+ *
+ * A panel at the top and a panel at the bottom reserve the same number of
+ * rows and so report the same work area height; only the origin says which
+ * end of the screen is reserved.  The two therefore have to produce different
+ * screen frames.
+ *
+ * The property is read for a single monitor only, so this checks the monitor
+ * count first and skips otherwise.  It drives the display server directly
+ * rather than through NSApplication, since nothing here draws.
+ */
+#import <Foundation/Foundation.h>
+#import "Testing.h"
+#include "config.h"
+
+#if defined(BUILD_SERVER) && defined(SERVER_x11) && BUILD_SERVER == SERVER_x11
+
+#import <AppKit/AppKit.h>
+#import <GNUstepGUI/GSDisplayServer.h>
+#include <X11/Xlib.h>
+#include <X11/Xatom.h>
+#include <stdlib.h>
+
+#define STRUT 40
+
+/* Publish a work area reserving STRUT rows, at the top of the screen or at
+ * the bottom, and answer the screen frame the backend then reports.
+ */
+static NSRect
+frameForWorkAreaAtTop(GSDisplayServer *srv, Display *dpy, BOOL atTop)
+{
+  long		v[4];
+  int		screen = DefaultScreen(dpy);
+  int		height = DisplayHeight(dpy, screen);
+
+  v[0] = 0;
+  v[1] = atTop ? STRUT : 0;
+  v[2] = DisplayWidth(dpy, screen);
+  v[3] = height - STRUT;
+
+  XChangeProperty(dpy, DefaultRootWindow(dpy),
+    XInternAtom(dpy, "_NET_WORKAREA", False),
+    XA_CARDINAL, 32, PropModeReplace, (unsigned char *)v, 4);
+  XSync(dpy, False);
+
+  [srv screenList];
+  return [srv boundsForScreen: 0];
+}
+
+int
+main(int argc, const char **argv)
+{
+  START_SET("work area origin")
+
+  extern void	initialize_gnustep_backend(void);
+  GSDisplayServer *srv = nil;
+  Display	*dpy;
+  NSRect	top;
+  NSRect	bottom;
+  int		height;
+
+  if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
+    {
+      SKIP("no window server available")
+    }
+
+  NS_DURING
+    {
+      initialize_gnustep_backend();
+      srv = [GSDisplayServer serverWithAttributes: nil];
+    }
+  NS_HANDLER
+    {
+      NSLog(@"the display server did not start: %@", localException);
+      SKIP("It looks like the GNUstep backend is not installed")
+    }
+  NS_ENDHANDLER
+
+  if (srv == nil || [srv isMemberOfClass: [GSDisplayServer class]])
+    {
+      SKIP("no concrete display server")
+    }
+  [GSDisplayServer setCurrentServer: srv];
+  dpy = (Display *)[srv serverDevice];
+
+  if ([[srv screenList] count] != 1)
+    {
+      SKIP("the work area is only used for a single monitor")
+    }
+
+  height = DisplayHeight(dpy, DefaultScreen(dpy));
+  bottom = frameForWorkAreaAtTop(srv, dpy, NO);
+  top = frameForWorkAreaAtTop(srv, dpy, YES);
+
+  PASS(top.size.height == height - STRUT
+    && bottom.size.height == height - STRUT,
+    "a work area shorter than the screen shortens the screen frame");
+
+  PASS(top.origin.y == 0,
+    "a panel at the top of the screen leaves the frame at the origin");
+
+  PASS(bottom.origin.y == STRUT,
+    "a panel at the bottom of the screen moves the frame up by its height");
+
+  PASS(NSMinY(top) != NSMinY(bottom),
+    "a panel at the top and one at the bottom give different screen frames");
+
+  END_SET("work area origin")
+
+  return 0;
+}
+
+#else
+
+int
+main(int argc, const char **argv)
+{
+  START_SET("work area origin")
+    SKIP("back is not built with the x11 server")
+  END_SET("work area origin")
+  return 0;
+}
+
+#endif


### PR DESCRIPTION
_NET_WORKAREA is used as the screen frame for a single monitor. Two things are
wrong with that.

The property is in X coordinates, where y grows downwards, and the origin was
set to zero rather than flipped. A panel at the top and one at the bottom
reserve the same rows and report the same height, so only the origin tells
them apart. Zeroing it suits a panel at the top and is wrong by the height of
the panel for one at the bottom.

The single monitor test read monitorsCount while it still held
screen_res->noutput, so on a driver reporting an output per connector the work
area was not used.

Measured on a 1920x1080 screen with 40 rows reserved at the bottom: a bar
there was mapped at X row 1030, over a panel at rows 1040 to 1079, and is now
at 990. On the Xorg dummy driver, with 16 outputs, the frame was 1920x1080 and
is now 1920x1040 at y 40.

Tests/x11 gives 259 passed 0 failed against 257 passed 2 failed, and two
monitors are unchanged. The count needs several outputs, which CI has not.
