### PR TITLE
Add an android display server drawing through cairo

### DIFF
--- a/Documentation/install.texi
+++ b/Documentation/install.texi
@@ -63,6 +63,43 @@ Before running an application, choose one backend using the defaults program:
 defaults write NSGlobalDomain GSBackend libgnustep-xlib
 @end example
 
+@subsection Android
+
+The android server draws through cairo and is chosen with
+
+@example
+configure --enable-server=android --enable-graphics=cairo
+@end example
+
+An application is run from a package, and a package carries an executable
+file only as @file{lib/<abi>/lib<name>.so}, so a tool is installed under
+that name and is found there rather than in the tool directories a
+filesystem layout gives.
+
+The activity a package declares must name the configuration changes it
+handles:
+
+@example
+<activity android:name="android.app.NativeActivity"
+          android:configChanges="orientation|screenSize|screenLayout|
+                                 smallestScreenSize|keyboardHidden|
+                                 density|uiMode">
+@end example
+
+Without that, Android destroys and recreates the activity on a rotation.
+The application is ended and started again from the beginning, losing
+everything it held, and no error is reported: the exit is a clean one.
+With it the activity is kept and the surface arrives again, which the
+server takes as a change of screen.
+
+A process that has no activity, such as a test, cannot ask Android how
+large the screen is.  It reports the size given by the
+@code{GSAndroidScreenSize} default instead:
+
+@example
+defaults write NSGlobalDomain GSAndroidScreenSize 1080x2340
+@end example
+
 @node Compilation, Installing, Configuration, Top
 @section Compilation
 

--- a/Headers/android/AndroidServer.h
+++ b/Headers/android/AndroidServer.h
@@ -1,0 +1,133 @@
+/*
+   AndroidServer.h
+
+   Copyright (C) 2026 Free Software Foundation, Inc.
+
+   Author: Todd White <todd.white@thalion.global>
+   Date: August 2026
+
+   This file is part of the GNU Objective C Backend Library.
+
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2 of the License, or (at your option) any later version.
+
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; see the file COPYING.LIB.
+   If not, see <http://www.gnu.org/licenses/> or write to the
+   Free Software Foundation, 51 Franklin Street, Fifth Floor,
+   Boston, MA 02110-1301, USA.
+*/
+
+#ifndef AndroidServer_h
+#define AndroidServer_h
+
+#include "config.h"
+
+#include <Foundation/NSGeometry.h>
+#include <Foundation/NSMapTable.h>
+#include <GNUstepGUI/GSDisplayServer.h>
+
+#include <android/input.h>
+#include <android/native_activity.h>
+#include <android/native_window.h>
+#include <jni.h>
+
+@class CairoSurface;
+
+/* One window as the server sees it.
+ *
+ * Everything above the server addresses a window by an integer id; this is
+ * what the id names, and a pointer to it is what the cairo surface is handed
+ * as its device, the same arrangement the wayland server uses with its own
+ * window struct.  Coordinates are OpenStep: origin at the bottom left of the
+ * screen, y increasing upwards.
+ */
+struct AndroidWindow
+{
+  int                 window_id;
+  NSRect              frame;
+  NSBackingStoreType  backing;
+  unsigned int        style;
+  int                 level;
+  int                 screen;
+  BOOL                mapped;
+  unsigned            ordered;   /* when it was last ordered in            */
+  CairoSurface       *surface;   /* nil until -setWindowdevice:forContext: */
+  ANativeWindow      *native;    /* NULL while the window is offscreen      */
+};
+
+@interface AndroidServer : GSDisplayServer
+{
+  NSMapTable *_windows;          /* window id -> struct AndroidWindow *      */
+  int         _lastWindowId;
+  NSRect      _screenBounds;
+  BOOL        _screenBoundsKnown;
+  BOOL        _screenWarningIssued;
+  NSPoint     _mouseLocation;
+  ANativeWindow *_activityWindow; /* the surface an activity was handed      */
+  int         _boundWindow;       /* the window it is bound to, 0 for none   */
+  unsigned    _orderSeq;          /* counts orderings, to find the front one */
+  int         _mouseButton;       /* the button a drag and an up belong to   */
+  int         _clickCount;        /* presses close together, AppKit's count  */
+  NSTimeInterval _lastClickTime;
+  NSPoint     _lastClickLocation;
+  NSTimeInterval _doubleTapTimeout;  /* 0 until the platform has been asked  */
+  JNIEnv     *_jniEnv;            /* for the platform's key character table  */
+  ANativeActivity *_activity;     /* for the input method, NULL without one  */
+  BOOL        _keyboardShown;     /* what the input method was last asked    */
+  NSRect      _announcedScreen;   /* the screen the gui library was told of  */
+  BOOL        _inScreenChange;    /* moving windows orders them, which is us */
+}
+
+/* How far apart two presses may be, in pixels, and still count as one click.
+ * The platform's own tolerance is ViewConfiguration -getScaledDoubleTapSlop,
+ * which is scaled by the screen density and reached through a ViewConfiguration
+ * made from a Context; the server is given a JNIEnv and no Context, so this
+ * stands in for it.
+ */
+#define	GS_ANDROID_CLICK_SLOP	16
+
++ (void) initializeBackend;
+
+/* The record for a window id, or NULL when the id is not one of ours. */
+- (struct AndroidWindow *) _windowWithId: (int)win;
+
+/* Bind the window an activity was given to one of ours, so that drawing
+ * reaches the screen instead of stopping at the image surface.  Passing NULL
+ * unbinds, which is what the activity losing its window means. */
+- (void) setNativeWindow: (ANativeWindow *)native forWindow: (int)win;
+- (ANativeWindow *) nativeWindowForWindow: (int)win;
+
+/* The surface an activity owns.  An application creates its windows when it
+ * pleases and nothing outside knows their numbers, so the server binds this to
+ * the first window ordered front that a person would call the application's,
+ * and rebinds when that window goes away.  Passing NULL unbinds. */
+- (void) setActivityWindow: (ANativeWindow *)native;
+- (ANativeWindow *) activityWindow;
+
+/* The window the activity's surface is currently bound to, or 0. */
+- (int) windowBoundToActivity;
+
+/* The environment the key character table is read through.  The NDK reports a
+ * key by code and meta state and offers no character for it. */
+- (void) setJavaEnvironment: (JNIEnv *)env;
+
+/* Translate one event from the activity's input queue and post it.  Answers
+ * YES when the event became an NSEvent. */
+- (BOOL) handleInputEvent: (const AInputEvent *)event;
+
+/* The activity the input method is shown and hidden through.  A device with no
+ * keyboard of its own has one on the screen, and it is shown only while
+ * something is being edited.  Passing NULL leaves the keyboard alone. */
+- (void) setActivity: (ANativeActivity *)activity;
+
+@end
+
+#endif /* AndroidServer_h */

--- a/Headers/cairo/AndroidCairoSurface.h
+++ b/Headers/cairo/AndroidCairoSurface.h
@@ -1,0 +1,63 @@
+/*
+   AndroidCairoSurface.h
+
+   Copyright (C) 2026 Free Software Foundation, Inc.
+
+   Author: Todd White <todd.white@thalion.global>
+   Date: August 2026
+
+   This file is part of GNUstep.
+
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2 of the License, or (at your option) any later version.
+
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; see the file COPYING.LIB.
+   If not, see <http://www.gnu.org/licenses/> or write to the
+   Free Software Foundation, 51 Franklin Street, Fifth Floor,
+   Boston, MA 02110-1301, USA.
+*/
+
+#ifndef AndroidCairoSurface_h
+#define AndroidCairoSurface_h
+
+#include "cairo/CairoSurface.h"
+
+#include <android/native_window.h>
+
+@interface AndroidCairoSurface : CairoSurface
+{
+  /* The window this surface posts to, or NULL while it is offscreen.  It is
+   * not retained: the server owns it and outlives the surface. */
+  ANativeWindow *_window;
+}
+
+- (void) setNativeWindow: (ANativeWindow *)window;
+- (ANativeWindow *) nativeWindow;
+
+@end
+
+/* Write one window's pixels into a buffer that is already locked, over the
+ * given region of it, leaving alone every pixel the window does not cover.
+ *
+ * An activity has one surface and an application has as many windows as it
+ * likes, so each window is written into that one buffer in turn, back to
+ * front.  The caller locks the buffer, clears the region and calls this once
+ * per window, so a window below cannot write over the one above it.
+ *
+ * frame is in screen coordinates, y up from the bottom; the buffer's rows count
+ * down from the top, which is what screenHeight turns one into the other.  The
+ * region is in the buffer's own coordinates.
+ */
+extern void
+GSAndroidBlitWindow(ANativeWindow_Buffer *buffer, cairo_surface_t *surface,
+  NSRect frame, int screenHeight, int x0, int y0, int x1, int y1);
+
+#endif /* AndroidCairoSurface_h */

--- a/Source/GSBackend.m
+++ b/Source/GSBackend.m
@@ -50,6 +50,11 @@
 @interface WaylandServer (Initialize)
 + (void) initializeBackend;
 @end
+#elif BUILD_SERVER == SERVER_android
+#include <android/AndroidServer.h>
+@interface AndroidServer (Initialize)
++ (void) initializeBackend;
+@end
 #elif BUILD_SERVER == SERVER_headless
 #include <headless/HeadlessServer.h>
 @interface HeadlessServer (Initialize)
@@ -75,6 +80,8 @@
   [WIN32Server initializeBackend];
 #elif BUILD_SERVER == SERVER_wayland
   [WaylandServer initializeBackend];
+#elif BUILD_SERVER == SERVER_android
+  [AndroidServer initializeBackend];
 #elif BUILD_SERVER == SERVER_headless
   [HeadlessServer initializeBackend];
 #else

