### PR TITLE
Fix: implement the primitives HeadlessGState left to GSGState

### DIFF
--- a/Headers/headless/HeadlessGState.h
+++ b/Headers/headless/HeadlessGState.h
@@ -31,6 +31,14 @@
 
 @interface HeadlessGState : GSGState
 {
+  /* Held so the DPScurrent... accessors answer what was set.  Nothing is
+     drawn, but a caller that sets a parameter and reads it back gets its own
+     value rather than an exception.  Initialised to the PostScript defaults. */
+  int _linecap;
+  int _linejoin;
+  int _strokeadjust;
+  CGFloat _linewidth;
+  CGFloat _miterlimit;
 }
 @end
 

--- a/Source/headless/HeadlessGState.m
+++ b/Source/headless/HeadlessGState.m
@@ -28,7 +28,42 @@
 
 @implementation HeadlessGState
 
+- (id) copyWithZone: (NSZone *)zone
+{
+  HeadlessGState *copy = (HeadlessGState *)[super copyWithZone: zone];
+
+  copy->_linecap = _linecap;
+  copy->_linejoin = _linejoin;
+  copy->_strokeadjust = _strokeadjust;
+  copy->_linewidth = _linewidth;
+  copy->_miterlimit = _miterlimit;
+  return copy;
+}
+
+- (id) initWithDrawContext: (GSContext *)drawContext
+{
+  self = [super initWithDrawContext: drawContext];
+  if (self != nil)
+    {
+      /* The PostScript defaults, so a read before any write is not zero. */
+      _linecap = 0;
+      _linejoin = 0;
+      _strokeadjust = 0;
+      _linewidth = 1.0;
+      _miterlimit = 10.0;
+    }
+  return self;
+}
+
 - (void) DPSclip
+{
+}
+
+- (void) DPSeoclip
+{
+}
+
+- (void) DPSinitclip
 {
 }
 
@@ -36,8 +71,100 @@
 {
 }
 
+- (void) DPSeofill
+{
+}
+
+- (void) _paintPath: (ctxt_object_t)drawType
+{
+}
+
+- (void *) saveClip
+{
+  return NULL;
+}
+
+- (void) restoreClip: (void *)savedClip
+{
+}
+
+- (void) DPSshow: (const char *)s
+{
+}
+
+- (void) GSShowText: (const char *)string : (size_t)length
+{
+}
+
+- (void) GSShowGlyphsWithAdvances: (const NSGlyph *)glyphs
+                                 : (const NSSize *)advances
+                                 : (size_t)length
+{
+}
+
 - (void) DPSsetlinewidth: (CGFloat)width
 {
+  _linewidth = width;
+}
+
+- (void) DPScurrentlinewidth: (CGFloat *)width
+{
+  if (width != NULL)
+    {
+      *width = _linewidth;
+    }
+}
+
+- (void) DPSsetlinecap: (int)linecap
+{
+  _linecap = linecap;
+}
+
+- (void) DPScurrentlinecap: (int *)linecap
+{
+  if (linecap != NULL)
+    {
+      *linecap = _linecap;
+    }
+}
+
+- (void) DPSsetlinejoin: (int)linejoin
+{
+  _linejoin = linejoin;
+}
+
+- (void) DPScurrentlinejoin: (int *)linejoin
+{
+  if (linejoin != NULL)
+    {
+      *linejoin = _linejoin;
+    }
+}
+
+- (void) DPSsetmiterlimit: (CGFloat)limit
+{
+  _miterlimit = limit;
+}
+
+- (void) DPScurrentmiterlimit: (CGFloat *)limit
+{
+  if (limit != NULL)
+    {
+      *limit = _miterlimit;
+    }
+}
+
+- (void) DPSsetstrokeadjust: (int)b
+{
+  _strokeadjust = b;
+}
+
+- (void) DPScurrentstrokeadjust: (int *)b
+{
+  if (b != NULL)
+    {
+      *b = _strokeadjust;
+    }
 }
 
 - (void) DPSsetdash: (const CGFloat *)pat : (NSInteger)size : (CGFloat)foffset

--- a/Tests/headless/GNUmakefile.preamble
+++ b/Tests/headless/GNUmakefile.preamble
@@ -1,0 +1,11 @@
+# Extra build settings for the headless backend tests.
+
+# config.h (used by the source-level guards) sits at the top of the (build)
+# tree.
+ADDITIONAL_INCLUDE_DIRS += -I$(GNUSTEP_BUILD_DIR)/../.. -I../..
+
+-include $(GNUSTEP_BUILD_DIR)/../../config.make
+-include ../../config.make
+
+# The test drives the loaded backend through AppKit, so the gui is linked.
+ADDITIONAL_TOOL_LIBS += -lgnustep-gui

