### PR TITLE
Fix: draw our own decorations when the window manager draws none

### DIFF
--- a/Source/x11/XGServerWindow.m
+++ b/Source/x11/XGServerWindow.m
@@ -1764,6 +1764,7 @@ _wmTestErrorHandler(Display *display, XErrorEvent *event)
       else if (offsets == 0)
         {
           BOOL	ok = YES;
+          BOOL	decorated = NO;
 
           /* No offsets available on the root window ... so we test each
            * style of window to determine its offsets.
@@ -1774,6 +1775,28 @@ _wmTestErrorHandler(Display *display, XErrorEvent *event)
                 {
                   ok = NO;	// test failed for this style
                 }
+              else if (generic.offsets[i].l != 0.0
+                || generic.offsets[i].r != 0.0
+                || generic.offsets[i].t != 0.0
+                || generic.offsets[i].b != 0.0)
+                {
+                  decorated = YES;
+                }
+            }
+
+          /* A window manager is running, and it put a border on none of the
+           * styles.  It is not going to draw a title bar or a close button
+           * either, so the gui library has to.  A window manager that is not
+           * running at all is dealt with above, and a decoration default the
+           * user has set stands.
+           */
+          if (decorated == NO && handlesWindowDecorations == YES
+            && [defs objectForKey: @"GSBackHandlesWindowDecorations"] == nil
+            && [defs objectForKey: @"GSX11HandlesWindowDecorations"] == nil)
+            {
+              NSLog(@"The window manager decorates none of our windows,"
+                @" so the gui library will draw the decorations.");
+              handlesWindowDecorations = NO;
             }
 
           if (ok == YES)

--- a/Source/x11/XGServerWindow.m
+++ b/Source/x11/XGServerWindow.m
@@ -450,6 +450,7 @@ BOOL AtomPresentAndPointsToItself(Display *dpy, Atom atom, Atom type)
 - (void) styleoffsets: (float *) l : (float *) r : (float *) t : (float *) b
                      : (unsigned int) style : (Window) win;
 - (void) _setSupportedWMProtocols: (gswindow_device_t *) window;
+- (unsigned long *) _getExtents: (Window)win;
 @end
 
 @implementation XGServer (WindowOps)

--- a/Source/x11/XGServerWindow.m
+++ b/Source/x11/XGServerWindow.m
@@ -719,6 +719,40 @@ _get_next_prop_new_event(Display *display, XEvent *event, char *arg)
     }
 }
 
+/* A window manager that decorates a window reports a frame extent for it.
+ * Some answer the _NET_REQUEST_FRAME_EXTENTS message with four zeros and
+ * publish the real extents only once the window has been mapped, so zeros for
+ * a style that carries a title bar are not an answer we can use.  A style
+ * without decoration is zero on all four sides and is taken as it stands.
+ */
+- (BOOL) _frameExtentsUsable: (gswindow_device_t *)window
+{
+  unsigned	style = window->win_attrs.window_style;
+  unsigned long	*extents;
+  BOOL		usable;
+
+  if (!((style & NSTitledWindowMask) || (style & NSClosableWindowMask)
+    || (style & NSMiniaturizableWindowMask)))
+    {
+      return YES;
+    }
+
+  extents = [self _getExtents: window->ident];
+  if (extents == 0)
+    {
+      return NO;
+    }
+  usable = (extents[0] != 0 || extents[1] != 0
+    || extents[2] != 0 || extents[3] != 0);
+  if (usable == NO)
+    {
+      NSDebugLLog(@"Offset", @"Frame extents for style %u are all zero,"
+        @" mapping the window to read them instead", style);
+    }
+  XFree(extents);
+  return usable;
+}
+
 - (BOOL) _tryRequestFrameExtents: (gswindow_device_t *)window
 {
   XEvent xEvent;
@@ -751,7 +785,7 @@ _get_next_prop_new_event(Display *display, XEvent *event, char *arg)
       else if (XCheckIfEvent(dpy, &xEvent, _get_next_prop_new_event,
                              (char*)(&event_data)))
         {
-          return YES;
+          return [self _frameExtentsUsable: window];
         }
       else
         {

--- a/Source/x11/XGServerWindow.m
+++ b/Source/x11/XGServerWindow.m
@@ -719,11 +719,26 @@ _get_next_prop_new_event(Display *display, XEvent *event, char *arg)
     }
 }
 