--- a/Source/android/AndroidServer.m
+++ b/Source/android/AndroidServer.m
@@ -1,0 +1,1771 @@
+/*
+   AndroidServer.m
+
+   Copyright (C) 2026 Free Software Foundation, Inc.
+
+   Author: Todd White <todd.white@thalion.global>
+   Date: August 2026
+
+   This file is part of the GNU Objective C Backend Library.
+
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2 of the License, or (at your option) any later version.
+
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; see the file COPYING.LIB.
+   If not, see <http://www.gnu.org/licenses/> or write to the
+   Free Software Foundation, 51 Franklin Street, Fifth Floor,
+   Boston, MA 02110-1301, USA.
+*/
+
+#include "config.h"
+
+#include <signal.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <AppKit/NSApplication.h>
+#include <AppKit/NSScreen.h>
+#include <AppKit/NSEvent.h>
+#include <AppKit/NSGraphics.h>
+#include <AppKit/NSGraphicsContext.h>
+#include <AppKit/NSText.h>
+#include <AppKit/NSWindow.h>
+#include <AppKit/DPSOperators.h>
+#include <Foundation/NSArray.h>
+#include <Foundation/NSDebug.h>
+#include <Foundation/NSString.h>
+#include <Foundation/NSUserDefaults.h>
+#include <Foundation/NSValue.h>
+
+#include "android/AndroidServer.h"
+#include "cairo/CairoSurface.h"
+#include "cairo/AndroidCairoSurface.h"
+
+/* Terminate cleanly if we get a signal to do so. */
+static void
+terminate(int sig)
+{
+  if (nil != NSApp)
+    {
+      [NSApp terminate: NSApp];
+    }
+  else
+    {
+      exit(1);
+    }
+}
+
+/* Parse "320x640" into a size, or NSZeroSize. */
+static NSSize
+sizeFromString(NSString *s)
+{
+  NSArray *parts;
+
+  if (s == nil)
+    {
+      return NSZeroSize;
+    }
+  parts = [s componentsSeparatedByString: @"x"];
+  if ([parts count] != 2)
+    {
+      return NSZeroSize;
+    }
+  return NSMakeSize([[parts objectAtIndex: 0] doubleValue],
+		    [[parts objectAtIndex: 1] doubleValue]);
+}
+
+@implementation AndroidServer
+
++ (void) initializeBackend
+{
+  NSDebugLog(@"Initializing GNUstep android backend.");
+  [GSDisplayServer setDefaultServerClass: [AndroidServer class]];
+  signal(SIGTERM, terminate);
+  signal(SIGINT, terminate);
+}
+
+- (id) initWithAttributes: (NSDictionary *)info
+{
+  self = [super initWithAttributes: info];
+  if (self != nil)
+    {
+      _windows = NSCreateMapTable(NSIntegerMapKeyCallBacks,
+				  NSNonOwnedPointerMapValueCallBacks, 8);
+      _lastWindowId = 0;
+      _screenBounds = NSZeroRect;
+      _screenBoundsKnown = NO;
+      _screenWarningIssued = NO;
+      _mouseLocation = NSZeroPoint;
+    }
+  return self;
+}
+
+- (void) dealloc
+{
+  if (_windows != NULL)
+    {
+      NSFreeMapTable(_windows);
+      _windows = NULL;
+    }
+  [super dealloc];
+}
+
+- (struct AndroidWindow *) _windowWithId: (int)win
+{
+  if (_windows == NULL || win <= 0)
+    {
+      return NULL;
+    }
+  return (struct AndroidWindow *) NSMapGet(_windows, (void *)(intptr_t)win);
+}
+
+/* The server draws no title bar, resize corner or border, so the gui library
+ * has to draw them.  GSDisplayServer answers YES by default. */
+- (BOOL) handlesWindowDecorations
+{
+  return NO;
+}
+
+/*
+ * Screens
+ */
+
+- (NSArray *) screenList
+{
+  return [NSArray arrayWithObject: [NSNumber numberWithInt: 0]];
+}
+
+/* The screen size comes from the GSAndroidScreenSize default, because a process
+ * with no Activity cannot ask Android for it: AConfiguration_getScreenWidthDp
+ * needs an AConfiguration, whose only source other than AConfiguration_new is
+ * AConfiguration_fromAssetManager, and the only documented way to obtain an
+ * AAssetManager is AAssetManager_fromJava, which needs a JNIEnv and a Java
+ * AssetManager.  ANativeWindow_getWidth has the same problem: the only
+ * documented producer of an ANativeWindow is ANativeWindow_fromSurface, which
+ * needs a Java Surface.
+ *
+ * When the default is not set this logs once and reports an empty screen.
+ */
+- (NSRect) boundsForScreen: (int)screen
+{
+  NSSize size;
+
+  if (screen != 0)
+    {
+      return NSZeroRect;
+    }
+  if (_screenBoundsKnown)
+    {
+      return _screenBounds;
+    }
+  /* The activity knows the real size, so the default below is the answer only
+   * for a process that has no activity at all -- which is every test but the
+   * ones that make a window of their own, and no application. */
+  if (_activityWindow != NULL)
+    {
+      int left, top, right, bottom;
+      int width = ANativeWindow_getWidth(_activityWindow);
+      int height = ANativeWindow_getHeight(_activityWindow);
+
+      /* The screen a window may use is the surface less what the system bars
+       * take, as the x11 server reports the work area rather than the whole
+       * display.  A window laid out under a bar cannot be seen and cannot be
+       * pressed, because the bar takes the press. */
+      [self _systemBarInsets: &left : &top : &right : &bottom];
+      _screenBounds = NSMakeRect(left, bottom,
+	width - left - right, height - top - bottom);
+      if (NSWidth(_screenBounds) <= 0.0 || NSHeight(_screenBounds) <= 0.0)
+	{
+	  _screenBounds = NSMakeRect(0, 0, width, height);
+	}
+      NSDebugLLog(@"NSEvent", @"android screen: surface %dx%d insets"
+	@" %d,%d,%d,%d giving %@", width, height, left, top, right, bottom,
+	NSStringFromRect(_screenBounds));
+      /* The bars are not settled when the first window is made: the insets
+       * arrive after the view has been laid out, so the answer is worked out
+       * again each time rather than kept. */
+      return _screenBounds;
+    }
+
+  size = sizeFromString([[NSUserDefaults standardUserDefaults]
+			  stringForKey: @"GSAndroidScreenSize"]);
+  if (NSEqualSizes(size, NSZeroSize))
+    {
+      if (NO == _screenWarningIssued)
+	{
+	  NSLog(@"AndroidServer: no screen size available. Set the "
+		@"GSAndroidScreenSize default (for example 320x640); the "
+		@"screen is reported as empty until then.");
+	  _screenWarningIssued = YES;
+	}
+      return NSZeroRect;
+    }
+
+  _screenBounds = NSMakeRect(0, 0, size.width, size.height);
+  _screenBoundsKnown = YES;
+  return _screenBounds;
+}
+
+/* What the status bar, the navigation bar and a display cutout take from the
+ * surface, in pixels.
+ *
+ * An activity is given the whole surface and the system draws its bars over
+ * it, so anything drawn underneath one cannot be seen and a press on it never
+ * arrives: the bar takes it.  The area left is what the platform calls the
+ * system bar insets, and it is what a window may use.
+ *
+ * The NDK reports none of this, so the view the activity is given is asked
+ * through JNI.  Everything answers zero without a JNI context or an activity,
+ * which is what a test binary has.
+ */
+- (BOOL) _systemBarInsets: (int *)left : (int *)top : (int *)right
+			 : (int *)bottom
+{
+  JNIEnv	*env = _jniEnv;
+  jobject	 decor = NULL;
+  jobject	 insets = NULL;
+  jobject	 bars = NULL;
+  jclass	 cls;
+  BOOL		 ok = NO;
+
+  *left = *top = *right = *bottom = 0;
+  if (env == NULL || _activity == NULL || _activity->clazz == NULL)
+    {
+      return NO;
+    }
+
+  cls = (*env)->GetObjectClass(env, _activity->clazz);
+  {
+    jmethodID	getWindow = (*env)->GetMethodID(env, cls,
+      "getWindow", "()Landroid/view/Window;");
+    jobject	window = (getWindow != NULL)
+      ? (*env)->CallObjectMethod(env, _activity->clazz, getWindow) : NULL;
+
+    if (window != NULL)
+      {
+	jclass	  wcls = (*env)->GetObjectClass(env, window);
+	jmethodID getDecor = (*env)->GetMethodID(env, wcls,
+	  "getDecorView", "()Landroid/view/View;");
+
+	if (getDecor != NULL)
+	  {
+	    decor = (*env)->CallObjectMethod(env, window, getDecor);
+	  }
+	(*env)->DeleteLocalRef(env, wcls);
+	(*env)->DeleteLocalRef(env, window);
+      }
+  }
+  (*env)->DeleteLocalRef(env, cls);
+
+  if (decor != NULL)
+    {
+      jclass	 vcls = (*env)->GetObjectClass(env, decor);
+      jmethodID	 getRoot = (*env)->GetMethodID(env, vcls,
+	"getRootWindowInsets", "()Landroid/view/WindowInsets;");
+
+      if (getRoot != NULL)
+	{
+	  insets = (*env)->CallObjectMethod(env, decor, getRoot);
+	}
+      (*env)->DeleteLocalRef(env, vcls);
+    }
+
+  if (insets != NULL)
+    {
+      jclass	types = (*env)->FindClass(env, "android/view/WindowInsets$Type");
+      jint	mask = 0;
+
+      if (types != NULL)
+	{
+	  jmethodID systemBars = (*env)->GetStaticMethodID(env, types,
+	    "systemBars", "()I");
+	  jmethodID ime = (*env)->GetStaticMethodID(env, types, "ime", "()I");
+
+	  if (systemBars != NULL)
+	    {
+	      mask = (*env)->CallStaticIntMethod(env, types, systemBars);
+	    }
+	  /* The input method covers the foot of the surface while it is up, and
+	   * a window laid out under it cannot be seen. */
+	  if (ime != NULL)
+	    {
+	      mask |= (*env)->CallStaticIntMethod(env, types, ime);
+	    }
+	  (*env)->DeleteLocalRef(env, types);
+	}
+
+      if (mask != 0)
+	{
+	  jclass     icls = (*env)->GetObjectClass(env, insets);
+	  jmethodID  get = (*env)->GetMethodID(env, icls,
+	    "getInsets", "(I)Landroid/graphics/Insets;");
+
+	  if (get != NULL)
+	    {
+	      bars = (*env)->CallObjectMethod(env, insets, get, mask);
+	    }
+	  (*env)->DeleteLocalRef(env, icls);
+	}
+    }
+
+  if (bars != NULL)
+    {
+      jclass bcls = (*env)->GetObjectClass(env, bars);
+
+      *left = (*env)->GetIntField(env, bars,
+	(*env)->GetFieldID(env, bcls, "left", "I"));
+      *top = (*env)->GetIntField(env, bars,
+	(*env)->GetFieldID(env, bcls, "top", "I"));
+      *right = (*env)->GetIntField(env, bars,
+	(*env)->GetFieldID(env, bcls, "right", "I"));
+      *bottom = (*env)->GetIntField(env, bars,
+	(*env)->GetFieldID(env, bcls, "bottom", "I"));
+      ok = YES;
+      (*env)->DeleteLocalRef(env, bcls);
+      (*env)->DeleteLocalRef(env, bars);
+    }
+
+  if (insets != NULL) (*env)->DeleteLocalRef(env, insets);
+  if (decor != NULL)  (*env)->DeleteLocalRef(env, decor);
+  (*env)->ExceptionClear(env);
+
+  return ok;
+}
+
+/* Tell the gui library when the screen a window may use has changed.
+ *
+ * The bars are not settled when the first window is made, so the screen the
+ * application laid itself out to is not the screen it ends up with; a rotation
+ * changes it again.  A window that has already been placed is not moved by
+ * anything else, so it keeps a position worked out for a screen that is gone.
+ *
+ * This is what the x11 server does when RandR reports the screen changed: the
+ * cached screens are dropped and the notification is posted, and NSWindow
+ * moves itself onto the new frame.
+ */
+- (void) _noticeScreenChange
+{
+  NSRect now;
+
+  if (_activityWindow == NULL || _inScreenChange == YES)
+    {
+      return;
+    }
+  now = [self boundsForScreen: 0];
+  if (NSEqualRects(now, _announcedScreen))
+    {
+      return;
+    }
+
+  /* Moving the windows orders them, which arrives back here. */
+  _inScreenChange = YES;
+  _announcedScreen = now;
+  NSDebugLLog(@"NSEvent", @"android screen changed to %@",
+    NSStringFromRect(now));
+  [NSScreen resetScreens];
+  [[NSNotificationCenter defaultCenter]
+    postNotificationName: NSApplicationDidChangeScreenParametersNotification
+		  object: NSApp];
+
+  /* A window is only moved by that notice, never resized, so a screen that has
+   * shrunk at the foot moves nothing: the origin rises by what the height
+   * falls.  The window that has the screen is given the new one. */
+  {
+    struct AndroidWindow *window = [self _windowWithId: _boundWindow];
+
+    if (window != NULL && NSWidth(now) > 0.0 && NSHeight(now) > 0.0
+      && !NSEqualRects(window->frame, now))
+      {
+	[self placewindow: now : _boundWindow];
+      }
+  }
+  _inScreenChange = NO;
+}
+
+/* The image surface is 32 bits per pixel with 8 bits per component in three
+ * components, which is what NSBestDepth is asked for here. */
+- (NSWindowDepth) windowDepthForScreen: (int)screen
+{
+  if (screen != 0)
+    {
+      return 0;
+    }
+  return NSBestDepth(NSCalibratedRGBColorSpace, 8, 24, NO, NULL);
+}
+
+/* The caller owns the returned list and frees it with NSZoneFree, which is what
+ * the x11 server does, so this must be allocated and not static: freeing a
+ * static array aborts the process with "Scudo ERROR: misaligned pointer when
+ * deallocating" on Android. */
+- (const NSWindowDepth *) availableDepthsForScreen: (int)screen
+{
+  NSWindowDepth *depths;
+
+  if (screen != 0)
+    {
+      return NULL;
+    }
+  depths = NSZoneMalloc(NSDefaultMallocZone(), sizeof(NSWindowDepth) * 2);
+  depths[0] = NSBestDepth(NSCalibratedRGBColorSpace, 8, 24, NO, NULL);
+  depths[1] = 0;   /* zero-terminated */
+  return depths;
+}
+
+/* The gui library scales the whole interface by this value, so the device's real
+ * density would rescale every window.  The x11 server also reports 72. */
+- (NSSize) resolutionForScreen: (int)screen
+{
+  return NSMakeSize(72, 72);
+}
+
+- (NSImage *) contentsOfScreen: (int)screen inRect: (NSRect)rect
+{
+  return nil;
+}
+
+/*
+ * Windows
+ */
+
+- (int) window: (NSRect)frame
+	      : (NSBackingStoreType)type
+	      : (unsigned int)style
+	      : (int)screen
+{
+  struct AndroidWindow *window;
+
+  /* A window always has an extent.  X refuses a zero-area window and clamps,
+   * and the rest of the gui library assumes a window it created can be drawn
+   * into; a 0x0 frame would also leave the cairo surface unmade. */
+  if (frame.size.width < 1.0)
+    {
+      frame.size.width = 1.0;
+    }
+  if (frame.size.height < 1.0)
+    {
+      frame.size.height = 1.0;
+    }
+
+  window = (struct AndroidWindow *)
+    NSZoneCalloc(NSDefaultMallocZone(), 1, sizeof(struct AndroidWindow));
+  window->window_id = ++_lastWindowId;
+  window->frame = frame;
+  window->backing = type;
+  window->style = style;
+  window->screen = screen;
+  window->level = NSNormalWindowLevel;
+  window->mapped = NO;
+  window->surface = nil;
+
+  NSMapInsert(_windows, (void *)(intptr_t)window->window_id, window);
+  [self _setWindowOwnedByServer: window->window_id];
+  return window->window_id;
+}
+
+- (void) termwindow: (int)win
+{
+  struct AndroidWindow *window = [self _windowWithId: win];
+
+  if (window == NULL)
+    {
+      return;
+    }
+  window->surface = nil;
+  NSMapRemove(_windows, (void *)(intptr_t)win);
+  NSZoneFree(NSDefaultMallocZone(), window);
+}
+
+- (void *) windowDevice: (int)win
+{
+  return (void *)[self _windowWithId: win];
+}
+
+- (void *) serverDevice
+{
+  return NULL;
+}
+
+- (NSRect) windowbounds: (int)win
+{
+  struct AndroidWindow *window = [self _windowWithId: win];
+
+  return (window == NULL) ? NSZeroRect : window->frame;
+}
+
+/* A move or a resize sends the window an AppKit-defined event, as the x11 server
+ * does.  There is no server round trip, so the new frame is final and the event
+ * is sent immediately. */
+- (void) placewindow: (NSRect)frame : (int)win
+{
+  struct AndroidWindow *window = [self _windowWithId: win];
+  NSWindow		*nswin;
+  NSEvent		*e;
+  BOOL			 resized, moved;
+
+  if (window == NULL)
+    {
+      NSLog(@"AndroidServer: placing invalid window %d", win);
+      return;
+    }
+  if (NSEqualRects(frame, window->frame))
+    {
+      return;
+    }
+
+  resized = !NSEqualSizes(frame.size, window->frame.size);
+  moved = !NSEqualPoints(frame.origin, window->frame.origin);
+  window->frame = frame;
+
+  if (window->surface != nil && resized)
+    {
+      [window->surface setSize: frame.size];
+    }
+
+  nswin = GSWindowWithNumber(win);
+  if (resized)
+    {
+      e = [NSEvent otherEventWithType: NSAppKitDefined
+			     location: frame.origin
+			modifierFlags: 0
+			    timestamp: 0
+			 windowNumber: win
+			      context: GSCurrentContext()
+			      subtype: GSAppKitWindowResized
+				data1: frame.size.width
+				data2: frame.size.height];
+      [nswin sendEvent: e];
+    }
+  else if (moved)
+    {
+      e = [NSEvent otherEventWithType: NSAppKitDefined
+			     location: NSZeroPoint
+			modifierFlags: 0
+			    timestamp: 0
+			 windowNumber: win
+			      context: GSCurrentContext()
+			      subtype: GSAppKitWindowMoved
+				data1: frame.origin.x
+				data2: frame.origin.y];
+      [nswin sendEvent: e];
+    }
+}
+
+- (void) movewindow: (NSPoint)loc : (int)win
+{
+  struct AndroidWindow *window = [self _windowWithId: win];
+
+  if (window == NULL)
+    {
+      return;
+    }
+  window->frame.origin = loc;
+}
+
+- (void) orderwindow: (int)op : (int)otherWin : (int)win
+{
+  struct AndroidWindow *window = [self _windowWithId: win];
+
+  if (window == NULL)
+    {
+      return;
+    }
+  window->mapped = (op != NSWindowOut);
+  if (window->mapped == YES)
+    {
+      window->ordered = ++_orderSeq;
+      [self _noticeScreenChange];
+    }
+
+  /* An activity is given one surface and an application makes as many windows
+   * as it likes, so the surface goes to the one being shown.  A menu and an
+   * application icon are windows too and carry no title bar, which is what
+   * separates them from the window a person means by the application's. */
+  if (_activityWindow != NULL)
+    {
+      if (win != _boundWindow && [self _isCandidate: window] == YES)
+	{
+	  [self _bindActivityTo: window];
+	}
+      else if (window->mapped == NO && win == _boundWindow)
+	{
+	  struct AndroidWindow	*next = [self _frontmostCandidate];
+
+	  [self setNativeWindow: NULL forWindow: win];
+	  _boundWindow = 0;
+	  /* A panel takes the surface from the window under it, so taking the
+	   * panel off has to give it back: an activity holding a surface
+	   * nothing draws into shows whatever was on it when the panel went. */
+	  if (next != NULL)
+	    {
+	      [self _bindActivityTo: next];
+	    }
+	}
+    }
+}
+
+/* Back to front: the lowest level first, and within a level the one ordered in
+ * longest ago.  This is the order the windows are written in. */
+static int
+compare_windows(const void *a, const void *b)
+{
+  struct AndroidWindow *l = *(struct AndroidWindow **)a;
+  struct AndroidWindow *r = *(struct AndroidWindow **)b;
+
+  if (l->level != r->level)
+    {
+      return (l->level < r->level) ? -1 : 1;
+    }
+  if (l->ordered != r->ordered)
+    {
+      return (l->ordered < r->ordered) ? -1 : 1;
+    }
+  return 0;
+}
+
+/* Write every window that is on screen into the activity's surface.
+ *
+ * An activity is given one surface, so a window cannot be given one of its
+ * own.  The region is locked once and each window on screen is written into it
+ * in turn, back to front, which is what puts a menu or a panel over the window
+ * it belongs to.  What no window covers is black.
+ *
+ * The rectangle is in screen coordinates, y up from the bottom.
+ */
+- (void) _compositeRect: (NSRect)rect
+{
+  ANativeWindow_Buffer	  buffer;
+  ARect			  dirty;
+  struct AndroidWindow	**order;
+  NSMapEnumerator	  e;
+  void			 *key, *value;
+  unsigned		  count = 0;
+  unsigned		  i;
+  int			  screenHeight;
+  int			  x, y, x0, y0, x1, y1;
+
+  if (_activityWindow == NULL)
+    {
+      return;
+    }
+  screenHeight = ANativeWindow_getHeight(_activityWindow);
+  if (screenHeight <= 0)
+    {
+      return;
+    }
+
+  /* The buffer counts its rows from the top, the screen from the bottom. */
+  dirty.left = (int32_t)floor(NSMinX(rect));
+  dirty.top = (int32_t)(screenHeight - ceil(NSMaxY(rect)));
+  dirty.right = (int32_t)ceil(NSMaxX(rect));
+  dirty.bottom = (int32_t)(screenHeight - floor(NSMinY(rect)));
+  if (dirty.right <= dirty.left || dirty.bottom <= dirty.top)
+    {
+      return;
+    }
+
+  if (ANativeWindow_lock(_activityWindow, &buffer, &dirty) != 0)
+    {
+      NSDebugLLog(@"AndroidCairoSurface",
+	@"the activity's window would not lock");
+      return;
+    }
+
+  /* The window widens the region to what this buffer has to have written,
+   * which is more than what changed: it hands out one of several buffers in
+   * turn, so the one locked here holds a frame from some time ago. */
+  x0 = dirty.left;
+  y0 = dirty.top;
+  x1 = dirty.right;
+  y1 = dirty.bottom;
+  if (x0 < 0) x0 = 0;
+  if (y0 < 0) y0 = 0;
+  if (x1 > buffer.width) x1 = buffer.width;
+  if (y1 > buffer.height) y1 = buffer.height;
+
+  NSDebugLLog(@"AndroidCairoSurface",
+    @"composite: buffer %dx%d stride %d bits %p region %d,%d %d,%d",
+    buffer.width, buffer.height, buffer.stride, buffer.bits,
+    x0, y0, x1, y1);
+
+  if (buffer.bits == NULL || buffer.stride < buffer.width)
+    {
+      ANativeWindow_unlockAndPost(_activityWindow);
+      return;
+    }
+
+  for (y = y0; y < y1; y++)
+    {
+      uint32_t *d = (uint32_t *)((unsigned char *)buffer.bits
+	+ (size_t)y * buffer.stride * 4);
+
+      for (x = x0; x < x1; x++)
+	{
+	  d[x] = 0xff000000;
+	}
+    }
+
+  order = (struct AndroidWindow **)
+    NSZoneMalloc(NSDefaultMallocZone(),
+      sizeof(struct AndroidWindow *) * (NSCountMapTable(_windows) + 1));
+  e = NSEnumerateMapTable(_windows);
+  while (NSNextMapEnumeratorPair(&e, &key, &value))
+    {
+      struct AndroidWindow *w = (struct AndroidWindow *)value;
+
+      if (w != NULL && w->mapped == YES && w->surface != nil)
+	{
+	  order[count++] = w;
+	}
+    }
+  NSEndMapTableEnumeration(&e);
+  qsort(order, count, sizeof(struct AndroidWindow *), compare_windows);
+
+  for (i = 0; i < count; i++)
+    {
+      GSAndroidBlitWindow(&buffer, [order[i]->surface surface],
+	order[i]->frame, screenHeight, x0, y0, x1, y1);
+    }
+  NSZoneFree(NSDefaultMallocZone(), order);
+
+  ANativeWindow_unlockAndPost(_activityWindow);
+}
+
+/* The window a person would be looking at: the highest level among those on
+ * screen, and among those the one ordered in most recently. */
+- (struct AndroidWindow *) _frontmostCandidate
+{
+  NSMapEnumerator	 e = NSEnumerateMapTable(_windows);
+  struct AndroidWindow	*best = NULL;
+  struct AndroidWindow	*window;
+  void			*key;
+
+  while (NSNextMapEnumeratorPair(&e, &key, (void **)&window) == YES)
+    {
+      if ([self _isCandidate: window] == NO)
+	{
+	  continue;
+	}
+      if (best == NULL
+	|| window->level > best->level
+	|| (window->level == best->level && window->ordered > best->ordered))
+	{
+	  best = window;
+	}
+    }
+  NSEndMapTableEnumeration(&e);
+
+  return best;
+}
+
+- (void) setwindowlevel: (int)level : (int)win
+{
+  struct AndroidWindow *window = [self _windowWithId: win];
+
+  if (window != NULL)
+    {
+      window->level = level;
+    }
+}
+
+- (int) windowlevel: (int)win
+{
+  struct AndroidWindow *window = [self _windowWithId: win];
+
+  return (window == NULL) ? 0 : window->level;
+}
+
+- (int) windowdepth: (int)win
+{
+  return NSBestDepth(NSCalibratedRGBColorSpace, 8, 24, NO, NULL);
+}
+
+/* No decorations are drawn, so there are no insets.  -handlesWindowDecorations
+ * answers NO, so the gui library draws its own and knows not to expect any. */
+- (void) styleoffsets: (float *)l : (float *)r : (float *)t : (float *)b
+		     : (unsigned int)style
+{
+  *l = *r = *t = *b = 0.0;
+}
+
+- (void) stylewindow: (unsigned int)style : (int)win
+{
+  struct AndroidWindow *window = [self _windowWithId: win];
+
+  if (window != NULL)
+    {
+      window->style = style;
+    }
+}
+
+- (void) windowbacking: (NSBackingStoreType)type : (int)win
+{
+  struct AndroidWindow *window = [self _windowWithId: win];
+
+  if (window != NULL)
+    {
+      window->backing = type;
+    }
+}
+
+/* Give the context a surface for this window.  GSSetDevice hands the window
+ * record to the cairo context, which allocates the surface class the backend
+ * was built with; the y offset is the window height because cairo's y axis
+ * points down and AppKit's points up. */
+- (void) setWindowdevice: (int)win forContext: (NSGraphicsContext *)ctxt
+{
+  struct AndroidWindow *window = [self _windowWithId: win];
+
+  if (window == NULL)
+    {
+      NSLog(@"AndroidServer: setWindowdevice for unknown window %d", win);
+      return;
+    }
+
+  GSSetDevice(ctxt, window, 0.0, NSHeight(window->frame));
+  DPSinitmatrix(ctxt);
+  DPSinitclip(ctxt);
+}
+
+/* Without an activity there is nothing to post to: the image surface the
+ * context drew into is already the destination.  With one, the region that
+ * changed is composited, which writes every window that covers it and not just
+ * this one, because they share the activity's surface. */
+- (void) flushwindowrect: (NSRect)rect : (int)win
+{
+  struct AndroidWindow *window = [self _windowWithId: win];
+
+  if (window == NULL || window->surface == nil)
+    {
+      return;
+    }
+
+  if (_activityWindow == NULL)
+    {
+      [window->surface flush];
+      return;
+    }
+
+  /* The rect arrives in the window's own coordinates; the composite works in
+   * the screen's, and both count y up from the bottom. */
+  [self _compositeRect: NSOffsetRect(rect,
+    NSMinX(window->frame), NSMinY(window->frame))];
+}
+
+- (void) setNativeWindow: (ANativeWindow *)native forWindow: (int)win
+{
+  struct AndroidWindow *window = [self _windowWithId: win];
+
+  if (window == NULL)
+    {
+      return;
+    }
+
+  window->native = native;
+  if (window->surface != nil)
+    {
+      [(AndroidCairoSurface *)window->surface setNativeWindow: native];
+    }
+
+  /* The screen is whatever the window says it is once there is one, so the
+   * cached answer has to be given up. */
+  _screenBoundsKnown = NO;
+}
+
+- (ANativeWindow *) nativeWindowForWindow: (int)win
+{
+  struct AndroidWindow *window = [self _windowWithId: win];
+
+  return (window == NULL) ? NULL : window->native;
+}
+
+/* Give the surface to one window and ask for it to be drawn again: whatever is
+ * on that window was drawn before it had a surface, so none of it has reached
+ * the screen. */
+- (void) _bindActivityTo: (struct AndroidWindow *)window
+{
+  _boundWindow = window->window_id;
+
+  /* The platform gives an application the screen, so the window that has the
+   * surface is given the screen too: one smaller than it would sit in a corner
+   * with black around it and no way for a person to move it.  This is what a
+   * window manager does when it fullscreens a window, and -placewindow: is the
+   * road that reaches AppKit, resizes the surface and lets the application lay
+   * itself out again. */
+  {
+    NSRect screen = [self boundsForScreen: 0];
+
+    if (NSWidth(screen) > 0.0 && NSHeight(screen) > 0.0
+      && !NSEqualRects(window->frame, screen))
+      {
+	[self placewindow: screen : window->window_id];
+      }
+  }
+
+  [self postEvent: [NSEvent otherEventWithType: NSAppKitDefined
+				      location: NSZeroPoint
+				 modifierFlags: 0
+				     timestamp:
+    [[NSDate date] timeIntervalSinceReferenceDate]
+				  windowNumber: window->window_id
+				       context: GSCurrentContext()
+				       subtype: GSAppKitRegionExposed
+					 data1: (int)NSWidth(window->frame)
+					 data2: (int)NSHeight(window->frame)]
+	 atStart: NO];
+}
+
+/* A window a person would call the application's: on screen, and carrying a
+ * title bar, which a menu and an application icon do not. */
+- (BOOL) _isCandidate: (struct AndroidWindow *)window
+{
+  return (window != NULL && window->mapped == YES
+    && (window->style & NSTitledWindowMask) != 0) ? YES : NO;
+}
+
+- (void) setActivityWindow: (ANativeWindow *)native
+{
+  _activityWindow = native;
+  /* The surface and the bars over it are both new, so what a window may use
+   * has to be worked out again. */
+  _screenBoundsKnown = NO;
+  if (native != NULL)
+    {
+      [self _noticeScreenChange];
+    }
+
+  /* The composite writes 4 bytes for every pixel, so the surface has to hold
+   * 4: an activity is given whatever format it was configured with, and a
+   * narrower one is overrun by the row arithmetic rather than merely drawn
+   * wrongly. */
+  if (native != NULL)
+    {
+      ANativeWindow_setBuffersGeometry(native, 0, 0, WINDOW_FORMAT_RGBA_8888);
+    }
+
+  if (native == NULL)
+    {
+      /* The activity is giving its surface up.  Nothing may be posted to it
+       * after this returns, so the binding goes now rather than when the
+       * window is next ordered out. */
+      if (_boundWindow != 0)
+	{
+	  [self setNativeWindow: NULL forWindow: _boundWindow];
+	  _boundWindow = 0;
+	}
+      return;
+    }
+
+  /* A surface arriving is the other half: on a resume the application orders
+   * nothing, so the window that was on screen has to be found again. */
+  {
+    struct AndroidWindow *window = [self _windowWithId: _boundWindow];
+    NSMapEnumerator	  e;
+    void		 *key;
+    void		 *value;
+
+    if ([self _isCandidate: window] == YES)
+      {
+	[self _bindActivityTo: window];
+	return;
+      }
+    _boundWindow = 0;
+    e = NSEnumerateMapTable(_windows);
+    while (NSNextMapEnumeratorPair(&e, &key, &value) == YES)
+      {
+	if ([self _isCandidate: (struct AndroidWindow *)value] == YES)
+	  {
+	    [self _bindActivityTo: (struct AndroidWindow *)value];
+	    break;
+	  }
+      }
+    NSEndMapTableEnumeration(&e);
+  }
+}
+
+- (ANativeWindow *) activityWindow
+{
+  return _activityWindow;
+}
+
+- (int) windowBoundToActivity
+{
+  return _boundWindow;
+}
+
+- (void) setJavaEnvironment: (JNIEnv *)env
+{
+  _jniEnv = env;
+}
+
+/* The activity reports a touch in the surface's own pixels, counted down from
+ * its top; a window sits somewhere in that surface and its own coordinates
+ * count up from its bottom.  The surface is not scaled to the window, so this
+ * is a move of the origin and a flip, with no factor in it.
+ */
+- (NSPoint) _locationFor: (const AInputEvent *)event
+		inWindow: (struct AndroidWindow *)window
+{
+  NSPoint point = [self _screenLocationFor: event];
+
+  if (window == NULL)
+    {
+      return NSZeroPoint;
+    }
+  return NSMakePoint(point.x - NSMinX(window->frame),
+    point.y - NSMinY(window->frame));
+}
+
+/* A key with no character of its own.  The platform's table answers nothing
+ * for these and AppKit names them. */
+static unichar
+android_special_key(int32_t code)
+{
+  switch (code)
+    {
+      case AKEYCODE_DEL:         return NSBackspaceCharacter;
+      case AKEYCODE_FORWARD_DEL: return NSDeleteCharacter;
+      case AKEYCODE_ENTER:       return NSCarriageReturnCharacter;
+      case AKEYCODE_TAB:         return NSTabCharacter;
+      case AKEYCODE_ESCAPE:      return 0x1b;
+      case AKEYCODE_DPAD_UP:     return NSUpArrowFunctionKey;
+      case AKEYCODE_DPAD_DOWN:   return NSDownArrowFunctionKey;
+      case AKEYCODE_DPAD_LEFT:   return NSLeftArrowFunctionKey;
+      case AKEYCODE_DPAD_RIGHT:  return NSRightArrowFunctionKey;
+      default:                   return 0;
+    }
+}
+
+static NSUInteger
+android_modifiers(int32_t meta)
+{
+  NSUInteger flags = 0;
+
+  if (meta & AMETA_SHIFT_ON) flags |= NSShiftKeyMask;
+  if (meta & AMETA_ALT_ON)   flags |= NSAlternateKeyMask;
+  if (meta & AMETA_CTRL_ON)  flags |= NSControlKeyMask;
+  return flags;
+}
+
+/* The flag a key of its own carries, or 0 for a key that is not a modifier. */
+static NSUInteger
+android_modifier_key(int32_t code)
+{
+  switch (code)
+    {
+      case AKEYCODE_SHIFT_LEFT:
+      case AKEYCODE_SHIFT_RIGHT:  return NSShiftKeyMask;
+      case AKEYCODE_ALT_LEFT:
+      case AKEYCODE_ALT_RIGHT:    return NSAlternateKeyMask;
+      case AKEYCODE_CTRL_LEFT:
+      case AKEYCODE_CTRL_RIGHT:   return NSControlKeyMask;
+      case AKEYCODE_META_LEFT:
+      case AKEYCODE_META_RIGHT:   return NSCommandKeyMask;
+      case AKEYCODE_CAPS_LOCK:    return NSAlphaShiftKeyMask;
+      default:                    return 0;
+    }
+}
+
+/* AppKit numbers the buttons 0 for the left, 1 for the right and 2 upwards for
+ * the rest.  A touch reports no button, which is the left one. */
+static int
+android_button(int32_t state)
+{
+  if (state & AMOTION_EVENT_BUTTON_SECONDARY)      return 1;
+  if (state & AMOTION_EVENT_BUTTON_STYLUS_PRIMARY) return 1;
+  if (state & AMOTION_EVENT_BUTTON_TERTIARY)       return 2;
+  return 0;
+}
+
+- (void) setActivity: (ANativeActivity *)activity
+{
+  _activity = activity;
+}
+
+/* Whether what has the keyboard's attention is something a person types into.
+ *
+ * Editing a text field makes the field editor the first responder, and the
+ * field editor is itself an NSTextView, so both a field and a text view answer
+ * to the one test.  A responder that is not editable is reading matter and
+ * wants no keyboard.
+ */
+- (BOOL) _wantsKeyboard
+{
+  NSResponder *responder = [[NSApp keyWindow] firstResponder];
+
+  if (NO == [responder isKindOfClass: [NSText class]])
+    {
+      return NO;
+    }
+  return [(NSText *)responder isEditable];
+}
+
+/* A device with no keyboard of its own has one on the screen, and it is shown
+ * only while something is being edited.
+ *
+ * AppKit says when a responder starts and stops being the first, but says it to
+ * nothing outside the gui library: -[NSTextInputContext activate] is where that
+ * would arrive and it is an empty method that nothing calls.  So the question
+ * is asked again after each event, which is the point at which the answer can
+ * have changed: a press moves the first responder, and so does a key that
+ * ends editing.
+ */
+/* Whether the press that has just been handled landed in the view being
+ * edited.  hitTest: wants the point in the window's own coordinates, which is
+ * what a press is given.
+ */
+- (BOOL) _pressWasInEditor
+{
+  NSWindow	*window = [NSApp keyWindow];
+  NSResponder	*responder = [window firstResponder];
+  NSView	*hit;
+
+  if (NO == [responder isKindOfClass: [NSText class]]
+    || NO == [(NSText *)responder isEditable])
+    {
+      return NO;
+    }
+  hit = [[window contentView] hitTest: _mouseLocation];
+  if (hit == nil)
+    {
+      return NO;
+    }
+
+  if (hit == (NSView *)responder || [hit isDescendantOf: (NSView *)responder])
+    {
+      return YES;
+    }
+
+  /* Editing a field makes the field editor the first responder, and a press
+   * lands on the field rather than on the editor inside it.  A field editor
+   * names the control it is editing as its delegate. */
+  {
+    id owner = [(NSText *)responder delegate];
+
+    if ([owner isKindOfClass: [NSView class]]
+      && (hit == (NSView *)owner || [hit isDescendantOf: (NSView *)owner]))
+      {
+	return YES;
+      }
+  }
+  return NO;
+}
+
+- (void) _updateKeyboard: (NSNumber *)afterPress
+{
+  BOOL wants;
+
+  if (_activity == NULL)
+    {
+      return;
+    }
+  wants = [self _wantsKeyboard];
+
+  /* A press outside the view being edited ends the editing, which is what a
+   * person means by it: the keyboard goes and the window grows back.  Without
+   * this a field stays the first responder for as long as the application
+   * lives, because AppKit does not resign one for a press on nothing. */
+  if (wants == YES && [afterPress boolValue] == YES
+    && NO == [self _pressWasInEditor])
+    {
+      NSWindow *window = [NSApp keyWindow];
+
+      [window makeFirstResponder: window];
+      wants = [self _wantsKeyboard];
+    }
+
+  /* The platform hides the keyboard itself on the back gesture and says
+   * nothing, so what was last asked for is not what is on the screen.  A press
+   * in the view being edited is the moment a person expects it back. */
+  if (wants == _keyboardShown
+    && NO == (wants && [afterPress boolValue]))
+    {
+      return;
+    }
+  _keyboardShown = wants;
+  NSDebugLLog(@"NSEvent", @"android keyboard: %@",
+    (wants ? @"shown" : @"hidden"));
+  [self _setKeyboardVisible: wants];
+
+  /* The keyboard takes its place over a moment rather than at once, so the
+   * screen is looked at again after it has. */
+  [self performSelector: @selector(_noticeScreenChange)
+	     withObject: nil
+	     afterDelay: 0.4];
+}
+
+/* Show or hide the input method.
+ *
+ * ANativeActivity_showSoftInput does not do this: it names the activity's
+ * content view, and the view the input method is serving is the window's
+ * decor view, so the request is refused with "Ignoring showSoftInput() as
+ * view=... is not served".  InputMethodManager is asked directly instead,
+ * naming the view it is serving.
+ */
+- (void) _setKeyboardVisible: (BOOL)visible
+{
+  JNIEnv	*env = _jniEnv;
+  jobject	 activity;
+  jclass	 activityCls = NULL;
+  jobject	 window = NULL;
+  jobject	 decor = NULL;
+  jobject	 manager = NULL;
+  jstring	 name = NULL;
+
+  if (env == NULL || _activity == NULL || _activity->clazz == NULL)
+    {
+      return;
+    }
+  activity = _activity->clazz;
+  activityCls = (*env)->GetObjectClass(env, activity);
+
+  {
+    jmethodID getWindow = (*env)->GetMethodID(env, activityCls,
+      "getWindow", "()Landroid/view/Window;");
+
+    if (getWindow != NULL)
+      {
+	window = (*env)->CallObjectMethod(env, activity, getWindow);
+      }
+  }
+  if (window != NULL)
+    {
+      jclass	 windowCls = (*env)->GetObjectClass(env, window);
+      jmethodID	 getDecorView = (*env)->GetMethodID(env, windowCls,
+	"getDecorView", "()Landroid/view/View;");
+
+      if (getDecorView != NULL)
+	{
+	  decor = (*env)->CallObjectMethod(env, window, getDecorView);
+	}
+      (*env)->DeleteLocalRef(env, windowCls);
+    }
+
+  name = (*env)->NewStringUTF(env, "input_method");
+  {
+    jmethodID getSystemService = (*env)->GetMethodID(env, activityCls,
+      "getSystemService", "(Ljava/lang/String;)Ljava/lang/Object;");
+
+    if (getSystemService != NULL && name != NULL)
+      {
+	manager = (*env)->CallObjectMethod(env, activity, getSystemService,
+	  name);
+      }
+  }
+
+  if (manager != NULL && decor != NULL)
+    {
+      jclass managerCls = (*env)->GetObjectClass(env, manager);
+
+      if (visible)
+	{
+	  jmethodID show = (*env)->GetMethodID(env, managerCls,
+	    "showSoftInput", "(Landroid/view/View;I)Z");
+
+	  if (show != NULL)
+	    {
+	      (*env)->CallBooleanMethod(env, manager, show, decor, 0);
+	    }
+	}
+      else
+	{
+	  jclass	viewCls = (*env)->GetObjectClass(env, decor);
+	  jmethodID	token = (*env)->GetMethodID(env, viewCls,
+	    "getWindowToken", "()Landroid/os/IBinder;");
+	  jmethodID	hide = (*env)->GetMethodID(env, managerCls,
+	    "hideSoftInputFromWindow", "(Landroid/os/IBinder;I)Z");
+
+	  if (token != NULL && hide != NULL)
+	    {
+	      jobject binder = (*env)->CallObjectMethod(env, decor, token);
+
+	      if (binder != NULL)
+		{
+		  (*env)->CallBooleanMethod(env, manager, hide, binder, 0);
+		  (*env)->DeleteLocalRef(env, binder);
+		}
+	    }
+	  (*env)->DeleteLocalRef(env, viewCls);
+	}
+      (*env)->DeleteLocalRef(env, managerCls);
+    }
+
+  if (name != NULL)    (*env)->DeleteLocalRef(env, name);
+  if (manager != NULL) (*env)->DeleteLocalRef(env, manager);
+  if (decor != NULL)   (*env)->DeleteLocalRef(env, decor);
+  if (window != NULL)  (*env)->DeleteLocalRef(env, window);
+  (*env)->DeleteLocalRef(env, activityCls);
+  (*env)->ExceptionClear(env);
+}
+
+/* How long after a press a second one still counts as part of the same click,
+ * taken from android.view.ViewConfiguration so that a person who has changed
+ * the platform's setting gets what they asked for.  The NDK reports no click
+ * count of its own.  Without a JNI context the platform's own default stands.
+ */
+- (NSTimeInterval) _doubleTapTimeout
+{
+  if (_doubleTapTimeout > 0.0)
+    {
+      return _doubleTapTimeout;
+    }
+  _doubleTapTimeout = 0.3;
+
+  if (_jniEnv != NULL)
+    {
+      jclass	cls;
+
+      cls = (*_jniEnv)->FindClass(_jniEnv, "android/view/ViewConfiguration");
+      if (cls != NULL)
+	{
+	  jmethodID m = (*_jniEnv)->GetStaticMethodID(_jniEnv, cls,
+	    "getDoubleTapTimeout", "()I");
+
+	  if (m != NULL)
+	    {
+	      jint ms = (*_jniEnv)->CallStaticIntMethod(_jniEnv, cls, m);
+
+	      if (ms > 0)
+		{
+		  _doubleTapTimeout = (NSTimeInterval)ms / 1000.0;
+		}
+	    }
+	  (*_jniEnv)->DeleteLocalRef(_jniEnv, cls);
+	}
+      (*_jniEnv)->ExceptionClear(_jniEnv);
+    }
+  return _doubleTapTimeout;
+}
+
+/* A press close enough to the one before it, and soon enough after it, carries
+ * the count on.  AppKit counts this way and the NDK reports no count. */
+- (void) _countClickAt: (NSPoint)location atTime: (NSTimeInterval)now
+{
+  CGFloat dx = location.x - _lastClickLocation.x;
+  CGFloat dy = location.y - _lastClickLocation.y;
+
+  if (_clickCount > 0
+    && now - _lastClickTime <= [self _doubleTapTimeout]
+    && (dx * dx + dy * dy) <= (CGFloat)(GS_ANDROID_CLICK_SLOP
+      * GS_ANDROID_CLICK_SLOP))
+    {
+      _clickCount++;
+    }
+  else
+    {
+      _clickCount = 1;
+    }
+  _lastClickTime = now;
+  _lastClickLocation = location;
+}
+
+/* android.view.KeyEvent holds the mapping from a key to a character; the NDK
+ * reports the code and the meta state and offers no character at all. */
+- (unichar) _characterForKey: (int32_t)code meta: (int32_t)meta
+{
+  static jclass    cls = NULL;
+  static jmethodID ctor = NULL;
+  static jmethodID unicode = NULL;
+  jobject	   event;
+  jint		   ch;
+
+  if (_jniEnv == NULL)
+    {
+      return 0;
+    }
+  if (cls == NULL)
+    {
+      jclass local = (*_jniEnv)->FindClass(_jniEnv, "android/view/KeyEvent");
+
+      if (local == NULL)
+	{
+	  (*_jniEnv)->ExceptionClear(_jniEnv);
+	  return 0;
+	}
+      cls = (*_jniEnv)->NewGlobalRef(_jniEnv, local);
+      ctor = (*_jniEnv)->GetMethodID(_jniEnv, cls, "<init>", "(II)V");
+      unicode = (*_jniEnv)->GetMethodID(_jniEnv, cls, "getUnicodeChar", "(I)I");
+    }
+  if (ctor == NULL || unicode == NULL)
+    {
+      return 0;
+    }
+  event = (*_jniEnv)->NewObject(_jniEnv, cls, ctor,
+    (jint)AKEY_EVENT_ACTION_DOWN, (jint)code);
+  if (event == NULL)
+    {
+      (*_jniEnv)->ExceptionClear(_jniEnv);
+      return 0;
+    }
+  ch = (*_jniEnv)->CallIntMethod(_jniEnv, event, unicode, (jint)meta);
+  (*_jniEnv)->DeleteLocalRef(_jniEnv, event);
+  return (unichar)ch;
+}
+
+/* The point an event names, in the screen's coordinates: the activity reports
+ * it in the surface's own pixels, counted down from the top, and the screen
+ * counts up from the bottom.
+ */
+- (NSPoint) _screenLocationFor: (const AInputEvent *)event
+{
+  float screenHeight;
+
+  if (_activityWindow == NULL)
+    {
+      return NSZeroPoint;
+    }
+  screenHeight = (float)ANativeWindow_getHeight(_activityWindow);
+  return NSMakePoint(AMotionEvent_getX(event, 0),
+    screenHeight - AMotionEvent_getY(event, 0));
+}
+
+/* The window a person is pointing at: the front-most one on screen whose frame
+ * holds the point.  Front-most is the highest level, and within a level the
+ * one ordered in most recently, which is the order the windows are written in
+ * reversed.
+ */
+- (struct AndroidWindow *) _windowUnderPoint: (NSPoint)point
+{
+  NSMapEnumerator	 e = NSEnumerateMapTable(_windows);
+  struct AndroidWindow	*best = NULL;
+  void			*key, *value;
+
+  while (NSNextMapEnumeratorPair(&e, &key, &value))
+    {
+      struct AndroidWindow *w = (struct AndroidWindow *)value;
+
+      if (w == NULL || w->mapped == NO
+	|| NO == NSPointInRect(point, w->frame))
+	{
+	  continue;
+	}
+      if (best == NULL
+	|| w->level > best->level
+	|| (w->level == best->level && w->ordered > best->ordered))
+	{
+	  best = w;
+	}
+    }
+  NSEndMapTableEnumeration(&e);
+
+  return best;
+}
+
+- (BOOL) handleInputEvent: (const AInputEvent *)event
+{
+  struct AndroidWindow	*window;
+  NSTimeInterval	 now;
+
+  if (event == NULL || _activityWindow == NULL)
+    {
+      return NO;
+    }
+
+  /* A press goes to the window it lands in; a key goes to the window that has
+   * the screen, because a key names no place. */
+  if (AInputEvent_getType(event) == AINPUT_EVENT_TYPE_MOTION)
+    {
+      window = [self _windowUnderPoint: [self _screenLocationFor: event]];
+    }
+  else
+    {
+      window = [self _windowWithId: _boundWindow];
+    }
+  if (window == NULL)
+    {
+      return NO;
+    }
+  now = [[NSDate date] timeIntervalSinceReferenceDate];
+
+  if (AInputEvent_getType(event) == AINPUT_EVENT_TYPE_MOTION)
+    {
+      NSEventType	type;
+      NSPoint		location;
+      NSUInteger	flags = android_modifiers(AMotionEvent_getMetaState(event));
+      int32_t		action;
+      int		button;
+
+      action = AMotionEvent_getAction(event) & AMOTION_EVENT_ACTION_MASK;
+      location = [self _locationFor: event inWindow: window];
+
+      /* A wheel, which a mouse has and a touchscreen does not.  Android counts
+       * a detent as 1 along the axis, which is what AppKit's delta counts. */
+      if (action == AMOTION_EVENT_ACTION_SCROLL)
+	{
+	  _mouseLocation = location;
+	  NSDebugLLog(@"NSEvent", @"android scroll: at %@ by %g,%g",
+	    NSStringFromPoint(location),
+	    (double)AMotionEvent_getAxisValue(event,
+	      AMOTION_EVENT_AXIS_HSCROLL, 0),
+	    (double)AMotionEvent_getAxisValue(event,
+	      AMOTION_EVENT_AXIS_VSCROLL, 0));
+	  [self postEvent:
+	    [NSEvent mouseEventWithType: NSScrollWheel
+			       location: location
+			  modifierFlags: flags
+			      timestamp: now
+			   windowNumber: window->window_id
+				context: GSCurrentContext()
+			    eventNumber: 0
+			     clickCount: 0
+			       pressure: 1.0
+			   buttonNumber: 0
+				 deltaX: AMotionEvent_getAxisValue(event,
+				   AMOTION_EVENT_AXIS_HSCROLL, 0)
+				 deltaY: AMotionEvent_getAxisValue(event,
+				   AMOTION_EVENT_AXIS_VSCROLL, 0)
+				 deltaZ: 0.0]
+		 atStart: NO];
+	  return YES;
+	}
+
+      /* A pointer moving with nothing held down.  A touchscreen reports this
+       * only from a stylus near the glass; a mouse reports it whenever it
+       * moves, and it is what a tracking rect and a cursor rect need. */
+      if (action == AMOTION_EVENT_ACTION_HOVER_MOVE
+	|| action == AMOTION_EVENT_ACTION_HOVER_ENTER
+	|| action == AMOTION_EVENT_ACTION_HOVER_EXIT)
+	{
+	  _mouseLocation = location;
+	  NSDebugLLog(@"NSEvent", @"android hover: at %@ flags %lx",
+	    NSStringFromPoint(location), (unsigned long)flags);
+	  [self postEvent:
+	    [NSEvent mouseEventWithType: NSMouseMoved
+			       location: location
+			  modifierFlags: flags
+			      timestamp: now
+			   windowNumber: window->window_id
+				context: GSCurrentContext()
+			    eventNumber: 0
+			     clickCount: 0
+			       pressure: 0.0
+			   buttonNumber: 0
+				 deltaX: 0.0
+				 deltaY: 0.0
+				 deltaZ: 0.0]
+		 atStart: NO];
+	  return YES;
+	}
+
+      switch (action)
+	{
+	  case AMOTION_EVENT_ACTION_DOWN:
+	    /* A touch reports no button at all, and a mouse reports the one it
+	     * is holding; the button a drag and an up belong to is the one that
+	     * went down, because the state is clear again by the up. */
+	    _mouseButton = android_button(AMotionEvent_getButtonState(event));
+	    [self _countClickAt: location atTime: now];
+	    button = _mouseButton;
+	    type = (button == 1) ? NSRightMouseDown
+	      : (button > 1) ? NSOtherMouseDown : NSLeftMouseDown;
+	    break;
+
+	  case AMOTION_EVENT_ACTION_UP:
+	  case AMOTION_EVENT_ACTION_CANCEL:
+	    button = _mouseButton;
+	    type = (button == 1) ? NSRightMouseUp
+	      : (button > 1) ? NSOtherMouseUp : NSLeftMouseUp;
+	    _mouseButton = 0;
+	    break;
+
+	  case AMOTION_EVENT_ACTION_MOVE:
+	    button = _mouseButton;
+	    type = (button == 1) ? NSRightMouseDragged
+	      : (button > 1) ? NSOtherMouseDragged : NSLeftMouseDragged;
+	    break;
+
+	  /* A second finger down or up.  AppKit has one pointer, so the first
+	   * finger goes on driving it and this is not passed on. */
+	  case AMOTION_EVENT_ACTION_POINTER_DOWN:
+	  case AMOTION_EVENT_ACTION_POINTER_UP:
+	  default:
+	    return NO;
+	}
+
+      _mouseLocation = location;
+      NSDebugLLog(@"NSEvent", @"android motion: type %d at %@ button %d"
+	@" clicks %d flags %lx", (int)type, NSStringFromPoint(location),
+	button, _clickCount, (unsigned long)flags);
+      [self postEvent: [NSEvent mouseEventWithType: type
+					  location: location
+				     modifierFlags: flags
+					 timestamp: now
+				      windowNumber: window->window_id
+					   context: GSCurrentContext()
+				       eventNumber: 0
+					clickCount: _clickCount
+					  pressure: 1.0
+				      buttonNumber: button
+					    deltaX: 0.0
+					    deltaY: 0.0
+					    deltaZ: 0.0]
+	     atStart: NO];
+      /* The press moves the first responder when the gui library takes the
+       * event off the queue, which is after this returns, so the keyboard is
+       * asked about once that has happened. */
+      [self performSelector: @selector(_updateKeyboard:)
+		 withObject: [NSNumber numberWithBool: YES]
+		 afterDelay: 0.0];
+      return YES;
+    }
+
+  if (AInputEvent_getType(event) == AINPUT_EVENT_TYPE_KEY)
+    {
+      NSEventType	 type;
+      int32_t		 code = AKeyEvent_getKeyCode(event);
+      int32_t		 meta = AKeyEvent_getMetaState(event);
+      unichar		 ch;
+      NSString		*characters;
+
+      /* The back key is the platform's own gesture. */
+      if (code == AKEYCODE_BACK)
+	{
+	  return NO;
+	}
+      switch (AKeyEvent_getAction(event))
+	{
+	  case AKEY_EVENT_ACTION_DOWN: type = NSKeyDown; break;
+	  case AKEY_EVENT_ACTION_UP:   type = NSKeyUp;   break;
+	  default:                     return NO;
+	}
+
+      /* A modifier has no character, so it is reported as the change in the
+       * flags rather than as a key.  The state Android reports is the one
+       * before the key it is reporting, so the key's own bit is set or cleared
+       * here. */
+      if (android_modifier_key(code) != 0)
+	{
+	  NSUInteger flags = android_modifiers(meta);
+
+	  if (type == NSKeyDown)
+	    {
+	      flags |= android_modifier_key(code);
+	    }
+	  else
+	    {
+	      flags &= ~android_modifier_key(code);
+	    }
+	  NSDebugLLog(@"NSEvent", @"android flags changed: key %d flags %lx",
+	    (int)code, (unsigned long)flags);
+	  [self postEvent: [NSEvent keyEventWithType: NSFlagsChanged
+					    location: _mouseLocation
+				       modifierFlags: flags
+					   timestamp: now
+					windowNumber: window->window_id
+					     context: GSCurrentContext()
+					  characters: @""
+			 charactersIgnoringModifiers: @""
+					   isARepeat: NO
+					     keyCode: (unsigned short)code]
+	     atStart: NO];
+	  return YES;
+	}
+
+      ch = android_special_key(code);
+      if (ch == 0)
+	{
+	  ch = [self _characterForKey: code meta: meta];
+	}
+      if (ch == 0)
+	{
+	  return NO;
+	}
+      characters = [NSString stringWithCharacters: &ch length: 1];
+      [self postEvent: [NSEvent keyEventWithType: type
+					location: NSZeroPoint
+				   modifierFlags: android_modifiers(meta)
+				       timestamp: now
+				    windowNumber: window->window_id
+					 context: GSCurrentContext()
+				      characters: characters
+		     charactersIgnoringModifiers: characters
+				       isARepeat:
+	  (AKeyEvent_getRepeatCount(event) > 0)
+					 keyCode: (unsigned short)code]
+	     atStart: NO];
+      /* A key can end editing, and a tab can move it somewhere else. */
+      [self performSelector: @selector(_updateKeyboard:)
+		 withObject: nil
+		 afterDelay: 0.0];
+      return YES;
+    }
+
+  return NO;
+}
+
+/* Nothing shows a title, a document-edited mark, an input state, an alpha or a
+ * shadow while the surface is offscreen.  These are present because the other
+ * servers have them and the gui library calls them on every window. */
+- (void) titlewindow: (NSString *)title : (int)win { }
+- (void) docedited: (int)edited : (int)win { }
+- (void) setinputstate: (int)state : (int)win { }
+- (void) setinputfocus: (int)win { }
+- (void) setalpha: (float)alpha : (int)win { }
+- (void) setShadow: (BOOL)hasShadow : (int)win { }
+- (void) setmaxsize: (NSSize)size : (int)win { }
+- (void) setminsize: (NSSize)size : (int)win { }
+- (void) setresizeincrements: (NSSize)size : (int)win { }
+- (void) miniwindow: (int)win { }
+- (void) setParentWindow: (int)parentWin forChildWindow: (int)childWin { }
+- (void) restrictWindow: (int)win toImage: (NSImage *)image { }
+- (void) beep { }
+
+/* Android has no window this process did not make, so there is no foreign
+ * window to adopt. */
+- (int) nativeWindow: (void *)winref
+		    : (NSRect *)frame
+		    : (NSBackingStoreType *)type
+		    : (unsigned int *)style
+		    : (int *)screen
+{
+  return 0;
+}
+
+/*
+ * Pointer and cursor
+ *
+ * No pointer device exists while the surface is offscreen, so the server owns
+ * the location: -setMouseLocation:onScreen: sets it and -mouselocation reports
+ * it back.  x11, win32 and wayland all answer these.
+ */
+
+- (NSPoint) mouselocation
+{
+  return _mouseLocation;
+}
+
+- (NSPoint) mouseLocationOnScreen: (int)aScreen window: (int *)win
+{
+  if (win != NULL)
+    {
+      *win = 0;
+    }
+  return (aScreen == 0) ? _mouseLocation : NSZeroPoint;
+}
+
+- (void) setMouseLocation: (NSPoint)mouseLocation onScreen: (int)aScreen
+{
+  if (aScreen == 0)
+    {
+      _mouseLocation = mouseLocation;
+    }
+}
+
+- (BOOL) capturemouse: (int)win { return NO; }
+- (void) releasemouse { }
+- (void) hidecursor { }
+- (void) showcursor { }
+- (void) standardcursor: (int)style : (void **)cid { *cid = NULL; }
+- (void) imagecursor: (NSPoint)hotp : (NSImage *)image : (void **)cid { *cid = NULL; }
+- (void) recolorcursor: (NSColor *)fg : (NSColor *)bg : (void *)cid { }
+- (void) setcursor: (void *)cid { }
+- (void) freecursor: (void *)cid { }
+
+@end

