### PR TITLE
CI: check out with a Node 24 action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,7 +99,7 @@ jobs:
       INSTALL_PATH: ${{ github.workspace }}/build
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
 
       - name: Install packages
         run: |


### PR DESCRIPTION
Every job ends with a warning that actions/checkout@v3 targets Node.js 20 and is being forced onto Node.js 24. The runner no longer gives checkout the runtime it declares, and the compatibility shim is being withdrawn.

checkout v3 declares node16 and v4 declares node20. v5 is the release that moved checkout to node24, so it is the smallest bump that removes the warning. v6 stores credentials in a separate file and v7 blocks checking out a fork under pull_request_target and workflow_run, neither of which belongs in this change.

v5 needs runner 2.327.1 or newer. The runners this workflow gets are 2.336.0.

Verified on the fork: all 5 jobs build and test green, and no job logs the deprecation warning.
