### PR TITLE
Fix: build the application icon pixmap on a depth 24 screen

### DIFF
--- a/Source/x11/XGServerWindow.m
+++ b/Source/x11/XGServerWindow.m
@@ -2928,12 +2928,12 @@ swapColors(unsigned char *image_data, NSBitmapImageRep *rep)
   height = [rep pixelsHigh];
   colors = [rep samplesPerPixel];
 
-  if (rcontext->depth != 32)
-    {
-      NSLog(@"Unsupported context depth %d", rcontext->depth);
-      return 0;
-    }
-
+  /* swapColors() writes four bytes per pixel, so the image must have that
+   * layout.  The depth itself does not have to be 32: a depth 24 visual,
+   * which is what almost every screen has, gives 32 bits per pixel with the
+   * fourth byte unused, and the transparency comes from xIconMask rather
+   * than from the pixmap.
+   */
   rxImage = RCreateXImage(rcontext, rcontext->depth, width, height);
   if (rxImage->image->bytes_per_line != 4 * width)
     {


### PR DESCRIPTION
-[XGServer _createAppIconPixmaps] returns early unless the RContext depth is 32. RCreateContext is called with no attributes, so it takes the default visual, which is depth 24 on almost every screen. The icon pixmap and mask are never built, and the app root window carries IconWindowHint alone.

The precondition this code needs is the bytes_per_line check below it, since swapColors() writes four bytes per pixel. A depth 24 visual gives 32 bits per pixel with the fourth byte unused, and the transparency comes from xIconMask. Removing the depth test leaves depth 16 rejected by bytes_per_line.

Measured under WindowMaker 0.96 at depth 24. Without this the icon area shows an empty tile for about 700 ms before the icon window draws; with it the icon is in the first frame. The pixmap read back off the server is 192x192 and holds the application icon.

Tests/ is 265 passed, 0 failed, 31 skipped either way. No test reaches this path: it needs a window manager advertising the WindowMaker protocols, and it goes through NSApp, so the AppKit tests skip on the x11 jobs.

Reported in #30.