--- a/Source/android/GNUmakefile
+++ b/Source/android/GNUmakefile
@@ -1,0 +1,45 @@
+#
+#  Main makefile for the GNUstep Android Backend
+#
+#  Copyright (C) 2026 Free Software Foundation, Inc.
+#
+#  Author: Adam Fedor <fedor@gnu.org>
+#  Author: Todd White <todd.white@thalion.global>
+#
+#  This file is part of the GNUstep Backend.
+#
+#  This library is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 2 of the License, or (at your option) any later version.
+#
+#  This library is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with this library; see the file COPYING.LIB.
+#  If not, see <http://www.gnu.org/licenses/> or write to the
+#  Free Software Foundation, 51 Franklin Street, Fifth Floor,
+#  Boston, MA 02110-1301, USA.
+
+PACKAGE_NAME = gnustep-back
+GNUSTEP_LOCAL_ADDITIONAL_MAKEFILES=../../back.make
+
+include $(GNUSTEP_MAKEFILES)/common.make
+
+include ../../config.make
+
+# The library to be compiled, as a library or as a bundle
+SUBPROJECT_NAME=android
+
+# The Objective-C source files to be compiled
+android_OBJC_FILES = \
+AndroidServer.m
+
+-include GNUmakefile.preamble
+
+include $(GNUSTEP_MAKEFILES)/subproject.make
+
+-include GNUmakefile.postamble