-/* A window manager that decorates a window reports a frame extent for it.
- * Some answer the _NET_REQUEST_FRAME_EXTENTS message with four zeros and
- * publish the real extents only once the window has been mapped, so zeros for
- * a style that carries a title bar are not an answer we can use.  A style
- * without decoration is zero on all four sides and is taken as it stands.
+/* A window manager that decorates a window reports a frame extent for it, so
+ * four zeros for a style that carries a title bar is not an answer we can
+ * use.  A style without decoration is zero on all four sides and is taken as
+ * it stands.
+ */
+static BOOL
+_extentsUsable(unsigned long *extents, unsigned style)
+{
+  if (!((style & NSTitledWindowMask) || (style & NSClosableWindowMask)
+    || (style & NSMiniaturizableWindowMask)))
+    {
+      return YES;
+    }
+  return (extents[0] != 0 || extents[1] != 0
+    || extents[2] != 0 || extents[3] != 0);
+}
+
+/* Some window managers answer the _NET_REQUEST_FRAME_EXTENTS message with
+ * four zeros and publish the real extents only once the window has been
+ * mapped.
  */
 - (BOOL) _frameExtentsUsable: (gswindow_device_t *)window
 {
@@ -731,19 +746,12 @@ _get_next_prop_new_event(Display *display, XEvent *event, char *arg)
   unsigned long	*extents;
   BOOL		usable;
 
-  if (!((style & NSTitledWindowMask) || (style & NSClosableWindowMask)
-    || (style & NSMiniaturizableWindowMask)))
-    {
-      return YES;
-    }
-
   extents = [self _getExtents: window->ident];
   if (extents == 0)
     {
       return NO;
     }
-  usable = (extents[0] != 0 || extents[1] != 0
-    || extents[2] != 0 || extents[3] != 0);
+  usable = _extentsUsable(extents, style);
   if (usable == NO)
     {
       NSDebugLLog(@"Offset", @"Frame extents for style %u are all zero,"
@@ -1104,6 +1112,17 @@ _wmTestErrorHandler(Display *display, XErrorEvent *event)
     }
 
   extents = [self _getExtents: window->ident];
+  if (extents != 0 && repp != 0 && _extentsUsable(extents, style) == NO)
+    {
+      /* The property still holds the answer given before the window was
+       * mapped, which a decorated window cannot have.  The window has been
+       * reparented, so its own geometry says what the decoration is.
+       */
+      NSDebugLLog(@"Offset", @"Frame extents are still all zero after mapping,"
+                  @" taking the offsets from the reparent instead");
+      XFree(extents);
+      extents = 0;
+    }
   if (extents != 0)
     {
       o->l = extents[0];

--- a/Tests/x11/FakeWindowManager.h
+++ b/Tests/x11/FakeWindowManager.h
@@ -1,0 +1,192 @@
+/* A window manager for the offsets tests, forked by the test that needs one.
+ *
+ * It announces itself the way an EWMH window manager does, advertises
+ * _NET_REQUEST_FRAME_EXTENTS and answers that message with four zeros, which
+ * is what recent Mutter releases do.  The real extents follow later: with
+ * reparenting NO they are published as the window is mapped, and with
+ * reparenting YES the window is put inside a frame and the extents are
+ * published after the reparent, so a client reading the property as soon as
+ * it sees the ReparentNotify reads the earlier answer instead.
+ */
+#ifndef FAKE_WINDOW_MANAGER_H
+#define FAKE_WINDOW_MANAGER_H
+
+#include <X11/Xlib.h>
+#include <X11/Xatom.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <signal.h>
+
+/* The height of the window manager's title bar. */
+#define FAKE_WM_TOP 37
+
+/* The windows being probed are destroyed as soon as they have been measured,
+ * so a request naming one can fail at any point.  Xlib's default handler
+ * exits, which would take the window manager down in the middle of a run.
+ */
+static int
+fakeWMIgnoreError(Display *d, XErrorEvent *e)
+{
+  return 0;
+}
+
+static void
+fakeWMSetExtents(Display *dpy, Window w, long top)
+{
+  Atom	extents = XInternAtom(dpy, "_NET_FRAME_EXTENTS", False);
+  long	v[4];
+
+  v[0] = 0; v[1] = 0; v[2] = top; v[3] = 0;
+  XChangeProperty(dpy, w, extents, XA_CARDINAL, 32, PropModeReplace,
+    (unsigned char *)v, 4);
+  XFlush(dpy);
+}
+
+/* Runs in the child and never returns. */
+static void
+fakeWMRun(BOOL reparenting)
+{
+  Display	*dpy;
+  Window	root;
+  Window	check;
+  Atom		supported[4];
+  Atom		netCheck;
+  Atom		netRequest;
+
+  dpy = XOpenDisplay(NULL);
+  if (dpy == NULL)
+    {
+      _exit(1);
+    }
+  XSetErrorHandler(fakeWMIgnoreError);
+  root = DefaultRootWindow(dpy);
+  netCheck = XInternAtom(dpy, "_NET_SUPPORTING_WM_CHECK", False);
+  netRequest = XInternAtom(dpy, "_NET_REQUEST_FRAME_EXTENTS", False);
+
+  check = XCreateSimpleWindow(dpy, root, -100, -100, 1, 1, 0, 0, 0);
+  XChangeProperty(dpy, check, netCheck, XA_WINDOW, 32, PropModeReplace,
+    (unsigned char *)&check, 1);
+  XChangeProperty(dpy, check, XInternAtom(dpy, "_NET_WM_NAME", False),
+    XInternAtom(dpy, "UTF8_STRING", False), 8, PropModeReplace,
+    (unsigned char *)"testwm", 6);
+
+  supported[0] = netCheck;
+  supported[1] = netRequest;
+  supported[2] = XInternAtom(dpy, "_NET_FRAME_EXTENTS", False);
+  supported[3] = XInternAtom(dpy, "_NET_WM_NAME", False);
+  XChangeProperty(dpy, root, XInternAtom(dpy, "_NET_SUPPORTED", False),
+    XA_ATOM, 32, PropModeReplace, (unsigned char *)supported, 4);
+
+  XSelectInput(dpy, root, SubstructureRedirectMask | SubstructureNotifyMask);
+  /* Announced last, so a client that sees it finds the rest in place. */
+  XChangeProperty(dpy, root, netCheck, XA_WINDOW, 32, PropModeReplace,
+    (unsigned char *)&check, 1);
+  XFlush(dpy);
+
+  for (;;)
+    {
+      XEvent	e;
+
+      XNextEvent(dpy, &e);
+      if (e.type == ClientMessage && e.xclient.message_type == netRequest)
+	{
+	  fakeWMSetExtents(dpy, e.xclient.window, 0);
+	}
+      else if (e.type == MapRequest)
+	{
+	  if (reparenting == YES)
+	    {
+	      XWindowAttributes	wa;
+	      Window		frame;
+
+	      XGetWindowAttributes(dpy, e.xmaprequest.window, &wa);
+	      frame = XCreateSimpleWindow(dpy, root, wa.x, wa.y,
+		wa.width, wa.height + FAKE_WM_TOP, 0, 0, 0);
+	      XReparentWindow(dpy, e.xmaprequest.window, frame,
+		0, FAKE_WM_TOP);
+	      XMapWindow(dpy, frame);
+	      XMapWindow(dpy, e.xmaprequest.window);
+	      XFlush(dpy);
+	      usleep(200000);
+	      fakeWMSetExtents(dpy, e.xmaprequest.window, FAKE_WM_TOP);
+	    }
+	  else
+	    {
+	      fakeWMSetExtents(dpy, e.xmaprequest.window, FAKE_WM_TOP);
+	      XMapWindow(dpy, e.xmaprequest.window);
+	      XFlush(dpy);
+	    }
+	}
+      else if (e.type == MapNotify && reparenting == NO
+	&& e.xmap.window != check)
+	{
+	  fakeWMSetExtents(dpy, e.xmap.window, FAKE_WM_TOP);
+	}
+    }
+}
+
+/* Wait for the child to announce itself, so the backend finds a window
+ * manager when it starts.  Answers NO if it never appears.
+ */
+static BOOL
+fakeWMWait(void)
+{
+  Display	*dpy;
+  Atom		netCheck;
+  unsigned	i;
+
+  dpy = XOpenDisplay(NULL);
+  if (dpy == NULL)
+    {
+      return NO;
+    }
+  netCheck = XInternAtom(dpy, "_NET_SUPPORTING_WM_CHECK", False);
+  for (i = 0; i < 200; i++)
+    {
+      Atom		type;
+      int		format;
+      unsigned long	nitems;
+      unsigned long	after;
+      unsigned char	*data = NULL;
+
+      if (XGetWindowProperty(dpy, DefaultRootWindow(dpy), netCheck, 0, 1,
+	    False, XA_WINDOW, &type, &format, &nitems, &after, &data)
+	  == Success && data != NULL)
+	{
+	  XFree(data);
+	  if (nitems == 1)
+	    {
+	      XCloseDisplay(dpy);
+	      return YES;
+	    }
+	}
+      usleep(50000);
+    }
+  XCloseDisplay(dpy);
+  return NO;
+}
+
+/* Answers the process id of the window manager, or -1. */
+static pid_t
+fakeWMStart(BOOL reparenting)
+{
+  pid_t	wm = fork();
+
+  if (wm == 0)
+    {
+      fakeWMRun(reparenting);
+      _exit(0);
+    }
+  if (wm < 0)
+    {
+      return -1;
+    }
+  if (fakeWMWait() == NO)
+    {
+      kill(wm, SIGKILL);
+      return -1;
+    }
+  return wm;
+}
+
+#endif

--- a/Tests/x11/FakeWindowManager.h
+++ b/Tests/x11/FakeWindowManager.h
@@ -1,12 +1,17 @@
 /* A window manager for the offsets tests, forked by the test that needs one.
  *
- * It announces itself the way an EWMH window manager does, advertises
- * _NET_REQUEST_FRAME_EXTENTS and answers that message with four zeros, which
- * is what recent Mutter releases do.  The real extents follow later: with
- * reparenting NO they are published as the window is mapped, and with
- * reparenting YES the window is put inside a frame and the extents are
- * published after the reparent, so a client reading the property as soon as
- * it sees the ReparentNotify reads the earlier answer instead.
+ * It announces itself the way an EWMH window manager does and advertises
+ * _NET_REQUEST_FRAME_EXTENTS.  What it does then depends on the mode:
+ *
+ * FakeWMDecorating answers that message with four zeros, which is what recent
+ * Mutter releases do, and publishes the real extents as the window is mapped.
+ *
+ * FakeWMReparenting answers with zeros as well, and puts the window inside a
+ * frame, publishing the real extents after the reparent, so a client reading
+ * the property as soon as it sees the ReparentNotify reads the earlier answer.
+ *
+ * FakeWMUndecorated maps windows and decorates nothing, which is how a
+ * rootless X server driving a native window manager can behave.
  */
 #ifndef FAKE_WINDOW_MANAGER_H
 #define FAKE_WINDOW_MANAGER_H
@@ -19,6 +24,16 @@
 
 /* The height of the window manager's title bar. */
 #define FAKE_WM_TOP 37
+
+enum
+{
+  /* Decorates, and publishes the extents as the window is mapped. */
+  FakeWMDecorating = 0,
+  /* Decorates by reparenting, and publishes the extents afterwards. */
+  FakeWMReparenting = 1,
+  /* Maps windows and decorates nothing at all. */
+  FakeWMUndecorated = 2
+};
 
 /* The windows being probed are destroyed as soon as they have been measured,
  * so a request naming one can fail at any point.  Xlib's default handler
@@ -44,7 +59,7 @@ fakeWMSetExtents(Display *dpy, Window w, long top)
 
 /* Runs in the child and never returns. */
 static void
-fakeWMRun(BOOL reparenting)
+fakeWMRun(int mode)
 {
   Display	*dpy;
   Window	root;
@@ -90,11 +105,20 @@ fakeWMRun(BOOL reparenting)
       XNextEvent(dpy, &e);
       if (e.type == ClientMessage && e.xclient.message_type == netRequest)
 	{
-	  fakeWMSetExtents(dpy, e.xclient.window, 0);
+	  /* One that decorates nothing has no extents to report. */
+	  if (mode != FakeWMUndecorated)
+	    {
+	      fakeWMSetExtents(dpy, e.xclient.window, 0);
+	    }
 	}
       else if (e.type == MapRequest)
 	{
-	  if (reparenting == YES)
+	  if (mode == FakeWMUndecorated)
+	    {
+	      XMapWindow(dpy, e.xmaprequest.window);
+	      XFlush(dpy);
+	    }
+	  else if (mode == FakeWMReparenting)
 	    {
 	      XWindowAttributes	wa;
 	      Window		frame;
@@ -117,7 +141,7 @@ fakeWMRun(BOOL reparenting)
 	      XFlush(dpy);
 	    }
 	}
-      else if (e.type == MapNotify && reparenting == NO
+      else if (e.type == MapNotify && mode == FakeWMDecorating
 	&& e.xmap.window != check)
 	{
 	  fakeWMSetExtents(dpy, e.xmap.window, FAKE_WM_TOP);
@@ -168,13 +192,13 @@ fakeWMWait(void)
 
 /* Answers the process id of the window manager, or -1. */
 static pid_t
-fakeWMStart(BOOL reparenting)
+fakeWMStart(int mode)
 {
   pid_t	wm = fork();
 
   if (wm == 0)
     {
-      fakeWMRun(reparenting);
+      fakeWMRun(mode);
       _exit(0);
     }
   if (wm < 0)

--- a/Tests/x11/GNUmakefile.preamble
+++ b/Tests/x11/GNUmakefile.preamble
@@ -31,4 +31,8 @@ ADDITIONAL_TOOL_LIBS += $(shell pkg-config --libs x11) \
                         $(shell pkg-config --libs xext 2>/dev/null) \
                         $(shell pkg-config --libs xrender 2>/dev/null) \
                         -lXmu -lm
+
+# A test that asks the display server what it reports needs the gui library,
+# which is where GSDisplayServer lives.
+ADDITIONAL_TOOL_LIBS += -lgnustep-gui
 endif

--- a/Tests/x11/decorationfallback.m
+++ b/Tests/x11/decorationfallback.m
@@ -1,13 +1,11 @@
-/* Window offsets have to survive a window manager that answers the
- * _NET_REQUEST_FRAME_EXTENTS message with four zeros and publishes the real
- * extents only once the window has been mapped.  Recent Mutter releases do
- * that, and taking the zeros leaves every decorated window style with no
- * decoration offset at all.
+/* A window manager that decorates nothing leaves every style without a
+ * border, and nothing else draws a title bar or a close button, so the
+ * windows cannot be moved or closed at all.  The gui library draws the
+ * decorations when -handlesWindowDecorations answers NO, so that is what the
+ * backend has to answer once it has found that out.
  *
- * The test forks a window manager that behaves that way, so it needs none on
- * the display it runs against.  The backend probes for offsets only when a
- * window manager is present, and otherwise reads them from the root window,
- * so GSIgnoreRootOffsets is set before the display server is created.
+ * A window manager that does decorate must still answer YES, and a decoration
+ * default the user has set has to stand either way.
  */
 #import <Foundation/Foundation.h>
 #import "Testing.h"
@@ -22,7 +20,7 @@
 int
 main(int argc, const char **argv)
 {
-  START_SET("frame extents")
+  START_SET("decoration fallback")
 
   extern void	initialize_gnustep_backend(void);
   GSDisplayServer *srv = nil;
@@ -37,7 +35,7 @@ main(int argc, const char **argv)
       SKIP("no window server available")
     }
 
-  wm = fakeWMStart(FakeWMDecorating);
+  wm = fakeWMStart(FakeWMUndecorated);
   if (wm < 0)
     {
       SKIP("the test window manager did not start")
@@ -67,18 +65,17 @@ main(int argc, const char **argv)
   [GSDisplayServer setCurrentServer: srv];
 
   [srv styleoffsets: &l : &r : &t : &b : NSTitledWindowMask];
-  PASS(t == (float)FAKE_WM_TOP,
-    "a title bar offset survives a window manager that answers the frame"
-    " extents request with zeros");
-
-  l = r = t = b = -1;
-  [srv styleoffsets: &l : &r : &t : &b : NSBorderlessWindowMask];
   PASS(l == 0.0 && r == 0.0 && t == 0.0 && b == 0.0,
-    "a borderless window has no offsets");
+    "a window manager that decorates nothing leaves a titled style with no"
+    " offsets");
+
+  PASS([srv handlesWindowDecorations] == NO,
+    "the gui library draws the decorations when the window manager draws"
+    " none");
 
   kill(wm, SIGKILL);
 
-  END_SET("frame extents")
+  END_SET("decoration fallback")
 
   return 0;
 }
@@ -88,9 +85,9 @@ main(int argc, const char **argv)
 int
 main(int argc, const char **argv)
 {
-  START_SET("frame extents")
+  START_SET("decoration fallback")
     SKIP("back is not built with the x11 server")
-  END_SET("frame extents")
+  END_SET("decoration fallback")
   return 0;
 }
 

--- a/Tests/x11/frameextents.m
+++ b/Tests/x11/frameextents.m
@@ -1,0 +1,235 @@
+/* Window offsets have to survive a window manager that answers the
+ * _NET_REQUEST_FRAME_EXTENTS message with four zeros and publishes the real
+ * extents only once the window has been mapped.  Recent Mutter releases do
+ * that, and taking the zeros leaves every decorated window style with no
+ * decoration offset at all.
+ *
+ * The test forks a small window manager that behaves that way, so it needs no
+ * window manager on the display it runs against.  The backend only probes for
+ * offsets when a window manager is present, and reads the cached offsets from
+ * the root window unless GSIgnoreRootOffsets is set, so both are arranged
+ * before the display server is created.
+ */
+#import <Foundation/Foundation.h>
+#import "Testing.h"
+#include "config.h"
+
+#if defined(BUILD_SERVER) && defined(SERVER_x11) && BUILD_SERVER == SERVER_x11
+
+#import <AppKit/AppKit.h>
+#import <GNUstepGUI/GSDisplayServer.h>
+#include <X11/Xlib.h>
+#include <X11/Xatom.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <signal.h>
+
+#define TOP 37          /* the height of the window manager's title bar */
+
+/* Announce an EWMH window manager and answer requests the unusable way.
+ * Runs in the child, which never returns.
+ */
+static void
+runWindowManager(void)
+{
+  Display	*dpy;
+  Window	root;
+  Window	check;
+  Atom		supported[4];
+  Atom		netCheck;
+  Atom		netName;
+  Atom		netRequest;
+  Atom		netExtents;
+  long		zero[4];
+  long		real[4];
+
+  dpy = XOpenDisplay(NULL);
+  if (dpy == NULL)
+    {
+      _exit(1);
+    }
+  root = DefaultRootWindow(dpy);
+  netCheck = XInternAtom(dpy, "_NET_SUPPORTING_WM_CHECK", False);
+  netName = XInternAtom(dpy, "_NET_WM_NAME", False);
+  netRequest = XInternAtom(dpy, "_NET_REQUEST_FRAME_EXTENTS", False);
+  netExtents = XInternAtom(dpy, "_NET_FRAME_EXTENTS", False);
+
+  zero[0] = zero[1] = zero[2] = zero[3] = 0;
+  real[0] = real[1] = real[3] = 0;
+  real[2] = TOP;
+
+  check = XCreateSimpleWindow(dpy, root, -100, -100, 1, 1, 0, 0, 0);
+  XChangeProperty(dpy, check, netCheck, XA_WINDOW, 32, PropModeReplace,
+    (unsigned char *)&check, 1);
+  XChangeProperty(dpy, check, netName,
+    XInternAtom(dpy, "UTF8_STRING", False), 8, PropModeReplace,
+    (unsigned char *)"testwm", 6);
+
+  supported[0] = netCheck;
+  supported[1] = netRequest;
+  supported[2] = netExtents;
+  supported[3] = netName;
+  XChangeProperty(dpy, root, XInternAtom(dpy, "_NET_SUPPORTED", False),
+    XA_ATOM, 32, PropModeReplace, (unsigned char *)supported, 4);
+
+  XSelectInput(dpy, root, SubstructureRedirectMask | SubstructureNotifyMask);
+  /* Announced last, so that a client seeing it finds the rest in place. */
+  XChangeProperty(dpy, root, netCheck, XA_WINDOW, 32, PropModeReplace,
+    (unsigned char *)&check, 1);
+  XFlush(dpy);
+
+  for (;;)
+    {
+      XEvent	e;
+
+      XNextEvent(dpy, &e);
+      if (e.type == ClientMessage && e.xclient.message_type == netRequest)
+	{
+	  XChangeProperty(dpy, e.xclient.window, netExtents, XA_CARDINAL, 32,
+	    PropModeReplace, (unsigned char *)zero, 4);
+	  XFlush(dpy);
+	}
+      else if (e.type == MapRequest)
+	{
+	  XChangeProperty(dpy, e.xmaprequest.window, netExtents, XA_CARDINAL,
+	    32, PropModeReplace, (unsigned char *)real, 4);
+	  XMapWindow(dpy, e.xmaprequest.window);
+	  XFlush(dpy);
+	}
+      else if (e.type == MapNotify && e.xmap.window != check)
+	{
+	  XChangeProperty(dpy, e.xmap.window, netExtents, XA_CARDINAL, 32,
+	    PropModeReplace, (unsigned char *)real, 4);
+	  XFlush(dpy);
+	}
+    }
+}
+
+/* Wait for the child to announce itself, so the backend finds a window
+ * manager when it starts.  Answers NO if it never appears.
+ */
+static BOOL
+waitForWindowManager(void)
+{
+  Display	*dpy;
+  Atom		netCheck;
+  unsigned	i;
+
+  dpy = XOpenDisplay(NULL);
+  if (dpy == NULL)
+    {
+      return NO;
+    }
+  netCheck = XInternAtom(dpy, "_NET_SUPPORTING_WM_CHECK", False);
+  for (i = 0; i < 200; i++)
+    {
+      Atom		type;
+      int		format;
+      unsigned long	nitems;
+      unsigned long	after;
+      unsigned char	*data = NULL;
+
+      if (XGetWindowProperty(dpy, DefaultRootWindow(dpy), netCheck, 0, 1,
+	    False, XA_WINDOW, &type, &format, &nitems, &after, &data)
+	  == Success && data != NULL)
+	{
+	  XFree(data);
+	  if (nitems == 1)
+	    {
+	      XCloseDisplay(dpy);
+	      return YES;
+	    }
+	}
+      usleep(50000);
+    }
+  XCloseDisplay(dpy);
+  return NO;
+}
+
+int
+main(int argc, const char **argv)
+{
+  START_SET("frame extents")
+
+  extern void	initialize_gnustep_backend(void);
+  GSDisplayServer *srv = nil;
+  pid_t		wm;
+  float		l = -1;
+  float		r = -1;
+  float		t = -1;
+  float		b = -1;
+
+  if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
+    {
+      SKIP("no window server available")
+    }
+
+  wm = fork();
+  if (wm == 0)
+    {
+      runWindowManager();
+      _exit(0);
+    }
+  if (wm < 0)
+    {
+      SKIP("cannot fork a window manager")
+    }
+  if (waitForWindowManager() == NO)
+    {
+      kill(wm, SIGKILL);
+      SKIP("the test window manager did not start")
+    }
+
+  /* The offsets are cached on the root window once they are known. */
+  [[NSUserDefaults standardUserDefaults]
+    setBool: YES forKey: @"GSIgnoreRootOffsets"];
+
+  NS_DURING
+    {
+      initialize_gnustep_backend();
+      srv = [GSDisplayServer serverWithAttributes: nil];
+    }
+  NS_HANDLER
+    {
+      NSLog(@"the display server did not start: %@", localException);
+      kill(wm, SIGKILL);
+      SKIP("It looks like the GNUstep backend is not installed")
+    }
+  NS_ENDHANDLER
+
+  if (srv == nil || [srv isMemberOfClass: [GSDisplayServer class]])
+    {
+      kill(wm, SIGKILL);
+      SKIP("no concrete display server")
+    }
+  [GSDisplayServer setCurrentServer: srv];
+
+  [srv styleoffsets: &l : &r : &t : &b : NSTitledWindowMask];
+  PASS(t == (float)TOP,
+    "a title bar offset survives a window manager that answers the frame"
+    " extents request with zeros");
+
+  l = r = t = b = -1;
+  [srv styleoffsets: &l : &r : &t : &b : NSBorderlessWindowMask];
+  PASS(l == 0.0 && r == 0.0 && t == 0.0 && b == 0.0,
+    "a borderless window has no offsets");
+
+  kill(wm, SIGKILL);
+
+  END_SET("frame extents")
+
+  return 0;
+}
+
+#else
+
+int
+main(int argc, const char **argv)
+{
+  START_SET("frame extents")
+    SKIP("back is not built with the x11 server")
+  END_SET("frame extents")
+  return 0;
+}
+
+#endif

--- a/Tests/x11/reparentoffsets.m
+++ b/Tests/x11/reparentoffsets.m
@@ -33,7 +33,7 @@ main(int argc, const char **argv)
       SKIP("no window server available")
     }
 
-  wm = fakeWMStart(YES);
+  wm = fakeWMStart(FakeWMReparenting);
   if (wm < 0)
     {
       SKIP("the test window manager did not start")

--- a/Tests/x11/reparentoffsets.m
+++ b/Tests/x11/reparentoffsets.m
@@ -1,13 +1,9 @@
-/* Window offsets have to survive a window manager that answers the
- * _NET_REQUEST_FRAME_EXTENTS message with four zeros and publishes the real
- * extents only once the window has been mapped.  Recent Mutter releases do
- * that, and taking the zeros leaves every decorated window style with no
- * decoration offset at all.
- *
- * The test forks a window manager that behaves that way, so it needs none on
- * the display it runs against.  The backend probes for offsets only when a
- * window manager is present, and otherwise reads them from the root window,
- * so GSIgnoreRootOffsets is set before the display server is created.
+/* A reparenting window manager puts the window inside a frame and publishes
+ * _NET_FRAME_EXTENTS after the reparent.  A client that reads the property as
+ * soon as it sees the ReparentNotify reads whatever was there before, which
+ * for a window manager that answers the _NET_REQUEST_FRAME_EXTENTS message
+ * with zeros is those zeros.  The window's own place inside the frame says
+ * what the decoration really is, so that is what the offsets come from.
  */
 #import <Foundation/Foundation.h>
 #import "Testing.h"
@@ -22,7 +18,7 @@
 int
 main(int argc, const char **argv)
 {
-  START_SET("frame extents")
+  START_SET("reparent offsets")
 
   extern void	initialize_gnustep_backend(void);
   GSDisplayServer *srv = nil;
@@ -37,7 +33,7 @@ main(int argc, const char **argv)
       SKIP("no window server available")
     }
 
-  wm = fakeWMStart(NO);
+  wm = fakeWMStart(YES);
   if (wm < 0)
     {
       SKIP("the test window manager did not start")
@@ -68,17 +64,12 @@ main(int argc, const char **argv)
 
   [srv styleoffsets: &l : &r : &t : &b : NSTitledWindowMask];
   PASS(t == (float)FAKE_WM_TOP,
-    "a title bar offset survives a window manager that answers the frame"
-    " extents request with zeros");
-
-  l = r = t = b = -1;
-  [srv styleoffsets: &l : &r : &t : &b : NSBorderlessWindowMask];
-  PASS(l == 0.0 && r == 0.0 && t == 0.0 && b == 0.0,
-    "a borderless window has no offsets");
+    "a title bar offset comes from the reparent when the extents published"
+    " before the window was mapped are still in place");
 
   kill(wm, SIGKILL);
 
-  END_SET("frame extents")
+  END_SET("reparent offsets")
 
   return 0;
 }
@@ -88,9 +79,9 @@ main(int argc, const char **argv)
 int
 main(int argc, const char **argv)
 {
-  START_SET("frame extents")
+  START_SET("reparent offsets")
     SKIP("back is not built with the x11 server")
-  END_SET("frame extents")
+  END_SET("reparent offsets")
   return 0;
 }
 


### PR DESCRIPTION
Stacked on #227, which adds the window manager the new test forks. It must not
merge before that one.

A window manager can ignore _MOTIF_WM_HINTS and decorate nothing, which is what
a rootless X server driving a native window manager does. Measured under one
that maps windows and decorates nothing, the hints GNUstep sets are right: for
a titled, closable, miniaturizable and resizable style the property holds
0x3, 0x3e, 0x6e, so title, border, resize handle, minimize and maximize are all
asked for. The window still comes back with no border and no close button, and
cannot be moved or closed. That is #82.

-handlesWindowDecorations decides which side draws them, and answered YES
whatever the window manager did, changing only for a user default. It is now
answered from the offsets probe: a window manager that puts a border on no
style draws no title bar either. A display with no window manager does not
reach this, and a user default still holds.

A titled window was 200x120, the content rect asked for, and is now 202x144.
Tests/x11 gives 260 passed 0 failed against 258 passed 2 failed.