--- a/Tests/headless/gstate.m
+++ b/Tests/headless/gstate.m
@@ -1,0 +1,116 @@
+/* Coverage for the drawing primitives HeadlessGState implements
+ * (Source/headless/HeadlessGState.m).
+ *
+ * GSGState declares 26 methods as subclassResponsibility, which raise
+ * NSInvalidArgumentException unless the graphics backend overrides them.  The
+ * headless backend draws nothing, so each of them has to return rather than
+ * raise: a caller cannot otherwise tell a primitive that does nothing from one
+ * that aborts the drawing.
+ *
+ * The line parameters are the part with observable state.  They are held so
+ * that the DPScurrent... accessors answer what was set, and they start at the
+ * PostScript defaults, so a read before any write gives 1, 0, 0, 10 and 0
+ * rather than zero.
+ *
+ * A backend test can only build against the backend it belongs to, so this
+ * guards on the headless graphics backend actually being built (config.h names
+ * it through BUILD_GRAPHICS) and skips cleanly on every other one.
+ */
+#import <Foundation/Foundation.h>
+#import "Testing.h"
+#include "config.h"
+
+#if defined(BUILD_GRAPHICS) && defined(GRAPHICS_headless) \
+  && BUILD_GRAPHICS == GRAPHICS_headless
+
+#import <AppKit/AppKit.h>
+
+int
+main(void)
+{
+  START_SET("headless gstate primitives")
+
+  NSGraphicsContext *ctxt = nil;
+  CGFloat width = -1.0;
+  CGFloat miter = -1.0;
+  int cap = -1;
+  int join = -1;
+  int adjust = -1;
+
+  /* Loading the backend raises when it cannot be found; treat that as
+   * nothing to test here rather than a failure. */
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+      ctxt = [NSGraphicsContext currentContext];
+    }
+  NS_HANDLER
+    {
+      if ([[localException name] isEqualToString: @"SkipSet"])
+	[localException raise];
+      ctxt = nil;
+    }
+  NS_ENDHANDLER
+
+  if (ctxt == nil)
+    {
+      SKIP("the headless backend is not available")
+    }
+  else
+    {
+      [ctxt DPScurrentlinewidth: &width];
+      [ctxt DPScurrentlinecap: &cap];
+      [ctxt DPScurrentlinejoin: &join];
+      [ctxt DPScurrentmiterlimit: &miter];
+      [ctxt DPScurrentstrokeadjust: &adjust];
+      PASS(width == 1.0 && cap == 0 && join == 0 && miter == 10.0
+	&& adjust == 0,
+	"the line parameters start at the PostScript defaults");
+
+      [ctxt DPSsetlinewidth: 4.5];
+      [ctxt DPSsetlinecap: 2];
+      [ctxt DPSsetlinejoin: 1];
+      [ctxt DPSsetmiterlimit: 3.25];
+      [ctxt DPSsetstrokeadjust: 1];
+
+      width = -1.0; miter = -1.0; cap = -1; join = -1; adjust = -1;
+      [ctxt DPScurrentlinewidth: &width];
+      [ctxt DPScurrentlinecap: &cap];
+      [ctxt DPScurrentlinejoin: &join];
+      [ctxt DPScurrentmiterlimit: &miter];
+      [ctxt DPScurrentstrokeadjust: &adjust];
+      PASS(width == 4.5 && cap == 2 && join == 1 && miter == 3.25
+	&& adjust == 1,
+	"a line parameter that is set reads back");
+
+      PASS_RUNS(({
+	  [ctxt DPSinitclip];
+	  [ctxt DPSeoclip];
+	  [ctxt DPSeofill];
+	  [ctxt DPSfill];
+	  [ctxt DPSstroke];
+	}),
+	"the clip and fill primitives return without drawing");
+
+      PASS_RUNS(({
+	  [ctxt DPSshow: "text"];
+	}),
+	"the text primitive returns without drawing");
+    }
+
+  END_SET("headless gstate primitives")
+  return 0;
+}
+
+#else
+
+int
+main(void)
+{
+  START_SET("headless gstate primitives")
+    SKIP("back is not built with the headless graphics backend")
+  END_SET("headless gstate primitives")
+  return 0;
+}
+
+#endif


### PR DESCRIPTION
GSGState declares 26 methods as subclassResponsibility. HeadlessGState
implemented 8, so a drawing path reaching any of the other 18 raised
NSInvalidArgumentException with "should be overridden by subclass". The backend
is meant to draw nothing, and a caller cannot tell a primitive that is a no-op
from one that aborts the drawing.

The 18 are implemented. The clip, fill, path and text operations return without
drawing. saveClip returns NULL and restoreClip ignores it. The line parameters
are held so the DPScurrent... accessors answer what was set, starting at the
PostScript defaults of 1, 0, 0, 10 and 0, and copyWithZone carries them into a
copied state.

Source/headless and Headers/headless are built only when BUILD_SERVER or
BUILD_GRAPHICS is headless, so no other backend is affected.

Tests/headless/gstate.m. It guards on the headless graphics backend being
built, and skips when the backend loaded at run time is not the headless one,
since the suite runs against the installed backend.

Against the unfixed HeadlessGState the set fails at the first accessor with
NSInvalidArgumentException. On x86_64-linux-android API 31 with this branch it
reports 4 passed, and in libs-gui the NSSwitch, NSPanel and NSRulerView render
tests reach their own assertions instead of an unexpected exception.