--- a/Source/android/GNUmakefile.preamble
+++ b/Source/android/GNUmakefile.preamble
@@ -4,6 +4,7 @@
 #  Copyright (C) 2002 Free Software Foundation, Inc.
 #
 #  Author: Adam Fedor <fedor@gnu.org>
+#  Author: Todd White <todd.white@thalion.global>
 #
 #  This file is part of the GNUstep Backend.
 #
@@ -28,49 +29,24 @@
 #
 
 # Additional flags to pass to the preprocessor
-ADDITIONAL_CPPFLAGS += -Wall
+ADDITIONAL_CPPFLAGS += -Wall $(CONFIG_SYSTEM_DEFS)
 
 # Additional flags to pass to the Objective-C compiler
-#ADDITIONAL_OBJCFLAGS += 
+ADDITIONAL_OBJCFLAGS = 
 
 # Additional flags to pass to the C compiler
-ADDITIONAL_CFLAGS += 
+ADDITIONAL_CFLAGS = 
 
 # Additional include directories the compiler should search
-ADDITIONAL_INCLUDE_DIRS += -I../Headers -I$(GNUSTEP_TARGET_DIR)
-CONFIG_SYSTEM_INCL += $(GRAPHIC_CFLAGS)
+ADDITIONAL_INCLUDE_DIRS += -I../../Headers \
+	-I../$(GNUSTEP_TARGET_DIR) $(GRAPHIC_CFLAGS)
 
 # Additional LDFLAGS to pass to the linker
-#ADDITIONAL_LDFLAGS +=
+ADDITIONAL_LDFLAGS =
 
 # Additional library directories the linker should search
-#ADDITIONAL_LIB_DIRS +=
-CONFIG_SYSTEM_LIB_DIR += $(GRAPHIC_LFLAGS)
-ifeq ($(WITH_EGL),yes)
-CONFIG_SYSTEM_LIB_DIR += -lGL -lEGL -lwayland-egl
-endif
-
-# The android server and its cairo surface call into the NDK's window API, so
-# the bundle links libandroid whichever of the two introduced the reference.
-ifeq ($(BUILD_SERVER),android)
-CONFIG_SYSTEM_LIB_DIR += -landroid
-endif
+ADDITIONAL_LIB_DIRS =
 
 #
-# Flags for compiling as a bundle or library (if the system depends
-# on having libraries specified).
+# Flags dealing with installing and uninstalling
 #
-libgnustep-$(BACKEND_FULL)_BUNDLE_LIBS = $(GRAPHIC_LIBS)
-
-ifeq ($(BACKEND_BUNDLE),)
-libgnustep-$(BACKEND_FULL)_LIBRARIES_DEPEND_UPON = \
-	-lgnustep-gui -l$(FOUNDATION_LIBRARY_NAME) $(GRAPHIC_LIBS)
-endif
-
-
-#
-# The */*.m is a hack to get make_strings to pull in all the .m files in all
-# sub-directories. Even if we aren't including a directory in the build, it is
-# important that the strings files contains all strings.
-#
-MAKE_STRINGS_OPTIONS = --aggressive-match --aggressive-remove */*.m

--- a/Source/cairo/AndroidCairoSurface.m
+++ b/Source/cairo/AndroidCairoSurface.m
@@ -1,0 +1,411 @@
+/* AndroidCairoSurface
+
+   A cairo surface for the Android backend.  It is an offscreen image surface:
+   the window has real geometry, nothing is on screen, and -flushwindowrect::
+   has nothing to post because the image surface is already the destination.
+   A surface backed by the buffer ANativeWindow_lock hands out replaces the
+   allocation here, behind this same class.
+
+   Copyright (C) 2026 Free Software Foundation, Inc.
+
+   Author: Todd White <todd.white@thalion.global>
+   Date: August 2026
+
+   This file is part of the GNU Objective C Backend Library.
+
+   This library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2 of the License, or (at your option) any later version.
+
+   This library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with this library; see the file COPYING.LIB.
+   If not, see <http://www.gnu.org/licenses/> or write to the
+   Free Software Foundation, 51 Franklin Street, Fifth Floor,
+   Boston, MA 02110-1301, USA.
+*/
+
+#include "android/AndroidServer.h"
+#include "cairo/AndroidCairoSurface.h"
+
+#include <Foundation/NSDebug.h>
+
+#include <math.h>
+#include <stdint.h>
+
+@implementation AndroidCairoSurface
+
+/* device is the struct AndroidWindow the server keeps for this window id. */
+- (id) initWithDevice: (void *)device
+{
+  struct AndroidWindow *window = (struct AndroidWindow *)device;
+  int			w, h;
+
+  if (window == NULL)
+    {
+      NSDebugLLog(@"AndroidCairoSurface", @"no device for the surface");
+      DESTROY(self);
+      return nil;
+    }
+
+  gsDevice = device;
+
+  w = (int)NSWidth(window->frame);
+  h = (int)NSHeight(window->frame);
+  if (w <= 0 || h <= 0)
+    {
+      NSDebugLLog(@"AndroidCairoSurface",
+		  @"window %d has a %dx%d frame, no surface made",
+		  window->window_id, w, h);
+      DESTROY(self);
+      return nil;
+    }
+
+  _surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, w, h);
+
+  /* A surface in an error state accepts every drawing call and discards it, so
+   * the status is checked while the surface is being created. */
+  if (cairo_surface_status(_surface) != CAIRO_STATUS_SUCCESS)
+    {
+      NSLog(@"AndroidCairoSurface: %dx%d surface: %s", w, h,
+	    cairo_status_to_string(cairo_surface_status(_surface)));
+      cairo_surface_destroy(_surface);
+      _surface = NULL;
+      DESTROY(self);
+      return nil;
+    }
+
+  /* The record carries the window when the activity handed one over before
+   * AppKit asked for a surface, which is the order an activity works in: the
+   * window arrives with APP_CMD_INIT_WINDOW, and the surface is made later,
+   * when something is first drawn. */
+  [self setNativeWindow: window->native];
+
+  window->surface = self;
+  return self;
+}
+
+- (void) dealloc
+{
+  struct AndroidWindow *window = (struct AndroidWindow *)gsDevice;
+
+  if (window != NULL && window->surface == self)
+    {
+      window->surface = nil;
+    }
+  /* _surface is destroyed by CairoSurface -dealloc. */
+  [super dealloc];
+}
+
+- (NSSize) size
+{
+  if (_surface == NULL)
+    {
+      return NSZeroSize;
+    }
+  return NSMakeSize(cairo_image_surface_get_width(_surface),
+		    cairo_image_surface_get_height(_surface));
+}
+
+- (void) setSize: (NSSize)newSize
+{
+  cairo_surface_t *replacement;
+  int		   w = (int)newSize.width;
+  int		   h = (int)newSize.height;
+
+  if (w <= 0 || h <= 0)
+    {
+      NSDebugLLog(@"AndroidCairoSurface",
+		  @"ignoring a resize to %dx%d", w, h);
+      return;
+    }
+  if (_surface != NULL
+      && cairo_image_surface_get_width(_surface) == w
+      && cairo_image_surface_get_height(_surface) == h)
+    {
+      return;
+    }
+
+  replacement = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, w, h);
+  if (cairo_surface_status(replacement) != CAIRO_STATUS_SUCCESS)
+    {
+      NSLog(@"AndroidCairoSurface: resize to %dx%d: %s", w, h,
+	    cairo_status_to_string(cairo_surface_status(replacement)));
+      cairo_surface_destroy(replacement);
+      return;
+    }
+  if (_surface != NULL)
+    {
+      cairo_surface_destroy(_surface);
+    }
+  _surface = replacement;
+
+  /* A bound window keeps handing out buffers of the size it was last told,
+   * so a resize that does not reach it clips every later post to the old
+   * geometry. */
+  /* The format is set; the size is not.  A buffer the size of the window is
+   * scaled to the surface by the platform, which stretches a window that is
+   * not the shape of the screen.  The window is placed in a buffer of the
+   * surface's own size instead, by -_postRect:. */
+  if (_window != NULL)
+    {
+      ANativeWindow_setBuffersGeometry(_window, 0, 0, WINDOW_FORMAT_RGBA_8888);
+    }
+}
+
+- (void) setNativeWindow: (ANativeWindow *)window
+{
+  _window = window;
+  if (_window != NULL && _surface != NULL)
+    {
+      ANativeWindow_setBuffersGeometry(_window, 0, 0, WINDOW_FORMAT_RGBA_8888);
+    }
+}
+
+- (ANativeWindow *) nativeWindow
+{
+  return _window;
+}
+
+/* Copy rect out of the image surface and post it.
+ *
+ * rect is in cairo coordinates: y counts down from the top, which is what the
+ * callers convert to.  The destination stride comes from the buffer and is
+ * never computed from the width, since a window is entitled to hand out a
+ * wider row than it shows.  cairo's ARGB32 is a native-endian 32-bit word, so
+ * its bytes are B, G, R, A, where RGBA_8888 is R, G, B, A: every pixel is
+ * swizzled rather than copied.
+ */
+void
+GSAndroidBlitWindow(ANativeWindow_Buffer *buffer, cairo_surface_t *surface,
+  NSRect frame, int screenHeight, int x0, int y0, int x1, int y1)
+{
+  int		 sw, sh, srcStride, x, y, offsetX, offsetY;
+  unsigned char	*src;
+
+  if (buffer == NULL || surface == NULL || screenHeight <= 0)
+    {
+      return;
+    }
+
+  cairo_surface_flush(surface);
+  sw = cairo_image_surface_get_width(surface);
+  sh = cairo_image_surface_get_height(surface);
+  srcStride = cairo_image_surface_get_stride(surface);
+  src = cairo_image_surface_get_data(surface);
+  if (src == NULL)
+    {
+      return;
+    }
+
+  /* cairo's own idea of the stride for this width, against the one the surface
+   * reports.  A mismatch means the surface is not the format the loop below
+   * assumes, and writing garbage silently is worse than saying so once. */
+  if (srcStride != cairo_format_stride_for_width(CAIRO_FORMAT_ARGB32, sw))
+    {
+      NSLog(@"AndroidCairoSurface: stride %d is not the %d ARGB32 needs for"
+	    @" width %d, not posting", srcStride,
+	    cairo_format_stride_for_width(CAIRO_FORMAT_ARGB32, sw), sw);
+      return;
+    }
+
+  offsetX = (int)NSMinX(frame);
+  offsetY = screenHeight - (int)NSMaxY(frame);
+
+  if (x0 < 0) x0 = 0;
+  if (y0 < 0) y0 = 0;
+  if (x1 > buffer->width) x1 = buffer->width;
+  if (y1 > buffer->height) y1 = buffer->height;
+
+  for (y = y0; y < y1; y++)
+    {
+      int	 sy = y - offsetY;
+      uint32_t	*s;
+      uint32_t	*d;
+
+      if (sy < 0 || sy >= sh)
+	{
+	  continue;
+	}
+      s = (uint32_t *)(src + (size_t)sy * srcStride);
+      d = (uint32_t *)((unsigned char *)buffer->bits
+	+ (size_t)y * buffer->stride * 4);
+
+      for (x = x0; x < x1; x++)
+	{
+	  int sx = x - offsetX;
+
+	  if (sx >= 0 && sx < sw)
+	    {
+	      uint32_t p = s[sx];
+	      uint32_t a = (p >> 24) & 0xff;
+	      uint32_t r = (p >> 16) & 0xff;
+	      uint32_t g = (p >> 8) & 0xff;
+	      uint32_t b = p & 0xff;
+
+	      d[x] = (a << 24) | (b << 16) | (g << 8) | r;
+	    }
+	}
+    }
+}
+
+- (void) _postRect: (NSRect)rect
+{
+  ANativeWindow_Buffer	 buffer;
+  ARect			 dirty;
+  int			 sw, sh, x0, y0, x1, y1, x, y, srcStride;
+  int			 offsetX, offsetY;
+  unsigned char		*src;
+
+  if (_window == NULL || _surface == NULL)
+    {
+      return;
+    }
+
+  cairo_surface_flush(_surface);
+  sw = cairo_image_surface_get_width(_surface);
+  sh = cairo_image_surface_get_height(_surface);
+  srcStride = cairo_image_surface_get_stride(_surface);
+  src = cairo_image_surface_get_data(_surface);
+  if (src == NULL)
+    {
+      return;
+    }
+
+  /* cairo's own idea of the stride for this width, against the one the surface
+   * reports.  A mismatch means the surface is not the format the loop below
+   * assumes, and posting garbage silently is worse than saying so once. */
+  if (srcStride != cairo_format_stride_for_width(CAIRO_FORMAT_ARGB32, sw))
+    {
+      NSLog(@"AndroidCairoSurface: stride %d is not the %d ARGB32 needs for"
+	    @" width %d, not posting", srcStride,
+	    cairo_format_stride_for_width(CAIRO_FORMAT_ARGB32, sw), sw);
+      return;
+    }
+
+  /* Where this window sits in the surface.  The frame is in screen
+   * coordinates, y up from the bottom; the buffer's rows count down from the
+   * top, so the window's top edge is the screen height less its maximum y. */
+  {
+    struct AndroidWindow *record = (struct AndroidWindow *)gsDevice;
+    int			  screenHeight = ANativeWindow_getHeight(_window);
+
+    if (record == NULL || screenHeight <= 0)
+      {
+	return;
+      }
+    offsetX = (int)NSMinX(record->frame);
+    offsetY = screenHeight - (int)NSMaxY(record->frame);
+  }
+
+  x0 = (int)floor(NSMinX(rect));
+  y0 = (int)floor(NSMinY(rect));
+  x1 = (int)ceil(NSMaxX(rect));
+  y1 = (int)ceil(NSMaxY(rect));
+  if (x0 < 0) x0 = 0;
+  if (y0 < 0) y0 = 0;
+  if (x1 > sw) x1 = sw;
+  if (y1 > sh) y1 = sh;
+  if (x1 <= x0 || y1 <= y0)
+    {
+      return;
+    }
+
+  /* The region to redraw is asked for rather than assumed.  A window locks one
+   * of several buffers in turn, so the one it hands out holds whatever was
+   * drawn into it some frames ago rather than what was posted last; the area
+   * that has to be written is therefore wider than the area that changed, and
+   * the window is the only thing that knows how much wider.  It reports that
+   * through the same argument, which is why the argument is not NULL.
+   */
+  /* The damage is named to the window in the buffer's own coordinates. */
+  dirty.left = x0 + offsetX;
+  dirty.top = y0 + offsetY;
+  dirty.right = x1 + offsetX;
+  dirty.bottom = y1 + offsetY;
+  if (ANativeWindow_lock(_window, &buffer, &dirty) != 0)
+    {
+      NSDebugLLog(@"AndroidCairoSurface", @"the window would not lock");
+      return;
+    }
+
+  x0 = dirty.left;
+  y0 = dirty.top;
+  x1 = dirty.right;
+  y1 = dirty.bottom;
+  if (x0 < 0) x0 = 0;
+  if (y0 < 0) y0 = 0;
+  if (x1 > buffer.width) x1 = buffer.width;
+  if (y1 > buffer.height) y1 = buffer.height;
+  if (x1 <= x0 || y1 <= y0)
+    {
+      ANativeWindow_unlockAndPost(_window);
+      return;
+    }
+
+  /* Everything the window says has to be written is written: the window's own
+   * pixels where it covers, and black where it does not.  Leaving the rest
+   * alone would show whichever frame this buffer last held. */
+  for (y = y0; y < y1; y++)
+    {
+      int	 sy = y - offsetY;
+      uint32_t	*s = (sy >= 0 && sy < sh)
+	? (uint32_t *)(src + (size_t)sy * srcStride) : NULL;
+      uint32_t	*d = (uint32_t *)((unsigned char *)buffer.bits
+				  + (size_t)y * buffer.stride * 4);
+
+      for (x = x0; x < x1; x++)
+	{
+	  int sx = x - offsetX;
+
+	  if (s != NULL && sx >= 0 && sx < sw)
+	    {
+	      uint32_t p = s[sx];
+	      uint32_t a = (p >> 24) & 0xff;
+	      uint32_t r = (p >> 16) & 0xff;
+	      uint32_t g = (p >> 8) & 0xff;
+	      uint32_t b = p & 0xff;
+
+	      d[x] = (a << 24) | (b << 16) | (g << 8) | r;
+	    }
+	  else
+	    {
+	      d[x] = 0xff000000;
+	    }
+	}
+    }
+
+  ANativeWindow_unlockAndPost(_window);
+}
+
+/* An expose asks for what is already drawn to be shown again, so it posts the
+ * rect it names.  With no window there is nothing to post: the image surface
+ * is already the destination. */
+- (void) handleExposeRect: (NSRect)rect
+{
+  [self _postRect: rect];
+}
+
+/* A flush is a request for everything held back to reach the destination, so
+ * it posts the whole surface.  A caller that knows the damaged rectangle calls
+ * -handleExposeRect: instead and must not call both, or the window is posted
+ * twice for one drawing operation. */
+- (void) flush
+{
+  NSSize size = [self size];
+
+  [super flush];
+  [self _postRect: NSMakeRect(0, 0, size.width, size.height)];
+}
+
+- (BOOL) isDrawingToScreen
+{
+  return (_window != NULL) ? YES : NO;
+}
+
+@end

