### PR TITLE
Skip on the absence of a display server, not of DISPLAY

### DIFF
--- a/Tests/cairo/bitmapcontextdraw.m
+++ b/Tests/cairo/bitmapcontextdraw.m
@@ -17,6 +17,7 @@
   && BUILD_GRAPHICS == GRAPHICS_cairo
 
 #import <AppKit/AppKit.h>
+#import <GNUstepGUI/GSDisplayServer.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -85,14 +86,16 @@ main(int argc, const char **argv)
   int x;
   int y;
 
-  if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
-    {
-      SKIP("no window server available")
-    }
-
+  /* Ask whether a display server can be reached rather than whether X11's
+   * DISPLAY is set: a backend that is not X11 has no DISPLAY and would skip
+   * here while being perfectly able to run the test. */
   NS_DURING
     {
       [NSApplication sharedApplication];
+      if (nil == GSCurrentServer())
+	{
+	  SKIP("no window server available")
+	}
     }
   NS_HANDLER
     {

--- a/Tests/cairo/bitmapcontextdraw.m
+++ b/Tests/cairo/bitmapcontextdraw.m
@@ -86,9 +86,6 @@ main(int argc, const char **argv)
   int x;
   int y;
 
-  /* Ask whether a display server can be reached rather than whether X11's
-   * DISPLAY is set: a backend that is not X11 has no DISPLAY and would skip
-   * here while being perfectly able to run the test. */
   NS_DURING
     {
       [NSApplication sharedApplication];

--- a/Tests/cairo/bitmapcontextflush.m
+++ b/Tests/cairo/bitmapcontextflush.m
@@ -14,6 +14,7 @@
   && BUILD_GRAPHICS == GRAPHICS_cairo
 
 #import <AppKit/AppKit.h>
+#import <GNUstepGUI/GSDisplayServer.h>
 #include <stdlib.h>
 
 int
@@ -24,12 +25,24 @@ main(int argc, const char **argv)
 
   START_SET("bitmap context flush")
 
-  if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
+  /* Ask whether a display server can be reached rather than whether X11's
+   * DISPLAY is set: a backend that is not X11 has no DISPLAY and would skip
+   * here while being perfectly able to run the test.  The handler matters as
+   * much as the question: starting the application raises when no backend can
+   * be loaded, and an unguarded call fails the set instead of skipping it. */
+  NS_DURING
     {
-      SKIP("no window server available")
+      [NSApplication sharedApplication];
+      if (nil == GSCurrentServer())
+	{
+	  SKIP("no window server available")
+	}
     }
-
-  [NSApplication sharedApplication];
+  NS_HANDLER
+    {
+      SKIP("It looks like the GNUstep backend is not installed")
+    }
+  NS_ENDHANDLER
 
   rep = AUTORELEASE([[NSBitmapImageRep alloc]
     initWithBitmapDataPlanes: NULL

--- a/Tests/cairo/bitmapcontextflush.m
+++ b/Tests/cairo/bitmapcontextflush.m
@@ -25,11 +25,6 @@ main(int argc, const char **argv)
 
   START_SET("bitmap context flush")
 
-  /* Ask whether a display server can be reached rather than whether X11's
-   * DISPLAY is set: a backend that is not X11 has no DISPLAY and would skip
-   * here while being perfectly able to run the test.  The handler matters as
-   * much as the question: starting the application raises when no backend can
-   * be loaded, and an unguarded call fails the set instead of skipping it. */
   NS_DURING
     {
       [NSApplication sharedApplication];

--- a/Tests/cairo/compatbitmap.m
+++ b/Tests/cairo/compatbitmap.m
@@ -40,9 +40,6 @@ main(int argc, const char **argv)
   id ctxt;
   NSBitmapImageRep *alphaFirst;
 
-  /* Ask whether a display server can be reached rather than whether X11's
-   * DISPLAY is set: a backend that is not X11 has no DISPLAY and would skip
-   * here while being perfectly able to run the test. */
   NS_DURING
     {
       [NSApplication sharedApplication];

--- a/Tests/cairo/compatbitmap.m
+++ b/Tests/cairo/compatbitmap.m
@@ -3,9 +3,9 @@
  * sample, standard-format RGB bitmap.  Anything else (planar, 16-bit, gray, or
  * a non-zero bitmap format such as alpha-first) is not compatible.
  *
- * It needs a window server (to load the backend), so it opens the display named
- * by the environment and skips when there is none, and it guards on the cairo
- * graphics backend being the one built.
+ * It needs a window server (to load the backend), so it skips when no display
+ * server can be reached, and it guards on the cairo graphics backend being the
+ * one built.
  */
 #import <Foundation/NSObject.h>
 #import "Testing.h"
@@ -15,6 +15,7 @@
   && BUILD_GRAPHICS == GRAPHICS_cairo
 
 #import <AppKit/AppKit.h>
+#import <GNUstepGUI/GSDisplayServer.h>
 #include <stdlib.h>
 
 @interface NSObject (CairoCompat)
@@ -39,14 +40,16 @@ main(int argc, const char **argv)
   id ctxt;
   NSBitmapImageRep *alphaFirst;
 
-  if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
-    {
-      SKIP("no window server available")
-    }
-
+  /* Ask whether a display server can be reached rather than whether X11's
+   * DISPLAY is set: a backend that is not X11 has no DISPLAY and would skip
+   * here while being perfectly able to run the test. */
   NS_DURING
     {
       [NSApplication sharedApplication];
+      if (nil == GSCurrentServer())
+	{
+	  SKIP("no window server available")
+	}
     }
   NS_HANDLER
     {

--- a/Tests/cairo/pdfps.m
+++ b/Tests/cairo/pdfps.m
@@ -61,9 +61,6 @@ main(int argc, const char **argv)
   GSPdfPsTestView *v;
   NSData *pdf, *eps;
 
-  /* Ask whether a display server can be reached rather than whether X11's
-   * DISPLAY is set: a backend that is not X11 has no DISPLAY and would skip
-   * here while being perfectly able to run the test. */
   NS_DURING
     {
       [NSApplication sharedApplication];

--- a/Tests/cairo/pdfps.m
+++ b/Tests/cairo/pdfps.m
@@ -3,9 +3,9 @@
  * cairo PDF and PS surfaces, and the resulting documents are checked for a
  * valid header, a non-trivial body and the expected document structure.
  *
- * It needs a window server (to load the backend), so it opens the display named
- * by the environment and skips when there is none, and it guards on the cairo
- * graphics backend being the one built.
+ * It needs a window server (to load the backend), so it skips when no display
+ * server can be reached, and it guards on the cairo graphics backend being the
+ * one built.
  */
 #import <Foundation/NSObject.h>
 #import "Testing.h"
@@ -15,6 +15,7 @@
   && BUILD_GRAPHICS == GRAPHICS_cairo
 
 #import <AppKit/AppKit.h>
+#import <GNUstepGUI/GSDisplayServer.h>
 #include <string.h>
 #include <stdlib.h>
 
@@ -60,14 +61,16 @@ main(int argc, const char **argv)
   GSPdfPsTestView *v;
   NSData *pdf, *eps;
 
-  if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
-    {
-      SKIP("no window server available")
-    }
-
+  /* Ask whether a display server can be reached rather than whether X11's
+   * DISPLAY is set: a backend that is not X11 has no DISPLAY and would skip
+   * here while being perfectly able to run the test. */
   NS_DURING
     {
       [NSApplication sharedApplication];
+      if (nil == GSCurrentServer())
+	{
+	  SKIP("no window server available")
+	}
     }
   NS_HANDLER
     {

--- a/Tests/cairo/plusdarker.m
+++ b/Tests/cairo/plusdarker.m
@@ -78,9 +78,6 @@ main(int argc, const char **argv)
 {
   START_SET("plus darker")
 
-  /* Ask whether a display server can be reached rather than whether X11's
-   * DISPLAY is set: a backend that is not X11 has no DISPLAY and would skip
-   * here while being perfectly able to run the test. */
   NS_DURING
     {
       [NSApplication sharedApplication];

--- a/Tests/cairo/plusdarker.m
+++ b/Tests/cairo/plusdarker.m
@@ -15,6 +15,7 @@
   && BUILD_GRAPHICS == GRAPHICS_cairo
 
 #import <AppKit/AppKit.h>
+#import <GNUstepGUI/GSDisplayServer.h>
 #include <stdlib.h>
 
 #define SIDE 20
@@ -77,14 +78,16 @@ main(int argc, const char **argv)
 {
   START_SET("plus darker")
 
-  if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
-    {
-      SKIP("no window server available")
-    }
-
+  /* Ask whether a display server can be reached rather than whether X11's
+   * DISPLAY is set: a backend that is not X11 has no DISPLAY and would skip
+   * here while being perfectly able to run the test. */
   NS_DURING
     {
       [NSApplication sharedApplication];
+      if (nil == GSCurrentServer())
+	{
+	  SKIP("no window server available")
+	}
     }
   NS_HANDLER
     {

--- a/Tests/cairo/surfacedevice.m
+++ b/Tests/cairo/surfacedevice.m
@@ -5,9 +5,9 @@
  * y-flip).  This exercises the surface/device set-up that backs offscreen
  * drawing.
  *
- * It needs a window server (to load the backend), so it opens the display named
- * by the environment and skips when there is none, and it guards on the cairo
- * graphics backend being the one built.
+ * It needs a window server (to load the backend), so it skips when no display
+ * server can be reached, and it guards on the cairo graphics backend being the
+ * one built.
  */
 #import <Foundation/NSObject.h>
 #import "Testing.h"
@@ -17,6 +17,7 @@
   && BUILD_GRAPHICS == GRAPHICS_cairo
 
 #import <AppKit/AppKit.h>
+#import <GNUstepGUI/GSDisplayServer.h>
 #include <stdlib.h>
 
 @interface NSObject (CairoDevice)
@@ -42,14 +43,16 @@ main(int argc, const char **argv)
   void *device;
   int x, y;
 
-  if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
-    {
-      SKIP("no window server available")
-    }
-
+  /* Ask whether a display server can be reached rather than whether X11's
+   * DISPLAY is set: a backend that is not X11 has no DISPLAY and would skip
+   * here while being perfectly able to run the test. */
   NS_DURING
     {
       [NSApplication sharedApplication];
+      if (nil == GSCurrentServer())
+	{
+	  SKIP("no window server available")
+	}
     }
   NS_HANDLER
     {

--- a/Tests/cairo/surfacedevice.m
+++ b/Tests/cairo/surfacedevice.m
@@ -43,9 +43,6 @@ main(int argc, const char **argv)
   void *device;
   int x, y;
 
-  /* Ask whether a display server can be reached rather than whether X11's
-   * DISPLAY is set: a backend that is not X11 has no DISPLAY and would skip
-   * here while being perfectly able to run the test. */
   NS_DURING
     {
       [NSApplication sharedApplication];

--- a/Tests/gsc/gstate.m
+++ b/Tests/gsc/gstate.m
@@ -58,9 +58,6 @@ main(int argc, const char **argv)
   NSAffineTransformStruct s;
   CGFloat m[6] = {1, 0, 0, 1, 5, 6};
 
-  /* Ask whether a display server can be reached rather than whether X11's
-   * DISPLAY is set: a backend that is not X11 has no DISPLAY and would skip
-   * here while being perfectly able to run the test. */
   NS_DURING
     {
       [NSApplication sharedApplication];

--- a/Tests/gsc/gstate.m
+++ b/Tests/gsc/gstate.m
@@ -3,10 +3,9 @@
  * a point or delta is mapped through it.
  *
  * GSGState lives in the backend bundle, so the test needs a backend loaded
- * (hence a window server); it opens the display named by the environment and
- * skips when there is none.  The code under test is the same for every backend;
- * it is built for the cairo backend, which is the one that loads on the test
- * display.
+ * (hence a window server); it skips when no display server can be reached.  The
+ * code under test is the same for every backend; it is built for the cairo
+ * backend.
  */
 #import <Foundation/Foundation.h>
 #import "Testing.h"
@@ -16,6 +15,7 @@
   && BUILD_GRAPHICS == GRAPHICS_cairo
 
 #import <AppKit/AppKit.h>
+#import <GNUstepGUI/GSDisplayServer.h>
 #include <stdlib.h>
 
 @interface NSObject (GSGStateCTM)
@@ -58,14 +58,16 @@ main(int argc, const char **argv)
   NSAffineTransformStruct s;
   CGFloat m[6] = {1, 0, 0, 1, 5, 6};
 
-  if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
-    {
-      SKIP("no window server available")
-    }
-
+  /* Ask whether a display server can be reached rather than whether X11's
+   * DISPLAY is set: a backend that is not X11 has no DISPLAY and would skip
+   * here while being perfectly able to run the test. */
   NS_DURING
     {
       [NSApplication sharedApplication];
+      if (nil == GSCurrentServer())
+	{
+	  SKIP("no window server available")
+	}
     }
   NS_HANDLER
     {

--- a/Tests/gsc/gstatealias.m
+++ b/Tests/gsc/gstatealias.m
@@ -3,10 +3,9 @@
  * changing after the call disturbs the other.
  *
  * GSGState lives in the backend bundle, so the test needs a backend loaded
- * (hence a window server); it opens the display named by the environment and
- * skips when there is none.  The code under test is the same for every backend;
- * it is built for the cairo backend, which is the one that loads on the test
- * display.
+ * (hence a window server); it skips when no display server can be reached.  The
+ * code under test is the same for every backend; it is built for the cairo
+ * backend.
  */
 #import <Foundation/Foundation.h>
 #import "Testing.h"
@@ -16,6 +15,7 @@
   && BUILD_GRAPHICS == GRAPHICS_cairo
 
 #import <AppKit/AppKit.h>
+#import <GNUstepGUI/GSDisplayServer.h>
 #include <stdlib.h>
 
 @interface NSObject (GSGStateAlias)
@@ -42,14 +42,16 @@ main(int argc, const char **argv)
   NSAffineTransform *t;
   NSPoint p;
 
-  if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
-    {
-      SKIP("no window server available")
-    }
-
+  /* Ask whether a display server can be reached rather than whether X11's
+   * DISPLAY is set: a backend that is not X11 has no DISPLAY and would skip
+   * here while being perfectly able to run the test. */
   NS_DURING
     {
       [NSApplication sharedApplication];
+      if (nil == GSCurrentServer())
+	{
+	  SKIP("no window server available")
+	}
     }
   NS_HANDLER
     {

--- a/Tests/gsc/gstatealias.m
+++ b/Tests/gsc/gstatealias.m
@@ -42,9 +42,6 @@ main(int argc, const char **argv)
   NSAffineTransform *t;
   NSPoint p;
 
-  /* Ask whether a display server can be reached rather than whether X11's
-   * DISPLAY is set: a backend that is not X11 has no DISPLAY and would skip
-   * here while being perfectly able to run the test. */
   NS_DURING
     {
       [NSApplication sharedApplication];

--- a/Tests/gsc/gstatecolor.m
+++ b/Tests/gsc/gstatecolor.m
@@ -49,9 +49,6 @@ main(int argc, const char **argv)
   id ctxt, gs;
   CGFloat r, g, b, k, a;
 
-  /* Ask whether a display server can be reached rather than whether X11's
-   * DISPLAY is set: a backend that is not X11 has no DISPLAY and would skip
-   * here while being perfectly able to run the test. */
   NS_DURING
     {
       [NSApplication sharedApplication];

--- a/Tests/gsc/gstatecolor.m
+++ b/Tests/gsc/gstatecolor.m
@@ -4,10 +4,9 @@
  * changes, and components are clamped to [0,1].
  *
  * GSGState lives in the backend bundle, so the test needs a backend loaded
- * (hence a window server); it opens the display named by the environment and
- * skips when there is none.  The code under test is the same for every backend;
- * it is built for the cairo backend, which is the one that loads on the test
- * display.
+ * (hence a window server); it skips when no display server can be reached.  The
+ * code under test is the same for every backend; it is built for the cairo
+ * backend.
  */
 #import <Foundation/Foundation.h>
 #import "Testing.h"
@@ -17,6 +16,7 @@
   && BUILD_GRAPHICS == GRAPHICS_cairo
 
 #import <AppKit/AppKit.h>
+#import <GNUstepGUI/GSDisplayServer.h>
 #include <stdlib.h>
 
 @interface NSObject (GSGStateColor)
@@ -49,14 +49,16 @@ main(int argc, const char **argv)
   id ctxt, gs;
   CGFloat r, g, b, k, a;
 
-  if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
-    {
-      SKIP("no window server available")
-    }
-
+  /* Ask whether a display server can be reached rather than whether X11's
+   * DISPLAY is set: a backend that is not X11 has no DISPLAY and would skip
+   * here while being perfectly able to run the test. */
   NS_DURING
     {
       [NSApplication sharedApplication];
+      if (nil == GSCurrentServer())
+	{
+	  SKIP("no window server available")
+	}
     }
   NS_HANDLER
     {

--- a/Tests/gsc/gstatepath.m
+++ b/Tests/gsc/gstatepath.m
@@ -5,10 +5,9 @@
  * transform.
  *
  * GSGState lives in the backend bundle, so the test needs a backend loaded
- * (hence a window server); it opens the display named by the environment and
- * skips when there is none.  The code under test is the same for every backend;
- * it is built for the cairo backend, which is the one that loads on the test
- * display.
+ * (hence a window server); it skips when no display server can be reached.  The
+ * code under test is the same for every backend; it is built for the cairo
+ * backend.
  */
 #import <Foundation/Foundation.h>
 #import "Testing.h"
@@ -18,6 +17,7 @@
   && BUILD_GRAPHICS == GRAPHICS_cairo
 
 #import <AppKit/AppKit.h>
+#import <GNUstepGUI/GSDisplayServer.h>
 #include <stdlib.h>
 
 @interface NSObject (GSGStatePath)
@@ -68,14 +68,16 @@ main(int argc, const char **argv)
   START_SET("GSGState path")
   id ctxt, gs;
 
-  if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
-    {
-      SKIP("no window server available")
-    }
-
+  /* Ask whether a display server can be reached rather than whether X11's
+   * DISPLAY is set: a backend that is not X11 has no DISPLAY and would skip
+   * here while being perfectly able to run the test. */
   NS_DURING
     {
       [NSApplication sharedApplication];
+      if (nil == GSCurrentServer())
+	{
+	  SKIP("no window server available")
+	}
     }
   NS_HANDLER
     {

--- a/Tests/gsc/gstatepath.m
+++ b/Tests/gsc/gstatepath.m
@@ -68,9 +68,6 @@ main(int argc, const char **argv)
   START_SET("GSGState path")
   id ctxt, gs;
 
-  /* Ask whether a display server can be reached rather than whether X11's
-   * DISPLAY is set: a backend that is not X11 has no DISPLAY and would skip
-   * here while being perfectly able to run the test. */
   NS_DURING
     {
       [NSApplication sharedApplication];

--- a/Tests/gsc/psescape.m
+++ b/Tests/gsc/psescape.m
@@ -6,10 +6,9 @@
  * unterminated.
  *
  * GSStreamContext lives in the backend bundle, so the test needs a backend
- * loaded (hence a window server); it opens the display named by the
- * environment and skips when there is none.  The code under test is the same
- * for every backend; it is built for the cairo backend, which is the one that
- * loads on the test display.
+ * loaded (hence a window server); it skips when no display server can be
+ * reached.  The code under test is the same for every backend; it is built for
+ * the cairo backend.
  */
 #import <Foundation/Foundation.h>
 #import "Testing.h"
@@ -19,6 +18,7 @@
   && BUILD_GRAPHICS == GRAPHICS_cairo
 
 #import <AppKit/AppKit.h>
+#import <GNUstepGUI/GSDisplayServer.h>
 #include <stdlib.h>
 
 @interface NSObject (GSStreamContextShow)
@@ -50,14 +50,16 @@ main(int argc, const char **argv)
   START_SET("PostScript escaping")
   Class cls;
 
-  if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
-    {
-      SKIP("no window server available")
-    }
-
+  /* Ask whether a display server can be reached rather than whether X11's
+   * DISPLAY is set: a backend that is not X11 has no DISPLAY and would skip
+   * here while being perfectly able to run the test. */
   NS_DURING
     {
       [NSApplication sharedApplication];
+      if (nil == GSCurrentServer())
+	{
+	  SKIP("no window server available")
+	}
     }
   NS_HANDLER
     {

--- a/Tests/gsc/psescape.m
+++ b/Tests/gsc/psescape.m
@@ -50,9 +50,6 @@ main(int argc, const char **argv)
   START_SET("PostScript escaping")
   Class cls;
 
-  /* Ask whether a display server can be reached rather than whether X11's
-   * DISPLAY is set: a backend that is not X11 has no DISPLAY and would skip
-   * here while being perfectly able to run the test. */
   NS_DURING
     {
       [NSApplication sharedApplication];

--- a/Tests/gsc/streambezier.m
+++ b/Tests/gsc/streambezier.m
@@ -47,9 +47,6 @@ main(int argc, const char **argv)
   NSBezierPath *bp;
   NSArray *lines;
 
-  /* Ask whether a display server can be reached rather than whether X11's
-   * DISPLAY is set: a backend that is not X11 has no DISPLAY and would skip
-   * here while being perfectly able to run the test. */
   NS_DURING
     {
       [NSApplication sharedApplication];

--- a/Tests/gsc/streambezier.m
+++ b/Tests/gsc/streambezier.m
@@ -2,10 +2,9 @@
  * the path line attributes, and then the path elements in order.
  *
  * GSStreamContext lives in the backend bundle, so the test needs a backend
- * loaded (hence a window server); it opens the display named by the
- * environment and skips when there is none.  The code under test is the same
- * for every backend; it is built for the cairo backend, which is the one that
- * loads on the test display.
+ * loaded (hence a window server); it skips when no display server can be
+ * reached.  The code under test is the same for every backend; it is built for
+ * the cairo backend.
  */
 #import <Foundation/Foundation.h>
 #import "Testing.h"
@@ -15,6 +14,7 @@
   && BUILD_GRAPHICS == GRAPHICS_cairo
 
 #import <AppKit/AppKit.h>
+#import <GNUstepGUI/GSDisplayServer.h>
 #include <stdlib.h>
 
 @interface NSObject (GSStreamContextBezier)
@@ -47,14 +47,16 @@ main(int argc, const char **argv)
   NSBezierPath *bp;
   NSArray *lines;
 
-  if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
-    {
-      SKIP("no window server available")
-    }
-
+  /* Ask whether a display server can be reached rather than whether X11's
+   * DISPLAY is set: a backend that is not X11 has no DISPLAY and would skip
+   * here while being perfectly able to run the test. */
   NS_DURING
     {
       [NSApplication sharedApplication];
+      if (nil == GSCurrentServer())
+	{
+	  SKIP("no window server available")
+	}
     }
   NS_HANDLER
     {

--- a/Tests/gsc/streamimage.m
+++ b/Tests/gsc/streamimage.m
@@ -45,9 +45,6 @@ main(int argc, const char **argv)
   unsigned char *d;
   int i;
 
-  /* Ask whether a display server can be reached rather than whether X11's
-   * DISPLAY is set: a backend that is not X11 has no DISPLAY and would skip
-   * here while being perfectly able to run the test. */
   NS_DURING
     {
       [NSApplication sharedApplication];

--- a/Tests/gsc/streamimage.m
+++ b/Tests/gsc/streamimage.m
@@ -3,10 +3,9 @@
  * data, and the operators that follow on their own lines.
  *
  * GSStreamContext lives in the backend bundle, so the test needs a backend
- * loaded (hence a window server); it opens the display named by the
- * environment and skips when there is none.  The code under test is the same
- * for every backend; it is built for the cairo backend, which is the one that
- * loads on the test display.
+ * loaded (hence a window server); it skips when no display server can be
+ * reached.  The code under test is the same for every backend; it is built for
+ * the cairo backend.
  */
 #import <Foundation/Foundation.h>
 #import "Testing.h"
@@ -16,6 +15,7 @@
   && BUILD_GRAPHICS == GRAPHICS_cairo
 
 #import <AppKit/AppKit.h>
+#import <GNUstepGUI/GSDisplayServer.h>
 #include <stdlib.h>
 
 @interface NSObject (GSStreamContextImage)
@@ -45,14 +45,16 @@ main(int argc, const char **argv)
   unsigned char *d;
   int i;
 
-  if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
-    {
-      SKIP("no window server available")
-    }
-
+  /* Ask whether a display server can be reached rather than whether X11's
+   * DISPLAY is set: a backend that is not X11 has no DISPLAY and would skip
+   * here while being perfectly able to run the test. */
   NS_DURING
     {
       [NSApplication sharedApplication];
+      if (nil == GSCurrentServer())
+	{
+	  SKIP("no window server available")
+	}
     }
   NS_HANDLER
     {

--- a/Tests/gsc/streamops.m
+++ b/Tests/gsc/streamops.m
@@ -5,10 +5,9 @@
  * emitted lines.
  *
  * GSStreamContext lives in the backend bundle, so the test needs a backend
- * loaded (hence a window server); it opens the display named by the
- * environment and skips when there is none.  The code under test is the same
- * for every backend; it is built for the cairo backend, which is the one that
- * loads on the test display.
+ * loaded (hence a window server); it skips when no display server can be
+ * reached.  The code under test is the same for every backend; it is built for
+ * the cairo backend.
  */
 #import <Foundation/Foundation.h>
 #import "Testing.h"
@@ -18,6 +17,7 @@
   && BUILD_GRAPHICS == GRAPHICS_cairo
 
 #import <AppKit/AppKit.h>
+#import <GNUstepGUI/GSDisplayServer.h>
 #include <stdlib.h>
 
 @interface NSObject (GSStreamContextOps)
@@ -105,14 +105,16 @@ main(int argc, const char **argv)
   CGFloat m[6] = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
   NSAffineTransform *ctm = [NSAffineTransform transform];
 
-  if (getenv("DISPLAY") == NULL || *getenv("DISPLAY") == '\0')
-    {
-      SKIP("no window server available")
-    }
-
+  /* Ask whether a display server can be reached rather than whether X11's
+   * DISPLAY is set: a backend that is not X11 has no DISPLAY and would skip
+   * here while being perfectly able to run the test. */
   NS_DURING
     {
       [NSApplication sharedApplication];
+      if (nil == GSCurrentServer())
+	{
+	  SKIP("no window server available")
+	}
     }
   NS_HANDLER
     {

--- a/Tests/gsc/streamops.m
+++ b/Tests/gsc/streamops.m
@@ -105,9 +105,6 @@ main(int argc, const char **argv)
   CGFloat m[6] = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
   NSAffineTransform *ctm = [NSAffineTransform transform];
 
-  /* Ask whether a display server can be reached rather than whether X11's
-   * DISPLAY is set: a backend that is not X11 has no DISPLAY and would skip
-   * here while being perfectly able to run the test. */
   NS_DURING
     {
       [NSApplication sharedApplication];


### PR DESCRIPTION
14 tests in Tests/cairo and Tests/gsc skip when the DISPLAY environment
variable is unset. None of them is an X11 test: 6 exercise the cairo graphics
backend and 8 the shared gsc code. A backend that is not X11 has no DISPLAY,
so on such a backend the set skips, reports success and asserts nothing.

They now ask whether a display server can be reached, which is what
Tests/server/servercontract.m already does. GSCurrentServer() is declared in
GSDisplayServer.h, so that header is imported where it was not there already.
The file comments that described the DISPLAY check are updated. Nothing
outside Tests changes.

Run gnustep-tests Tests/cairo Tests/gsc on a cairo build, once with a display
and once without.

Under X11 the counts are the same as before, with a display and without one.
On a backend that has no DISPLAY all 14 go from skipping to running, and 94
assertions pass with none failing.