--- a/Source/cairo/CairoContext.m
+++ b/Source/cairo/CairoContext.m
@@ -79,6 +79,12 @@
 #  include "cairo/WaylandCairoShmSurface.h"
 #  define _CAIRO_GSTATE_CLASSNAME CairoGState
 #  define _CAIRO_SURFACE_CLASSNAME WaylandCairoShmSurface
+#elif BUILD_SERVER == SERVER_android
+#  include "android/AndroidServer.h"
+#  include "cairo/CairoGState.h"
+#  include "cairo/AndroidCairoSurface.h"
+#  define _CAIRO_GSTATE_CLASSNAME CairoGState
+#  define _CAIRO_SURFACE_CLASSNAME AndroidCairoSurface
 #else
 #  error Invalid server for Cairo backend : non implemented
 #endif /* BUILD_SERVER */

--- a/Source/cairo/GNUmakefile
+++ b/Source/cairo/GNUmakefile
@@ -45,24 +45,38 @@ cairo_OBJC_FILES = CairoSurface.m \
   ../fontconfig/FCFontAssetInstaller.m \
 
 
+# The window surface is chosen by the display server, because a surface is that
+# server's window seen as something cairo can draw into.  Each server names its
+# own, and a server with no branch here compiles no window surface at all --
+# which is the right answer for a server that has no window to draw into, and is
+# what lets a new server be added without touching the others.
+#
+# This subproject is reached only when the graphics backend is cairo, since
+# Source/GNUmakefile puts $(BUILD_GRAPHICS) in SUBPROJECTS, so the graphics
+# backend is not tested again in each branch.
+
 ifeq ($(BUILD_SERVER),x11)
   ifeq ($(WITH_GLITZ),yes)
     cairo_OBJC_FILES += XGCairoGlitzSurface.m
   else
     cairo_OBJC_FILES += XGCairoSurface.m XGCairoXImageSurface.m XGCairoModernSurface.m
   endif
-else
-  ifeq ($(BUILD_SERVER),wayland)
-    cairo_OBJC_FILES += WaylandCairoShmSurface.m
+endif
+
+ifeq ($(BUILD_SERVER),wayland)
+  cairo_OBJC_FILES += WaylandCairoShmSurface.m
+endif
+
+ifeq ($(BUILD_SERVER),android)
+  cairo_OBJC_FILES += AndroidCairoSurface.m
+endif
+
+ifeq ($(BUILD_SERVER),win32)
+  ifeq ($(WITH_GLITZ),yes)
+    cairo_OBJC_FILES += Win32CairoGlitzSurface.m
   else
-    ifeq ($(BUILD_GRAPHICS),cairo)
-      ifeq ($(WITH_GLITZ),yes)
-        cairo_OBJC_FILES += Win32CairoGlitzSurface.m
-      else
-        cairo_OBJC_FILES += Win32CairoSurface.m Win32CairoGState.m
-        # Win32CairoXImageSurface.m 
-      endif
-    endif
+    cairo_OBJC_FILES += Win32CairoSurface.m Win32CairoGState.m
+    # Win32CairoXImageSurface.m
   endif
 endif
 

--- a/Tests/cairo/GNUmakefile.preamble
+++ b/Tests/cairo/GNUmakefile.preamble
@@ -37,3 +37,21 @@ ifeq ($(WITH_EGL),yes)
 wlglcontext_TOOL_LIBS += -lGL
 endif
 endif
+
+# The android surface test compiles the android+cairo surface source in
+# directly, the same way, so its headers and libraries are added only for that
+# backend; a source-level guard keeps it inert elsewhere.
+ifeq ($(BUILD_SERVER)-$(BUILD_GRAPHICS),android-cairo)
+ADDITIONAL_INCLUDE_DIRS += -I$(GNUSTEP_BUILD_DIR)/../../Headers \
+                           -I$(GNUSTEP_BUILD_DIR)/../../Source \
+                           -I../../Headers -I../../Source \
+                           $(shell pkg-config --cflags cairo)
+
+# The surface posts through ANativeWindow, so a test that compiles it in links
+# libandroid as well as cairo.
+ADDITIONAL_TOOL_LIBS += $(shell pkg-config --libs cairo) -landroid
+
+# The post test needs a window to post into, and AImageReader supplies one
+# without an activity.  It is the only test that needs libmediandk.
+androidpost_TOOL_LIBS += -lmediandk
+endif

--- a/Tests/cairo/androidpost.m
+++ b/Tests/cairo/androidpost.m
@@ -1,0 +1,226 @@
+/* The android surface posts what was drawn into the window bound to it.
+ *
+ * AImageReader hands out a real ANativeWindow without an activity, so the whole
+ * lock, blit and post path runs here and the posted pixels are read back and
+ * asserted.  The figure is opaque red rather than a grey: cairo's ARGB32 is a
+ * native-endian word, so its bytes are B, G, R, A, while the window's
+ * RGBA_8888 is R, G, B, A.  A blit that copies without swizzling passes on any
+ * colour whose red and blue are equal.
+ */
+#import <Foundation/Foundation.h>
+#import "Testing.h"
+#include "config.h"
+
+#if defined(BUILD_SERVER) && defined(SERVER_android) \
+  && defined(BUILD_GRAPHICS) && defined(GRAPHICS_cairo) \
+  && BUILD_SERVER == SERVER_android && BUILD_GRAPHICS == GRAPHICS_cairo
+
+#import <AppKit/AppKit.h>
+#include <android/native_window.h>
+#include <media/NdkImage.h>
+#include <media/NdkImageReader.h>
+#include <cairo.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "android/AndroidServer.h"
+
+/* The surface class lives in the backend bundle, which is dlopened when the
+ * application starts, so it is named here rather than linked: a class literal
+ * would leave _OBJC_REF_CLASS_AndroidCairoSurface undefined at link time.  The
+ * selectors are declared for the same reason. */
+@interface NSObject (AndroidPostTest)
+- (id) initWithDevice: (void *)device;
+- (void) setNativeWindow: (ANativeWindow *)window;
+- (ANativeWindow *) nativeWindow;
+- (cairo_surface_t *) surface;
+- (BOOL) isDrawingToScreen;
+- (void) flush;
+@end
+
+#define W 32
+#define H 16
+
+int
+main(void)
+{
+  START_SET("android post")
+  NSAutoreleasePool	*arp = [NSAutoreleasePool new];
+  AImageReader		*reader = NULL;
+  ANativeWindow		*window = NULL;
+  AImage		*image = NULL;
+  Class			 surfaceClass;
+  id			 surface;
+  struct AndroidWindow	 record;
+  struct AndroidWindow	*record2;
+  cairo_t		*cr;
+  uint8_t		*plane = NULL;
+  int			 planeLen = 0, rowStride = 0, pixelStride = 0;
+
+  /* Starting the application loads the backend bundle, which is where the
+   * surface class comes from. */
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      SKIP("the application would not start")
+    }
+  NS_ENDHANDLER
+
+  surfaceClass = NSClassFromString(@"AndroidCairoSurface");
+  PASS(surfaceClass != Nil, "the backend bundle carries AndroidCairoSurface");
+  if (surfaceClass == Nil)
+    {
+      SKIP("no surface class, the rest cannot be checked")
+    }
+
+  if (AImageReader_new(W, H, AIMAGE_FORMAT_RGBA_8888, 2, &reader) != AMEDIA_OK
+      || AImageReader_getWindow(reader, &window) != AMEDIA_OK
+      || window == NULL)
+    {
+      SKIP("no AImageReader window on this device")
+    }
+
+  memset(&record, 0, sizeof(record));
+  record.window_id = 1;
+  record.frame = NSMakeRect(0, 0, W, H);
+
+  surface = [[surfaceClass alloc] initWithDevice: &record];
+  PASS(surface != nil, "a surface is made for the window record");
+
+  [surface setNativeWindow: window];
+  PASS([surface nativeWindow] == window, "the native window reads back");
+  PASS([surface isDrawingToScreen] == YES,
+       "a surface with a window bound is drawing to screen");
+
+  /* Opaque red over the whole surface, through cairo directly: what is under
+   * test here is the post, not AppKit's route to it. */
+  cr = cairo_create([surface surface]);
+  cairo_set_source_rgba(cr, 1.0, 0.0, 0.0, 1.0);
+  cairo_paint(cr);
+  cairo_destroy(cr);
+
+  [surface flush];
+
+  PASS(AImageReader_acquireNextImage(reader, &image) == AMEDIA_OK
+       && image != NULL,
+       "the post produced an image in the reader");
+  if (image == NULL)
+    {
+      AImageReader_delete(reader);
+      SKIP("nothing was posted, the rest cannot be checked")
+    }
+
+  AImage_getPlaneRowStride(image, 0, &rowStride);
+  AImage_getPlanePixelStride(image, 0, &pixelStride);
+  AImage_getPlaneData(image, 0, &plane, &planeLen);
+  PASS(plane != NULL && planeLen > 0, "the image has pixels");
+  PASS(pixelStride == 4, "the plane is 4 bytes per pixel");
+
+  /* R, G, B, A in memory: red is 255, 0, 0, 255.  A blit that copied cairo's
+   * B, G, R, A would answer 0, 0, 255, 255 here. */
+  PASS(plane[0] == 255, "the red channel of the first pixel is 255");
+  PASS(plane[1] == 0, "the green channel is 0");
+  PASS(plane[2] == 0, "the blue channel is 0");
+  PASS(plane[3] == 255, "the alpha channel is 255");
+
+  /* A pixel on the last row, reached through the image's own stride rather
+   * than one computed from the width. */
+  PASS(plane[(H - 1) * rowStride] == 255, "the last row was posted too");
+
+  AImage_delete(image);
+  image = NULL;
+  DESTROY(surface);
+
+  /* The same path, reached the way AppKit reaches it: through the server, by
+   * window id, with the rect in the window's own coordinates. */
+  {
+    AndroidServer *server = nil;
+    int		   win;
+
+    NS_DURING
+      {
+	server = (AndroidServer *)GSCurrentServer();
+      }
+    NS_HANDLER
+      {
+	server = nil;
+      }
+    NS_ENDHANDLER
+
+    if (server == nil)
+      {
+	AImageReader_delete(reader);
+	SKIP("no display server, the binding cannot be checked")
+      }
+
+    win = [server window: NSMakeRect(0, 0, W, H) : NSBackingStoreBuffered
+			: NSBorderlessWindowMask : 0];
+    PASS(win > 0, "the server makes a window");
+
+    [server setNativeWindow: window forWindow: win];
+    PASS([server nativeWindowForWindow: win] == window,
+	 "the native window reads back from the server");
+
+    /* The screen is the activity's surface, not a window's: an activity is
+     * given one surface and every window is written into it. */
+    [server setActivityWindow: window];
+    PASS(NSEqualRects([server boundsForScreen: 0], NSMakeRect(0, 0, W, H)),
+	 "the screen bounds come from the activity's surface");
+
+    /* Give the window a surface and paint it green, then post through the
+     * server rather than through the surface.  The record is reached with
+     * -_windowWithId:, which the server already declares, rather than by
+     * inventing an accessor for the test. */
+    /* Only a window that is on screen is written into the activity's surface,
+     * so this one is ordered in before it is posted. */
+    [server orderwindow: NSWindowAbove : 0 : win];
+    [server setWindowdevice: win forContext: GSCurrentContext()];
+    record2 = [server _windowWithId: win];
+    PASS(record2 != NULL && record2->surface != nil,
+	 "the server gave the window a surface");
+    if (record2 == NULL || record2->surface == nil)
+      {
+	AImageReader_delete(reader);
+	SKIP("no surface for the window, the post cannot be checked")
+      }
+    cr = cairo_create([record2->surface surface]);
+    cairo_set_source_rgba(cr, 0.0, 1.0, 0.0, 1.0);
+    cairo_paint(cr);
+    cairo_destroy(cr);
+
+    [server flushwindowrect: NSMakeRect(0, 0, W, H) : win];
+
+    PASS(AImageReader_acquireNextImage(reader, &image) == AMEDIA_OK
+	 && image != NULL,
+	 "flushwindowrect:: posted through the server");
+    if (image != NULL)
+      {
+	AImage_getPlaneData(image, 0, &plane, &planeLen);
+	PASS(plane[0] == 0, "the red channel is 0 after the green paint");
+	PASS(plane[1] == 255, "the green channel is 255");
+	PASS(plane[2] == 0, "the blue channel is 0");
+	AImage_delete(image);
+      }
+  }
+
+  AImageReader_delete(reader);
+  [arp release];
+  END_SET("android post")
+  return 0;
+}
+
+#else
+
+int
+main(void)
+{
+  START_SET("android post")
+  SKIP("not an android server with cairo graphics")
+  END_SET("android post")
+  return 0;
+}
+
+#endif

--- a/Tests/cairo/androidrebind.m
+++ b/Tests/cairo/androidrebind.m
@@ -1,0 +1,120 @@
+/* The activity's surface goes back to a window that is still on screen when
+ * the window holding it is taken off.
+ *
+ * An activity is given one surface, so the server binds it to one window and
+ * takes it away again as windows are ordered in and out.  A panel ordered in
+ * takes the surface from the window under it; when the panel closes there is
+ * still a window on screen, and it has to be given the surface back.  Without
+ * that the activity keeps a surface nothing draws into and the screen stays as
+ * it was when the panel closed.
+ *
+ * AImageReader hands out a real ANativeWindow without an activity, so the
+ * binding runs here with no activity to drive it.
+ */
+#import <Foundation/Foundation.h>
+#import "Testing.h"
+#include "config.h"
+
+#if defined(BUILD_SERVER) && defined(SERVER_android) \
+  && defined(BUILD_GRAPHICS) && defined(GRAPHICS_cairo) \
+  && BUILD_SERVER == SERVER_android && BUILD_GRAPHICS == GRAPHICS_cairo
+
+#import <AppKit/AppKit.h>
+#import <GNUstepGUI/GSDisplayServer.h>
+#include <android/native_window.h>
+#include <media/NdkImageReader.h>
+
+/* The server class lives in the backend bundle, which is dlopened when the
+ * application starts, so the selectors are declared rather than the class
+ * named: a class literal would leave the reference undefined at link time.
+ */
+@interface NSObject (AndroidRebindTest)
+- (void) setActivityWindow: (ANativeWindow *)native;
+- (int) windowBoundToActivity;
+@end
+
+#define W 32
+#define H 16
+
+int
+main(void)
+{
+  START_SET("android rebind")
+  NSAutoreleasePool	*arp = [NSAutoreleasePool new];
+  AImageReader		*reader = NULL;
+  ANativeWindow		*window = NULL;
+  GSDisplayServer	*server;
+  int			 lower, upper;
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      SKIP("the application would not start")
+    }
+  NS_ENDHANDLER
+
+  server = GSCurrentServer();
+  if (NO == [server respondsToSelector: @selector(windowBoundToActivity)])
+    {
+      SKIP("not the android server")
+    }
+
+  if (AImageReader_new(W, H, AIMAGE_FORMAT_RGBA_8888, 4, &reader) != AMEDIA_OK
+      || AImageReader_getWindow(reader, &window) != AMEDIA_OK
+      || window == NULL)
+    {
+      SKIP("no AImageReader window on this device")
+    }
+
+  [server setActivityWindow: window];
+
+  lower = [server window: NSMakeRect(0, 0, W, H)
+			: NSBackingStoreBuffered
+			: 8
+			: 0];
+  [server stylewindow: NSTitledWindowMask : lower];
+  [server orderwindow: NSWindowAbove : 0 : lower];
+  PASS([server windowBoundToActivity] == lower,
+    "the first window on screen is given the activity's surface");
+
+  upper = [server window: NSMakeRect(0, 0, W, H)
+			: NSBackingStoreBuffered
+			: 8
+			: 0];
+  [server stylewindow: NSTitledWindowMask : upper];
+  [server orderwindow: NSWindowAbove : 0 : upper];
+  PASS([server windowBoundToActivity] == upper,
+    "a window ordered in over it takes the surface");
+
+  [server orderwindow: NSWindowOut : 0 : upper];
+  PASS([server windowBoundToActivity] == lower,
+    "taking that window off gives the surface back to the one still on screen");
+
+  [server orderwindow: NSWindowOut : 0 : lower];
+  PASS([server windowBoundToActivity] == 0,
+    "with no window on screen the surface is bound to none");
+
+  [server termwindow: upper];
+  [server termwindow: lower];
+  [server setActivityWindow: NULL];
+  AImageReader_delete(reader);
+  [arp release];
+  END_SET("android rebind")
+  return 0;
+}
+
+#else
+
+int
+main(void)
+{
+  START_SET("android rebind")
+  SKIP("not an android server with cairo graphics")
+  END_SET("android rebind")
+  return 0;
+}
+
+#endif

--- a/Tests/cairo/androidrender.m
+++ b/Tests/cairo/androidrender.m
@@ -1,0 +1,131 @@
+/* Drawing through AppKit reaches the android backend's image surface.
+ *
+ * A window is made, its device is set, rectangles are filled through AppKit, and
+ * the pixels are read back out of the cairo image surface the backend drew into.
+ *
+ * The figures are axis-aligned and unantialiased, so the expected values are
+ * exact.  ARGB32 is premultiplied and in native byte order, so opaque black is
+ * 0xff000000 and opaque white is 0xffffffff.
+ */
+#import <Foundation/Foundation.h>
+#import "Testing.h"
+#include "config.h"
+
+#if defined(BUILD_SERVER) && defined(SERVER_android) \
+  && defined(BUILD_GRAPHICS) && defined(GRAPHICS_cairo) \
+  && BUILD_SERVER == SERVER_android && BUILD_GRAPHICS == GRAPHICS_cairo
+
+#import <AppKit/AppKit.h>
+#import <GNUstepGUI/GSDisplayServer.h>
+#include <cairo.h>
+#include <stdint.h>
+
+#include "android/AndroidServer.h"
+#include "cairo/CairoSurface.h"
+
+/* The pixel at (x, y) in cairo's own coordinates: y counts down from the top
+ * of the surface, which is the opposite of the AppKit rect used to draw. */
+static uint32_t
+pixelAt(cairo_surface_t *s, int x, int y)
+{
+  unsigned char *data = cairo_image_surface_get_data(s);
+  int		 stride = cairo_image_surface_get_stride(s);
+
+  return *(uint32_t *)(data + y * stride + x * 4);
+}
+
+int
+main(void)
+{
+  START_SET("android rendering")
+  NSAutoreleasePool	*arp = [NSAutoreleasePool new];
+  GSDisplayServer	*server = nil;
+  NSWindow		*window;
+  struct AndroidWindow	*record;
+  cairo_surface_t	*cs = NULL;
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+      server = GSCurrentServer();
+    }
+  NS_HANDLER
+    {
+      server = nil;
+    }
+  NS_ENDHANDLER
+
+  if (nil == server)
+    {
+      SKIP("no display server available")
+    }
+
+  window = [[NSWindow alloc]
+	     initWithContentRect: NSMakeRect(0, 0, 20, 10)
+		       styleMask: NSBorderlessWindowMask
+			 backing: NSBackingStoreBuffered
+			   defer: NO];
+  PASS([window windowNumber] > 0, "the server made a window")
+
+  [window orderFront: nil];
+  [[window contentView] lockFocus];
+  [[NSColor blackColor] set];
+  NSRectFill(NSMakeRect(0, 0, 20, 10));
+  [[NSColor whiteColor] set];
+  NSRectFill(NSMakeRect(4, 2, 6, 3));
+  [[window contentView] unlockFocus];
+  [window flushWindow];
+
+  record = (struct AndroidWindow *)
+    [server windowDevice: [window windowNumber]];
+  PASS(record != NULL, "the server hands out a device for the window")
+  PASS(record != NULL && record->surface != nil,
+    "setting the window device attached a cairo surface")
+
+  if (record != NULL && record->surface != nil)
+    {
+      cs = [record->surface surface];
+    }
+  PASS(cs != NULL && cairo_surface_status(cs) == CAIRO_STATUS_SUCCESS,
+    "the attached surface is in a good state")
+
+  if (cs != NULL)
+    {
+      cairo_surface_flush(cs);
+
+      /* The white rect covers AppKit x 4..9, y 2..4.  cairo's y counts from
+       * the top of a 10-high surface, so those are cairo rows 5..7. */
+      PASS(pixelAt(cs, 0, 0) == 0xff000000u,
+        "the corner outside the white rect is opaque black")
+      PASS(pixelAt(cs, 4, 5) == 0xffffffffu,
+        "the first pixel of the white rect is opaque white")
+      PASS(pixelAt(cs, 9, 7) == 0xffffffffu,
+        "the last pixel of the white rect is opaque white")
+      PASS(pixelAt(cs, 3, 5) == 0xff000000u,
+        "the pixel one column left of the white rect is still black")
+      PASS(pixelAt(cs, 10, 7) == 0xff000000u,
+        "the pixel one column right of the white rect is still black")
+      PASS(pixelAt(cs, 4, 4) == 0xff000000u,
+        "the pixel one row above the white rect is still black")
+      PASS(pixelAt(cs, 4, 8) == 0xff000000u,
+        "the pixel one row below the white rect is still black")
+    }
+
+  [window release];
+  [arp release];
+  END_SET("android rendering")
+  return 0;
+}
+
+#else
+
+int
+main(void)
+{
+  START_SET("android rendering")
+    SKIP("back is not built with the android+cairo backend")
+  END_SET("android rendering")
+  return 0;
+}
+
+#endif

--- a/Tests/cairo/androidrepaint.m
+++ b/Tests/cairo/androidrepaint.m
@@ -1,0 +1,192 @@
+/* Posting part of the surface leaves the rest of the window showing the
+ * current frame, not an older one.
+ *
+ * A window hands out one of several buffers in turn, so the buffer locked for
+ * a post holds whatever was drawn into it some frames ago rather than what was
+ * posted last.  A post that copies only the rectangle that changed therefore
+ * has to copy into a buffer whose other pixels are stale, and the window is
+ * asked how much has to be written.
+ *
+ * The first image is held while the second post is made, which is what forces
+ * the second post onto a different buffer.  Releasing it first hands the same
+ * buffer straight back, the stale pixels are the ones just posted, and the
+ * test passes whether the code is right or not.
+ */
+#import <Foundation/Foundation.h>
+#import "Testing.h"
+#include "config.h"
+
+#if defined(BUILD_SERVER) && defined(SERVER_android) \
+  && defined(BUILD_GRAPHICS) && defined(GRAPHICS_cairo) \
+  && BUILD_SERVER == SERVER_android && BUILD_GRAPHICS == GRAPHICS_cairo
+
+#import <AppKit/AppKit.h>
+#include <android/native_window.h>
+#include <media/NdkImage.h>
+#include <media/NdkImageReader.h>
+#include <cairo.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "android/AndroidServer.h"
+
+@interface NSObject (AndroidRepaintTest)
+- (id) initWithDevice: (void *)device;
+- (void) setNativeWindow: (ANativeWindow *)window;
+- (cairo_surface_t *) surface;
+- (void) flush;
+- (void) handleExposeRect: (NSRect)rect;
+@end
+
+#define W 32
+#define H 16
+
+/* Paint the whole surface one colour, through cairo directly: what is under
+ * test is the post, not AppKit's route to it. */
+static void
+paint_all(id surface, double r, double g, double b)
+{
+  cairo_t *cr = cairo_create([surface surface]);
+
+  cairo_set_source_rgba(cr, r, g, b, 1.0);
+  cairo_paint(cr);
+  cairo_destroy(cr);
+}
+
+static void
+paint_rect(id surface, double r, double g, double b, NSRect rect)
+{
+  cairo_t *cr = cairo_create([surface surface]);
+
+  cairo_set_source_rgba(cr, r, g, b, 1.0);
+  cairo_rectangle(cr, NSMinX(rect), NSMinY(rect),
+    NSWidth(rect), NSHeight(rect));
+  cairo_fill(cr);
+  cairo_destroy(cr);
+}
+
+int
+main(void)
+{
+  START_SET("android repaint")
+  NSAutoreleasePool	*arp = [NSAutoreleasePool new];
+  AImageReader		*reader = NULL;
+  ANativeWindow		*window = NULL;
+  AImage		*image = NULL;
+  AImage		*first = NULL;
+  Class			 surfaceClass;
+  id			 surface;
+  struct AndroidWindow	 record;
+  uint8_t		*plane = NULL;
+  int			 planeLen = 0, rowStride = 0, pixelStride = 0;
+
+  NS_DURING
+    {
+      [NSApplication sharedApplication];
+    }
+  NS_HANDLER
+    {
+      SKIP("the application would not start")
+    }
+  NS_ENDHANDLER
+
+  surfaceClass = NSClassFromString(@"AndroidCairoSurface");
+  PASS(surfaceClass != Nil, "the backend bundle carries AndroidCairoSurface");
+  if (surfaceClass == Nil)
+    {
+      SKIP("no surface class, the rest cannot be checked")
+    }
+
+  /* Room for more than one image at a time, so the first can be held while
+   * the second is posted and the producer still has a buffer to write into. */
+  if (AImageReader_new(W, H, AIMAGE_FORMAT_RGBA_8888, 4, &reader) != AMEDIA_OK
+      || AImageReader_getWindow(reader, &window) != AMEDIA_OK
+      || window == NULL)
+    {
+      SKIP("no AImageReader window on this device")
+    }
+
+  memset(&record, 0, sizeof(record));
+  record.window_id = 1;
+  record.frame = NSMakeRect(0, 0, W, H);
+
+  surface = [[surfaceClass alloc] initWithDevice: &record];
+  PASS(surface != nil, "a surface is made for the window record");
+  [surface setNativeWindow: window];
+
+  /* The first frame: red everywhere. */
+  paint_all(surface, 1.0, 0.0, 0.0);
+  [surface flush];
+
+  PASS(AImageReader_acquireNextImage(reader, &image) == AMEDIA_OK
+       && image != NULL,
+       "the first post produced an image");
+  if (image == NULL)
+    {
+      AImageReader_delete(reader);
+      SKIP("nothing was posted, the rest cannot be checked")
+    }
+  AImage_getPlaneRowStride(image, 0, &rowStride);
+  AImage_getPlanePixelStride(image, 0, &pixelStride);
+  AImage_getPlaneData(image, 0, &plane, &planeLen);
+  PASS(pixelStride == 4 && plane != NULL, "the first image has pixels");
+  PASS(plane[(H - 1) * rowStride] == 255,
+       "the first post reached the last row");
+  /* Held, not released: the next post must go to another buffer. */
+  first = image;
+  image = NULL;
+
+  /* The second frame changes four pixels in the top left corner and posts only
+   * those.  Everything else must still be the red of the frame before. */
+  paint_rect(surface, 0.0, 0.0, 1.0, NSMakeRect(0, 0, 4, 4));
+  [surface handleExposeRect: NSMakeRect(0, 0, 4, 4)];
+
+  PASS(AImageReader_acquireNextImage(reader, &image) == AMEDIA_OK
+       && image != NULL,
+       "the partial post produced an image");
+  if (image == NULL)
+    {
+      AImageReader_delete(reader);
+      SKIP("nothing was posted the second time")
+    }
+  AImage_getPlaneRowStride(image, 0, &rowStride);
+  AImage_getPlaneData(image, 0, &plane, &planeLen);
+
+  /* The damage itself. */
+  PASS(plane[2] == 255 && plane[0] == 0,
+       "the rectangle that changed was posted blue");
+
+  /* Away from the damage, in the same image.  This is the assertion the whole
+   * file exists for: a post that wrote only the damaged rectangle leaves these
+   * pixels holding whatever the buffer held before it was handed back. */
+  PASS(plane[(H - 1) * rowStride] == 255,
+       "the last row still holds the red of the current frame");
+  PASS(plane[(H - 1) * rowStride + 2] == 0,
+       "and it is red rather than the blue of the damage");
+  PASS(plane[8 * rowStride + 16 * 4] == 255,
+       "a pixel in the middle still holds the current frame");
+
+  AImage_delete(image);
+  if (first != NULL)
+    {
+      AImage_delete(first);
+    }
+  AImageReader_delete(reader);
+  DESTROY(surface);
+  [arp release];
+  END_SET("android repaint")
+  return 0;
+}
+
+#else
+
+int
+main(void)
+{
+  START_SET("android repaint")
+  SKIP("this test is for the android server with cairo graphics")
+  END_SET("android repaint")
+  return 0;
+}
+
+#endif

--- a/Tests/cairo/androidsurface.m
+++ b/Tests/cairo/androidsurface.m
@@ -1,0 +1,128 @@
+/* AndroidCairoSurface, checked directly.
+ *
+ * The real source file is compiled in, with a small CairoSurface stand-in, as
+ * Tests/cairo/shmbuffer.m does for the wayland surface, so this needs no
+ * gui-linked back bundle and no display server.
+ *
+ * A backend test can only build against the backend it belongs to, so it guards
+ * on config.h's BUILD_SERVER and BUILD_GRAPHICS and skips everywhere else.  The
+ * matching GNUmakefile.preamble adds cairo's headers and libraries under the
+ * same condition.
+ */
+#import <Foundation/Foundation.h>
+#import "Testing.h"
+#include "config.h"
+
+#if defined(BUILD_SERVER) && defined(SERVER_android) \
+  && defined(BUILD_GRAPHICS) && defined(GRAPHICS_cairo) \
+  && BUILD_SERVER == SERVER_android && BUILD_GRAPHICS == GRAPHICS_cairo
+
+#include <string.h>
+#include <stdint.h>
+
+#include "cairo/CairoSurface.h"
+#include "android/AndroidServer.h"
+
+/* Minimal stand-in for CairoSurface (the real one lives in CairoSurface.m). */
+@implementation CairoSurface
+- (id) initWithDevice: (void *)device { gsDevice = device; return self; }
+- (void) dealloc
+{
+  if (_surface != NULL) { cairo_surface_destroy(_surface); }
+  [super dealloc];
+}
+- (NSSize) size { return NSMakeSize(0, 0); }
+- (void) setSize: (NSSize)newSize { (void)newSize; }
+- (cairo_surface_t *) surface { return _surface; }
+- (void) handleExposeRect: (NSRect)rect { (void)rect; }
+- (void) flush { }
+- (BOOL) isDrawingToScreen { return YES; }
+@end
+
+#include "cairo/AndroidCairoSurface.m"
+
+int
+main(void)
+{
+  START_SET("AndroidCairoSurface")
+  NSAutoreleasePool	*arp = [NSAutoreleasePool new];
+  struct AndroidWindow	 win;
+  AndroidCairoSurface	*s;
+  cairo_surface_t	*cs;
+  cairo_t		*cr;
+  uint32_t		*data;
+
+  memset(&win, 0, sizeof(win));
+  win.window_id = 7;
+  win.frame = NSMakeRect(0, 0, 40, 30);
+
+  s = [[AndroidCairoSurface alloc] initWithDevice: &win];
+  PASS(s != nil, "a surface is created for a window with a non-empty frame")
+
+  cs = [s surface];
+  PASS(cs != NULL && cairo_surface_status(cs) == CAIRO_STATUS_SUCCESS,
+    "the cairo surface is created without error")
+  PASS(cs != NULL && cairo_surface_get_type(cs) == CAIRO_SURFACE_TYPE_IMAGE,
+    "the surface is an image surface, which needs no window system")
+  PASS(cs != NULL && cairo_image_surface_get_format(cs) == CAIRO_FORMAT_ARGB32,
+    "the surface format is ARGB32")
+  PASS_EQUAL([NSValue valueWithSize: [s size]],
+             [NSValue valueWithSize: NSMakeSize(40, 30)],
+    "the surface size is the window frame size")
+  PASS(cs != NULL && cairo_image_surface_get_stride(cs)
+         == cairo_format_stride_for_width(CAIRO_FORMAT_ARGB32, 40),
+    "the stride is the one cairo asks for, not width times four")
+  PASS([s isDrawingToScreen] == NO,
+    "an offscreen surface says it is not drawing to screen")
+  PASS(win.surface == (CairoSurface *)s,
+    "the window record points back at its surface")
+
+  /* Painting has to reach the data the surface owns; a surface that is created
+   * but never written to would pass every check above. */
+  if (cs != NULL)
+    {
+      cr = cairo_create(cs);
+      cairo_set_operator(cr, CAIRO_OPERATOR_SOURCE);
+      cairo_set_source_rgba(cr, 0.0, 0.0, 1.0, 1.0);
+      cairo_paint(cr);
+      cairo_destroy(cr);
+      cairo_surface_flush(cs);
+      data = (uint32_t *)cairo_image_surface_get_data(cs);
+      PASS(data != NULL && data[0] == 0xff0000ffu,
+        "painting opaque blue leaves 0xff0000ff in the first pixel")
+    }
+
+  [s setSize: NSMakeSize(11, 5)];
+  cs = [s surface];
+  PASS(cs != NULL && cairo_image_surface_get_width(cs) == 11
+       && cairo_image_surface_get_height(cs) == 5,
+    "setSize: reallocates the surface at the new size")
+  PASS_EQUAL([NSValue valueWithSize: [s size]],
+             [NSValue valueWithSize: NSMakeSize(11, 5)],
+    "size reports the new size after setSize:")
+
+  [s release];
+
+  memset(&win, 0, sizeof(win));
+  win.window_id = 8;
+  win.frame = NSMakeRect(0, 0, 0, 0);
+  s = [[AndroidCairoSurface alloc] initWithDevice: &win];
+  PASS(s == nil, "a zero-area window produces no surface")
+
+  [arp release];
+  END_SET("AndroidCairoSurface")
+  return 0;
+}
+
+#else
+
+int
+main(void)
+{
+  START_SET("AndroidCairoSurface")
+    SKIP("back is not built with the android+cairo backend")
+  END_SET("AndroidCairoSurface")
+  return 0;
+}
+
+#endif

--- a/config.h.in
+++ b/config.h.in
@@ -5,6 +5,7 @@
 #define SERVER_win32      2
 #define SERVER_wayland    3
 #define SERVER_headless   4
+#define SERVER_android    5
 #define GRAPHICS_xdps     0
 #define GRAPHICS_art      1
 #define GRAPHICS_xlib     2
@@ -29,6 +30,9 @@
 /* Define to 1 if you have the <DPS/dpsNXargs.h> header file. */
 #undef HAVE_DPS_DPSNXARGS_H
 
+/* Define if EGL is available for Wayland OpenGL support */
+#undef HAVE_EGL
+
 /* Define if you have FcPatternCreate */
 #undef HAVE_FC
 
@@ -41,31 +45,28 @@
 /* Define if you have the glx library */
 #undef HAVE_GLX
 
-/* Define if EGL is available for Wayland OpenGL support */
-#undef HAVE_EGL
-
 /* Define to 1 if you have the <inttypes.h> header file. */
 #undef HAVE_INTTYPES_H
 
-/* Define to 1 if you have the `wayland-client' library (-lwayland-client). */
+/* Define to 1 if you have the 'wayland-client' library (-lwayland-client). */
 #undef HAVE_LIBWAYLAND_CLIENT
 
-/* Define to 1 if you have the `Xext' library (-lXext). */
+/* Define to 1 if you have the 'Xext' library (-lXext). */
 #undef HAVE_LIBXEXT
 
-/* Define to 1 if you have the `Xft' library (-lXft). */
+/* Define to 1 if you have the 'Xft' library (-lXft). */
 #undef HAVE_LIBXFT
 
-/* Define to 1 if you have the `xkbcommon' library (-lxkbcommon). */
+/* Define to 1 if you have the 'xkbcommon' library (-lxkbcommon). */
 #undef HAVE_LIBXKBCOMMON
 
-/* Define to 1 if you have the `Xmu' library (-lXmu). */
+/* Define to 1 if you have the 'Xmu' library (-lXmu). */
 #undef HAVE_LIBXMU
 
-/* Define to 1 if you have the `Xt' library (-lXt). */
+/* Define to 1 if you have the 'Xt' library (-lXt). */
 #undef HAVE_LIBXT
 
-/* Define to 1 if you have the `shmctl' function. */
+/* Define to 1 if you have the 'shmctl' function. */
 #undef HAVE_SHMCTL
 
 /* Define to 1 if you have the <stdint.h> header file. */
@@ -83,7 +84,7 @@
 /* Define to 1 if you have the <string.h> header file. */
 #undef HAVE_STRING_H
 
-/* Define to 1 if you have the `syslog' function. */
+/* Define to 1 if you have the 'syslog' function. */
 #undef HAVE_SYSLOG
 
 /* Define to 1 if you have the <syslog.h> header file. */
@@ -98,7 +99,7 @@
 /* Define to 1 if you have the <unistd.h> header file. */
 #undef HAVE_UNISTD_H
 
-/* Define to 1 if you have the `usleep' function. */
+/* Define to 1 if you have the 'usleep' function. */
 #undef HAVE_USLEEP
 
 /* Define if you have XftDrawStringUtf8 */
@@ -144,7 +145,7 @@
 /* Define to enable Xshape support */
 #undef HAVE_XSHAPE
 
-/* Define to 1 if you have the `Xutf8LookupString' function. */
+/* Define to 1 if you have the 'Xutf8LookupString' function. */
 #undef HAVE_XUTF8LOOKUPSTRING
 
 /* Define to the address where bug reports for this package should be sent. */
@@ -165,7 +166,7 @@
 /* Define to the version of this package. */
 #undef PACKAGE_VERSION
 
-/* Define to 1 if all of the C90 standard headers exist (not just the ones
+/* Define to 1 if all of the C89 standard headers exist (not just the ones
    required in a freestanding environment). This macro is provided for
    backward compatibility; new code need not use it. */
 #undef STDC_HEADERS

--- a/configure
+++ b/configure
@@ -515,29 +515,6 @@ as_cr_alnum=$as_cr_Letters$as_cr_digits
   exit
 }
 
-
-# Determine whether it's possible to make 'echo' print without a newline.
-# These variables are no longer used directly by Autoconf, but are AC_SUBSTed
-# for compatibility with existing Makefiles.
-ECHO_C= ECHO_N= ECHO_T=
-case `echo -n x` in #(((((
--n*)
-  case `echo 'xy\c'` in
-  *c*) ECHO_T='	';;	# ECHO_T is single tab character.
-  xy)  ECHO_C='\c';;
-  *)   echo `echo ksh88 bug on AIX 6.1` > /dev/null
-       ECHO_T='	';;
-  esac;;
-*)
-  ECHO_N='-n';;
-esac
-
-# For backward compatibility with old third-party macros, we provide
-# the shell variables $as_echo and $as_echo_n.  New code should use
-# AS_ECHO(["message"]) and AS_ECHO_N(["message"]), respectively.
-as_echo='printf %s\n'
-as_echo_n='printf %s'
-
 rm -f conf$$ conf$$.exe conf$$.file
 if test -d conf$$.dir; then
   rm -f conf$$.dir/conf$$.file
@@ -653,8 +630,8 @@ WARN_FLAGS
 BUILD_SERVER
 BUILD_GRAPHICS
 WITH_EGL
-WITH_WRASTER
 USE_WRASTER
+WITH_WRASTER
 WITH_GLITZ
 GLITZ_WGL_LIBS
 GLITZ_WGL_CFLAGS
@@ -764,6 +741,7 @@ enable_glx
 enable_xim
 enable_wgl
 enable_glitz
+enable_wraster
 enable_server
 enable_graphics
 with_name
@@ -1438,9 +1416,10 @@ Optional Features:
   --disable-xim           Disable XIM support
   --disable-wgl           Disable WGL support
   --enable-glitz          Enable Glitz support
-  --enable-server=SRV     Build server type: x11, win32, wayland, headless
+  --enable-wraster        use the wraster image code instead of the plain-Xlib
+                          layer (default: no)
+  --enable-server=SRV     Build server type: x11, win32, wayland, android, headless
   --enable-graphics=GPH   Build graphics: xlib, xdps, winlib, art, cairo, opal, headless
-  --enable-wraster        use the wraster image code instead of the plain-Xlib layer (default: no)
 
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
@@ -1622,7 +1601,7 @@ printf '%s\n' "$ac_try_echo"; } >&5
 then :
   ac_retval=0
 else case e in #(
-  e) printf "%s\n" "$as_me: failed program was:" >&5
+  e) printf '%s\n' "$as_me: failed program was:" >&5
 sed 's/^/| /' conftest.$ac_ext >&5
 
 	ac_retval=1 ;;
@@ -2108,8 +2087,8 @@ esac
 printf '%s\n' "$as_me: loading site script $ac_site_file" >&6;}
     sed 's/^/| /' "$ac_site_file" >&5
     . "$ac_site_file" \
-      || { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in '$ac_pwd':" >&5
-printf "%s\n" "$as_me: error: in '$ac_pwd':" >&2;}
+      || { { printf '%s\n' "$as_me:${as_lineno-$LINENO}: error: in '$ac_pwd':" >&5
+printf '%s\n' "$as_me: error: in '$ac_pwd':" >&2;}
 as_fn_error $? "failed to load site script $ac_site_file
 See 'config.log' for more details" "$LINENO" 5; }
   fi
@@ -2672,12 +2651,12 @@ for ac_var in $ac_precious_vars; do
   eval ac_new_val=\$ac_env_${ac_var}_value
   case $ac_old_set,$ac_new_set in
     set,)
-      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: '$ac_var' was set to '$ac_old_val' in the previous run" >&5
-printf "%s\n" "$as_me: error: '$ac_var' was set to '$ac_old_val' in the previous run" >&2;}
+      { printf '%s\n' "$as_me:${as_lineno-$LINENO}: error: '$ac_var' was set to '$ac_old_val' in the previous run" >&5
+printf '%s\n' "$as_me: error: '$ac_var' was set to '$ac_old_val' in the previous run" >&2;}
       ac_cache_corrupted=: ;;
     ,set)
-      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: '$ac_var' was not set in the previous run" >&5
-printf "%s\n" "$as_me: error: '$ac_var' was not set in the previous run" >&2;}
+      { printf '%s\n' "$as_me:${as_lineno-$LINENO}: error: '$ac_var' was not set in the previous run" >&5
+printf '%s\n' "$as_me: error: '$ac_var' was not set in the previous run" >&2;}
       ac_cache_corrupted=: ;;
     ,);;
     *)
@@ -2692,18 +2671,18 @@ printf "%s\n" "$as_me: error: '$ac_var' was not set in the previous run" >&2;}
 	  ac_new_val_w="$ac_new_val_w $ac_val"
 	done
 	if test "$ac_old_val_w" != "$ac_new_val_w"; then
-	  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: '$ac_var' has changed since the previous run:" >&5
-printf "%s\n" "$as_me: error: '$ac_var' has changed since the previous run:" >&2;}
+	  { printf '%s\n' "$as_me:${as_lineno-$LINENO}: error: '$ac_var' has changed since the previous run:" >&5
+printf '%s\n' "$as_me: error: '$ac_var' has changed since the previous run:" >&2;}
 	  ac_cache_corrupted=:
 	else
-	  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: warning: ignoring whitespace changes in '$ac_var' since the previous run:" >&5
-printf "%s\n" "$as_me: warning: ignoring whitespace changes in '$ac_var' since the previous run:" >&2;}
+	  { printf '%s\n' "$as_me:${as_lineno-$LINENO}: warning: ignoring whitespace changes in '$ac_var' since the previous run:" >&5
+printf '%s\n' "$as_me: warning: ignoring whitespace changes in '$ac_var' since the previous run:" >&2;}
 	  eval $ac_var=\$ac_old_val
 	fi
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}:   former value:  '$ac_old_val'" >&5
-printf "%s\n" "$as_me:   former value:  '$ac_old_val'" >&2;}
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}:   current value: '$ac_new_val'" >&5
-printf "%s\n" "$as_me:   current value: '$ac_new_val'" >&2;}
+	{ printf '%s\n' "$as_me:${as_lineno-$LINENO}:   former value:  '$ac_old_val'" >&5
+printf '%s\n' "$as_me:   former value:  '$ac_old_val'" >&2;}
+	{ printf '%s\n' "$as_me:${as_lineno-$LINENO}:   current value: '$ac_new_val'" >&5
+printf '%s\n' "$as_me:   current value: '$ac_new_val'" >&2;}
       fi;;
   esac
   # Pass precious variables to config.status.
@@ -2719,10 +2698,10 @@ printf "%s\n" "$as_me:   current value: '$ac_new_val'" >&2;}
   fi
 done
 if $ac_cache_corrupted; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in '$ac_pwd':" >&5
-printf "%s\n" "$as_me: error: in '$ac_pwd':" >&2;}
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: changes in the environment can compromise the build" >&5
-printf "%s\n" "$as_me: error: changes in the environment can compromise the build" >&2;}
+  { printf '%s\n' "$as_me:${as_lineno-$LINENO}: error: in '$ac_pwd':" >&5
+printf '%s\n' "$as_me: error: in '$ac_pwd':" >&2;}
+  { printf '%s\n' "$as_me:${as_lineno-$LINENO}: error: changes in the environment can compromise the build" >&5
+printf '%s\n' "$as_me: error: changes in the environment can compromise the build" >&2;}
   as_fn_error $? "run '${MAKE-make} distclean' and/or 'rm $cache_file'
 	    and start over" "$LINENO" 5
 fi
@@ -2770,6 +2749,9 @@ fi
 
 #--------------------------------------------------------------------
 # Use config.guess, config.sub and install-sh provided by gnustep-make
+# Evaluation order of the configure script means we can not depend on
+# GNUSTEP_MAKEFILES being set for simple variable substitution, so we
+# execute a bit of shell code to dynamically get the directory.
 #--------------------------------------------------------------------
 
 
@@ -3390,8 +3372,8 @@ fi
 fi
 
 
-test -z "$CC" && { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in '$ac_pwd':" >&5
-printf "%s\n" "$as_me: error: in '$ac_pwd':" >&2;}
+test -z "$CC" && { { printf '%s\n' "$as_me:${as_lineno-$LINENO}: error: in '$ac_pwd':" >&5
+printf '%s\n' "$as_me: error: in '$ac_pwd':" >&2;}
 as_fn_error $? "no acceptable C compiler found in \$PATH
 See 'config.log' for more details" "$LINENO" 5; }
 
@@ -3508,13 +3490,13 @@ printf '%s\n' "no" >&6; }
 printf '%s\n' "$as_me: failed program was:" >&5
 sed 's/^/| /' conftest.$ac_ext >&5
 
-{ { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in '$ac_pwd':" >&5
-printf "%s\n" "$as_me: error: in '$ac_pwd':" >&2;}
+{ { printf '%s\n' "$as_me:${as_lineno-$LINENO}: error: in '$ac_pwd':" >&5
+printf '%s\n' "$as_me: error: in '$ac_pwd':" >&2;}
 as_fn_error 77 "C compiler cannot create executables
 See 'config.log' for more details" "$LINENO" 5; }
 else case e in #(
-  e) { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; } ;;
+  e) { printf '%s\n' "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf '%s\n' "yes" >&6; } ;;
 esac
 fi
 { printf '%s\n' "$as_me:${as_lineno-$LINENO}: checking for C compiler default output file name" >&5
@@ -3553,8 +3535,8 @@ for ac_file in conftest.exe conftest conftest.*; do
   esac
 done
 else case e in #(
-  e) { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in '$ac_pwd':" >&5
-printf "%s\n" "$as_me: error: in '$ac_pwd':" >&2;}
+  e) { { printf '%s\n' "$as_me:${as_lineno-$LINENO}: error: in '$ac_pwd':" >&5
+printf '%s\n' "$as_me: error: in '$ac_pwd':" >&2;}
 as_fn_error $? "cannot compute suffix of executables: cannot compile and link
 See 'config.log' for more details" "$LINENO" 5; } ;;
 esac
@@ -3614,8 +3596,8 @@ printf '%s\n' "$ac_try_echo"; } >&5
     if test "$cross_compiling" = maybe; then
 	cross_compiling=yes
     else
-	{ { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in '$ac_pwd':" >&5
-printf "%s\n" "$as_me: error: in '$ac_pwd':" >&2;}
+	{ { printf '%s\n' "$as_me:${as_lineno-$LINENO}: error: in '$ac_pwd':" >&5
+printf '%s\n' "$as_me: error: in '$ac_pwd':" >&2;}
 as_fn_error 77 "cannot run C compiled programs.
 If you meant to cross compile, use '--host'.
 See 'config.log' for more details" "$LINENO" 5; }
@@ -3667,11 +3649,11 @@ then :
   esac
 done
 else case e in #(
-  e) printf "%s\n" "$as_me: failed program was:" >&5
+  e) printf '%s\n' "$as_me: failed program was:" >&5
 sed 's/^/| /' conftest.$ac_ext >&5
 
-{ { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in '$ac_pwd':" >&5
-printf "%s\n" "$as_me: error: in '$ac_pwd':" >&2;}
+{ { printf '%s\n' "$as_me:${as_lineno-$LINENO}: error: in '$ac_pwd':" >&5
+printf '%s\n' "$as_me: error: in '$ac_pwd':" >&2;}
 as_fn_error $? "cannot compute suffix of object files: cannot compile
 See 'config.log' for more details" "$LINENO" 5; } ;;
 esac
@@ -3892,16 +3874,16 @@ fi
 
 if test "x$ac_cv_prog_cc_c11" = xno
 then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: unsupported" >&5
-printf "%s\n" "unsupported" >&6; }
+  { printf '%s\n' "$as_me:${as_lineno-$LINENO}: result: unsupported" >&5
+printf '%s\n' "unsupported" >&6; }
 else case e in #(
   e) if test "x$ac_cv_prog_cc_c11" = x
 then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: none needed" >&5
-printf "%s\n" "none needed" >&6; }
+  { printf '%s\n' "$as_me:${as_lineno-$LINENO}: result: none needed" >&5
+printf '%s\n' "none needed" >&6; }
 else case e in #(
-  e) { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_prog_cc_c11" >&5
-printf "%s\n" "$ac_cv_prog_cc_c11" >&6; }
+  e) { printf '%s\n' "$as_me:${as_lineno-$LINENO}: result: $ac_cv_prog_cc_c11" >&5
+printf '%s\n' "$ac_cv_prog_cc_c11" >&6; }
      CC="$CC $ac_cv_prog_cc_c11" ;;
 esac
 fi
@@ -3941,16 +3923,16 @@ fi
 
 if test "x$ac_cv_prog_cc_c99" = xno
 then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: unsupported" >&5
-printf "%s\n" "unsupported" >&6; }
+  { printf '%s\n' "$as_me:${as_lineno-$LINENO}: result: unsupported" >&5
+printf '%s\n' "unsupported" >&6; }
 else case e in #(
   e) if test "x$ac_cv_prog_cc_c99" = x
 then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: none needed" >&5
-printf "%s\n" "none needed" >&6; }
+  { printf '%s\n' "$as_me:${as_lineno-$LINENO}: result: none needed" >&5
+printf '%s\n' "none needed" >&6; }
 else case e in #(
-  e) { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_prog_cc_c99" >&5
-printf "%s\n" "$ac_cv_prog_cc_c99" >&6; }
+  e) { printf '%s\n' "$as_me:${as_lineno-$LINENO}: result: $ac_cv_prog_cc_c99" >&5
+printf '%s\n' "$ac_cv_prog_cc_c99" >&6; }
      CC="$CC $ac_cv_prog_cc_c99" ;;
 esac
 fi
@@ -3990,16 +3972,16 @@ fi
 
 if test "x$ac_cv_prog_cc_c89" = xno
 then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: unsupported" >&5
-printf "%s\n" "unsupported" >&6; }
+  { printf '%s\n' "$as_me:${as_lineno-$LINENO}: result: unsupported" >&5
+printf '%s\n' "unsupported" >&6; }
 else case e in #(
   e) if test "x$ac_cv_prog_cc_c89" = x
 then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: none needed" >&5
-printf "%s\n" "none needed" >&6; }
+  { printf '%s\n' "$as_me:${as_lineno-$LINENO}: result: none needed" >&5
+printf '%s\n' "none needed" >&6; }
 else case e in #(
-  e) { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_prog_cc_c89" >&5
-printf "%s\n" "$ac_cv_prog_cc_c89" >&6; }
+  e) { printf '%s\n' "$as_me:${as_lineno-$LINENO}: result: $ac_cv_prog_cc_c89" >&5
+printf '%s\n' "$ac_cv_prog_cc_c89" >&6; }
      CC="$CC $ac_cv_prog_cc_c89" ;;
 esac
 fi
@@ -4140,8 +4122,8 @@ if $ac_preproc_ok
 then :
 
 else case e in #(
-  e) { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in '$ac_pwd':" >&5
-printf "%s\n" "$as_me: error: in '$ac_pwd':" >&2;}
+  e) { { printf '%s\n' "$as_me:${as_lineno-$LINENO}: error: in '$ac_pwd':" >&5
+printf '%s\n' "$as_me: error: in '$ac_pwd':" >&2;}
 as_fn_error $? "C preprocessor \"$CPP\" fails sanity check
 See 'config.log' for more details" "$LINENO" 5; } ;;
 esac
@@ -4456,7 +4438,7 @@ then :
 ac_x_libraries=
 else case e in #(
   e) LIBS=$ac_save_LIBS
-for ac_dir in `printf "%s\n" "$ac_x_includes $ac_x_header_dirs" | sed s/include/lib/g`
+for ac_dir in `printf '%s\n' "$ac_x_includes $ac_x_header_dirs" | sed s/include/lib/g`
 do
   # Don't even attempt the hair of trying to link an X program!
   for ac_extension in a so sl dylib la dll; do
@@ -4564,8 +4546,8 @@ then :
 printf '%s\n' "yes" >&6; }
 	  X_LIBS="$X_LIBS -R $x_libraries"
 else case e in #(
-  e) { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: neither works" >&5
-printf "%s\n" "neither works" >&6; } ;;
+  e) { printf '%s\n' "$as_me:${as_lineno-$LINENO}: result: neither works" >&5
+printf '%s\n' "neither works" >&6; } ;;
 esac
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.beam \
@@ -4614,7 +4596,7 @@ if ac_fn_c_try_link "$LINENO"
 then :
 
 else case e in #(
-  e) { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for dnet_ntoa in -ldnet" >&5
+  e) { printf '%s\n' "$as_me:${as_lineno-$LINENO}: checking for dnet_ntoa in -ldnet" >&5
 printf %s "checking for dnet_ntoa in -ldnet... " >&6; }
 if test ${ac_cv_lib_dnet_dnet_ntoa+y}
 then :
@@ -5335,10 +5317,10 @@ Alternatively, you may set the environment variables XEXT_CFLAGS
 and XEXT_LIBS to avoid the need to call pkg-config.
 See the pkg-config man page for more details." "$LINENO" 5
 elif test $pkg_failed = untried; then
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
-	{ { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in '$ac_pwd':" >&5
-printf "%s\n" "$as_me: error: in '$ac_pwd':" >&2;}
+        { printf '%s\n' "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf '%s\n' "no" >&6; }
+	{ { printf '%s\n' "$as_me:${as_lineno-$LINENO}: error: in '$ac_pwd':" >&5
+printf '%s\n' "$as_me: error: in '$ac_pwd':" >&2;}
 as_fn_error $? "The pkg-config script could not be found or is too old.  Make sure it
 is in your PATH or set the PKG_CONFIG environment variable to the full
 path to pkg-config.
@@ -5471,10 +5453,10 @@ Alternatively, you may set the environment variables XT_CFLAGS
 and XT_LIBS to avoid the need to call pkg-config.
 See the pkg-config man page for more details." "$LINENO" 5
 elif test $pkg_failed = untried; then
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
-	{ { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in '$ac_pwd':" >&5
-printf "%s\n" "$as_me: error: in '$ac_pwd':" >&2;}
+        { printf '%s\n' "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf '%s\n' "no" >&6; }
+	{ { printf '%s\n' "$as_me:${as_lineno-$LINENO}: error: in '$ac_pwd':" >&5
+printf '%s\n' "$as_me: error: in '$ac_pwd':" >&2;}
 as_fn_error $? "The pkg-config script could not be found or is too old.  Make sure it
 is in your PATH or set the PKG_CONFIG environment variable to the full
 path to pkg-config.
@@ -5607,10 +5589,10 @@ Alternatively, you may set the environment variables XMU_CFLAGS
 and XMU_LIBS to avoid the need to call pkg-config.
 See the pkg-config man page for more details." "$LINENO" 5
 elif test $pkg_failed = untried; then
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
-	{ { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in '$ac_pwd':" >&5
-printf "%s\n" "$as_me: error: in '$ac_pwd':" >&2;}
+        { printf '%s\n' "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf '%s\n' "no" >&6; }
+	{ { printf '%s\n' "$as_me:${as_lineno-$LINENO}: error: in '$ac_pwd':" >&5
+printf '%s\n' "$as_me: error: in '$ac_pwd':" >&2;}
 as_fn_error $? "The pkg-config script could not be found or is too old.  Make sure it
 is in your PATH or set the PKG_CONFIG environment variable to the full
 path to pkg-config.
@@ -5894,7 +5876,7 @@ fi
 # Old X11 support
 { printf '%s\n' "$as_me:${as_lineno-$LINENO}: checking for X11 function prototypes" >&5
 printf %s "checking for X11 function prototypes... " >&6; }
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for egrep -e" >&5
+{ printf '%s\n' "$as_me:${as_lineno-$LINENO}: checking for egrep -e" >&5
 printf %s "checking for egrep -e... " >&6; }
 if test ${ac_cv_path_EGREP_TRADITIONAL+y}
 then :
@@ -5931,7 +5913,7 @@ case `"$ac_path_EGREP_TRADITIONAL" --version 2>&1` in #(
     cat "conftest.in" "conftest.in" >"conftest.tmp"
     mv "conftest.tmp" "conftest.in"
     cp "conftest.in" "conftest.nl"
-    printf "%s\n" 'EGREP_TRADITIONAL' >> "conftest.nl"
+    printf '%s\n' 'EGREP_TRADITIONAL' >> "conftest.nl"
     "$ac_path_EGREP_TRADITIONAL" -E 'EGR(EP|AC)_TRADITIONAL$' < "conftest.nl" >"conftest.out" 2>/dev/null || break
     diff "conftest.out" "conftest.nl" >/dev/null 2>&1 || break
     as_fn_arith $ac_count + 1 && ac_count=$as_val
@@ -5993,7 +5975,7 @@ case `"$ac_path_EGREP_TRADITIONAL" --version 2>&1` in #(
     cat "conftest.in" "conftest.in" >"conftest.tmp"
     mv "conftest.tmp" "conftest.in"
     cp "conftest.in" "conftest.nl"
-    printf "%s\n" 'EGREP_TRADITIONAL' >> "conftest.nl"
+    printf '%s\n' 'EGREP_TRADITIONAL' >> "conftest.nl"
     "$ac_path_EGREP_TRADITIONAL" 'EGR(EP|AC)_TRADITIONAL$' < "conftest.nl" >"conftest.out" 2>/dev/null || break
     diff "conftest.out" "conftest.nl" >/dev/null 2>&1 || break
     as_fn_arith $ac_count + 1 && ac_count=$as_val
@@ -6024,8 +6006,8 @@ esac
 fi ;;
 esac
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_path_EGREP_TRADITIONAL" >&5
-printf "%s\n" "$ac_cv_path_EGREP_TRADITIONAL" >&6; }
+{ printf '%s\n' "$as_me:${as_lineno-$LINENO}: result: $ac_cv_path_EGREP_TRADITIONAL" >&5
+printf '%s\n' "$ac_cv_path_EGREP_TRADITIONAL" >&6; }
  EGREP_TRADITIONAL=$ac_cv_path_EGREP_TRADITIONAL
 
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -6166,10 +6148,10 @@ Alternatively, you may set the environment variables FREETYPE_CFLAGS
 and FREETYPE_LIBS to avoid the need to call pkg-config.
 See the pkg-config man page for more details." "$LINENO" 5
 elif test $pkg_failed = untried; then
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
-	{ { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in '$ac_pwd':" >&5
-printf "%s\n" "$as_me: error: in '$ac_pwd':" >&2;}
+        { printf '%s\n' "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf '%s\n' "no" >&6; }
+	{ { printf '%s\n' "$as_me:${as_lineno-$LINENO}: error: in '$ac_pwd':" >&5
+printf '%s\n' "$as_me: error: in '$ac_pwd':" >&2;}
 as_fn_error $? "The pkg-config script could not be found or is too old.  Make sure it
 is in your PATH or set the PKG_CONFIG environment variable to the full
 path to pkg-config.
@@ -7504,6 +7486,46 @@ printf '%s\n' "yes" >&6; }
 	have_fontconfig=yes
 fi
 
+# A fontconfig built as an archive keeps the libraries it needs in Libs.private,
+# and pkg-config reports those only when it is asked for a static link line.
+# Reading a configuration is what reaches them, so a link that does no more than
+# initialise the library can succeed while the backend, which parses one, fails
+# on expat's symbols.  The reported line is tried against a call that parses, and
+# the static line is used when it does not resolve.
+if test "$have_fontconfig" = yes; then
+  gs_save_LIBS="$LIBS"
+  LIBS="$FONTCONFIG_LIBS $LIBS"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <fontconfig/fontconfig.h>
+int
+main (void)
+{
+FcConfig *c = FcInitLoadConfig(); (void)c;
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"
+then :
+  gs_fontconfig_links=yes
+else case e in #(
+  e) gs_fontconfig_links=no ;;
+esac
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
+  LIBS="$gs_save_LIBS"
+  if test "$gs_fontconfig_links" = no; then
+    gs_fontconfig_static=`$PKG_CONFIG --static --libs fontconfig 2>/dev/null`
+    if test -n "$gs_fontconfig_static"; then
+      { printf '%s\n' "$as_me:${as_lineno-$LINENO}: fontconfig needs its static link line: $gs_fontconfig_static" >&5
+printf '%s\n' "$as_me: fontconfig needs its static link line: $gs_fontconfig_static" >&6;}
+      FONTCONFIG_LIBS="$gs_fontconfig_static"
+    fi
+  fi
+fi
+
 if test "$have_cairo" = no; then
   { printf '%s\n' "$as_me:${as_lineno-$LINENO}: checking for cairo_create in -lcairo" >&5
 printf %s "checking for cairo_create in -lcairo... " >&6; }
@@ -8067,20 +8089,23 @@ fi
 #--------------------------------------------------------------------
 WITH_WRASTER=no
 
+
 # Check whether --enable-wraster was given.
 if test ${enable_wraster+y}
 then :
-  enableval=$enable_wraster;
+  enableval=$enable_wraster; enable_wraster=$enableval
 else case e in #(
   e) enable_wraster=no ;;
 esac
 fi
+
 
 if test "x$enable_wraster" = "xyes"; then
   USE_WRASTER=1
 else
   USE_WRASTER=0
 fi
+
 
 printf '%s\n' "#define USE_WRASTER $USE_WRASTER" >>confdefs.h
 
@@ -8137,6 +8162,8 @@ printf '%s\n' "$as_me: WARNING: can't find freetype, required for graphics=cairo
       BUILD_GRAPHICS=winlib
     elif test $BUILD_SERVER = wayland; then
       as_fn_error $? "wayland backend requires cairo" "$LINENO" 5
+    elif test $BUILD_SERVER = android; then
+      as_fn_error $? "android backend requires cairo" "$LINENO" 5
     else
       BUILD_GRAPHICS=xlib
     fi
@@ -8149,6 +8176,8 @@ printf '%s\n' "$as_me: WARNING: can't find cairo, required for graphics=cairo!" 
       BUILD_GRAPHICS=winlib
     elif test $BUILD_SERVER = wayland; then
       as_fn_error $? "wayland backend requires cairo" "$LINENO" 5
+    elif test $BUILD_SERVER = android; then
+      as_fn_error $? "android backend requires cairo" "$LINENO" 5
     else
       BUILD_GRAPHICS=art
     fi
@@ -8361,7 +8390,7 @@ else case e in #(
 esac
 fi
 
-      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for eglGetDisplay in -lEGL" >&5
+      { printf '%s\n' "$as_me:${as_lineno-$LINENO}: checking for eglGetDisplay in -lEGL" >&5
 printf %s "checking for eglGetDisplay in -lEGL... " >&6; }
 if test ${ac_cv_lib_EGL_eglGetDisplay+y}
 then :
@@ -8402,8 +8431,8 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam \
 LIBS=$ac_check_lib_save_LIBS ;;
 esac
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_EGL_eglGetDisplay" >&5
-printf "%s\n" "$ac_cv_lib_EGL_eglGetDisplay" >&6; }
+{ printf '%s\n' "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_EGL_eglGetDisplay" >&5
+printf '%s\n' "$ac_cv_lib_EGL_eglGetDisplay" >&6; }
 if test "x$ac_cv_lib_EGL_eglGetDisplay" = xyes
 then :
   have_egl=yes
@@ -8415,10 +8444,15 @@ fi
       if test "x$have_egl_h" = "xyes" -a "x$have_egl" = "xyes"; then
         WITH_EGL=yes
 
-printf "%s\n" "#define HAVE_EGL 1" >>confdefs.h
+printf '%s\n' "#define HAVE_EGL 1" >>confdefs.h
 
         LIBS="-lGL -lEGL -lwayland-egl $LIBS"
       fi
+    elif test $BUILD_SERVER = android; then
+                                                            CAIRO_LIBS="$CAIRO_LIBS $FONTCONFIG_LIBS"
+      CAIRO_CFLAGS="$CAIRO_CFLAGS $FONTCONFIG_CFLAGS"
+      { printf '%s\n' "$as_me:${as_lineno-$LINENO}: result: android" >&5
+printf '%s\n' "android" >&6; }
     fi
 
     LIBS="$CAIRO_LIBS $LIBS"
@@ -8623,44 +8657,7 @@ cat >confcache <<\_ACEOF
 
 _ACEOF
 
-# The following way of writing the cache mishandles newlines in values,
-# but we know of no workaround that is simple, portable, and efficient.
-# So, we kill variables containing newlines.
-# Ultrix sh set writes to stderr and can't be redirected directly,
-# and sets the high bit in the cache file unless we assign to the vars.
-(
-  for ac_var in `(set) 2>&1 | sed -n 's/^\([a-zA-Z_][a-zA-Z0-9_]*\)=.*/\1/p'`; do
-    eval ac_val=\$$ac_var
-    case $ac_val in #(
-    *${as_nl}*)
-      case $ac_var in #(
-      *_cv_*) { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: cache variable $ac_var contains a newline" >&5
-printf "%s\n" "$as_me: WARNING: cache variable $ac_var contains a newline" >&2;} ;;
-      esac
-      case $ac_var in #(
-      _ | IFS | as_nl) ;; #(
-      BASH_ARGV | BASH_SOURCE) eval $ac_var= ;; #(
-      *) { eval $ac_var=; unset $ac_var;} ;;
-      esac ;;
-    esac
-  done
-
-  (set) 2>&1 |
-    case $as_nl`(ac_space=' '; set) 2>&1` in #(
-    *${as_nl}ac_space=\ *)
-      # 'set' does not quote correctly, so add quotes: double-quote
-      # substitution turns \\\\ into \\, and sed turns \\ into \.
-      sed -n \
-	"s/'/'\\\\''/g;
-	  s/^\\([_$as_cr_alnum]*_cv_[_$as_cr_alnum]*\\)=\\(.*\\)/\\1='\\2'/p"
-      ;; #(
-    *)
-      # 'set' quotes correctly as required by POSIX, so do not add quotes.
-      sed -n "/^[_$as_cr_alnum]*_cv_[_$as_cr_alnum]*=/p"
-      ;;
-    esac |
-    sort
-) |
+ac_cache_dump |
   sed '
      /^ac_cv_env_/b end
      t clear
@@ -9795,9 +9792,9 @@ test -z "$ac_datarootdir_hack$ac_datarootdir_seen" &&
   { ac_out=`sed -n '/\${datarootdir}/p' "$ac_tmp/out"`; test -n "$ac_out"; } &&
   { ac_out=`sed -n '/^[	 ]*datarootdir[	 ]*:*=/p' \
       "$ac_tmp/out"`; test -z "$ac_out"; } &&
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: $ac_file contains a reference to the variable 'datarootdir'
+  { printf '%s\n' "$as_me:${as_lineno-$LINENO}: WARNING: $ac_file contains a reference to the variable 'datarootdir'
 which seems to be undefined.  Please make sure it is defined" >&5
-printf "%s\n" "$as_me: WARNING: $ac_file contains a reference to the variable 'datarootdir'
+printf '%s\n' "$as_me: WARNING: $ac_file contains a reference to the variable 'datarootdir'
 which seems to be undefined.  Please make sure it is defined" >&2;}
 
   rm -f "$ac_tmp/stdin"

--- a/configure.ac
+++ b/configure.ac
@@ -475,6 +475,28 @@ PKG_CHECK_MODULES(CAIRO_WIN32, cairo-win32, have_cairo_win32=yes, have_cairo_win
 PKG_CHECK_MODULES(CAIRO_GLITZ, cairo-glitz, have_cairo_glitz=yes, have_cairo_glitz=no)
 PKG_CHECK_MODULES(FONTCONFIG, fontconfig, have_fontconfig=yes, have_fontconfig=no)
 
+# A fontconfig built as an archive keeps the libraries it needs in Libs.private,
+# and pkg-config reports those only when it is asked for a static link line.
+# Reading a configuration is what reaches them, so a link that does no more than
+# initialise the library can succeed while the backend, which parses one, fails
+# on expat's symbols.  The reported line is tried against a call that parses, and
+# the static line is used when it does not resolve.
+if test "$have_fontconfig" = yes; then
+  gs_save_LIBS="$LIBS"
+  LIBS="$FONTCONFIG_LIBS $LIBS"
+  AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <fontconfig/fontconfig.h>]],
+                                  [[FcConfig *c = FcInitLoadConfig(); (void)c;]])],
+                 [gs_fontconfig_links=yes], [gs_fontconfig_links=no])
+  LIBS="$gs_save_LIBS"
+  if test "$gs_fontconfig_links" = no; then
+    gs_fontconfig_static=`$PKG_CONFIG --static --libs fontconfig 2>/dev/null`
+    if test -n "$gs_fontconfig_static"; then
+      AC_MSG_NOTICE([fontconfig needs its static link line: $gs_fontconfig_static])
+      FONTCONFIG_LIBS="$gs_fontconfig_static"
+    fi
+  fi
+fi
+
 if test "$have_cairo" = no; then
   AC_CHECK_LIB(cairo, cairo_create, have_cairo=yes)
 fi
@@ -589,8 +611,8 @@ case $target_os in
               BUILD_GRAPHICS=winlib;;
 esac
 
-AC_ARG_ENABLE(server, 
-  [  --enable-server=SRV     Build server type: x11, win32, wayland, headless],,
+AC_ARG_ENABLE(server,
+  [  --enable-server=SRV     Build server type: x11, win32, wayland, android, headless],,
   enable_server=$BUILD_SERVER)
 AC_ARG_ENABLE(graphics, 
   [  --enable-graphics=GPH   Build graphics: xlib, xdps, winlib, art, cairo, opal, headless],,
@@ -611,6 +633,8 @@ if test x"$BUILD_GRAPHICS" = "xcairo"; then
       BUILD_GRAPHICS=winlib
     elif test $BUILD_SERVER = wayland; then
       AC_MSG_ERROR([wayland backend requires cairo])
+    elif test $BUILD_SERVER = android; then
+      AC_MSG_ERROR([android backend requires cairo])
     else
       BUILD_GRAPHICS=xlib
     fi
@@ -621,6 +645,8 @@ if test x"$BUILD_GRAPHICS" = "xcairo"; then
       BUILD_GRAPHICS=winlib
     elif test $BUILD_SERVER = wayland; then
       AC_MSG_ERROR([wayland backend requires cairo])
+    elif test $BUILD_SERVER = android; then
+      AC_MSG_ERROR([android backend requires cairo])
     else
       BUILD_GRAPHICS=art
     fi
@@ -692,6 +718,19 @@ if test x"$BUILD_GRAPHICS" = "xcairo"; then
         AC_DEFINE(HAVE_EGL, 1, [Define if EGL is available for Wayland OpenGL support])
         LIBS="-lGL -lEGL -lwayland-egl $LIBS"
       fi
+    elif test $BUILD_SERVER = android; then
+      dnl The android surface draws into a cairo image surface, so nothing from
+      dnl the NDK is linked.  A surface backed by ANativeWindow adds
+      dnl -landroid -lnativewindow here.
+      dnl
+      dnl fontconfig is named here for the same reason win32 names it: on this
+      dnl platform it is usually an archive, and cairo-ft's link line reports it
+      dnl without the libraries it needs itself.  Reading a configuration then
+      dnl leaves expat's symbols undefined in the bundle, which loads as far as
+      dnl "Can't load object file from backend" and says nothing more.
+      CAIRO_LIBS="$CAIRO_LIBS $FONTCONFIG_LIBS"
+      CAIRO_CFLAGS="$CAIRO_CFLAGS $FONTCONFIG_CFLAGS"
+      AC_MSG_RESULT(android)
     fi
 AC_SUBST(WITH_EGL)
     LIBS="$CAIRO_LIBS $LIBS"
@@ -800,6 +839,7 @@ AH_TOP([
 #define SERVER_win32      2
 #define SERVER_wayland    3
 #define SERVER_headless   4
+#define SERVER_android    5
 #define GRAPHICS_xdps     0
 #define GRAPHICS_art      1
 #define GRAPHICS_xlib     2


### PR DESCRIPTION
This adds an android server over the existing cairo graphics path, on the
Wayland pattern. 

AndroidServer is a GSDisplayServer subclass holding a window
table, screen metrics and window ordering; AndroidCairoSurface is a
CairoSurface subclass. 

configure takes android in --enable-server and errors,
as wayland does, rather than falling back to xlib when cairo or freetype is
missing, and it links fontconfig's own libraries, which a static fontconfig
keeps private.

The surface draws into an image and posts it to the window an activity is
given, asking the window which region has to be redrawn. The window bound to
that surface is given the screen, since a smaller one would sit in a corner.
Touches and keys become NSEvents. The surface is given up and taken back with
the activity.

The screen size is read from the bound window, or from GSAndroidScreenSize
where there is none.

Tests/cairo/androidpost and androidrepaint drive a real ANativeWindow through
AImageReader, so they need no activity.
