### PR TITLE
CI: build and run the test suite on Android

### DIFF
--- a/.github/scripts/android/android.cross.config
+++ b/.github/scripts/android/android.cross.config
@@ -1,0 +1,25 @@
+# libs-base cross answers for Android x86_64-linux-android, API 31.
+# Produced by running each configure test on an emulator.
+# NDK 29.0.14206865, libobjc2 -fobjc-runtime=gnustep-2.2.
+cross_CMDLINE_TERMINATED=1
+cross_NEED_WORD_ALIGNMENT=0
+cross_VASPRINTF_RETURNS_LENGTH=1
+cross_VSPRINTF_RETURNS_LENGTH=1
+cross_reuseaddr_ok=1
+cross_have_kvm_env=0
+cross_working_register_printf=0
+cross_wide_register_printf=0
+cross_have_poll=yes
+cross_ffi_ok=yes
+cross_gs_cv_objc_works=yes
+cross_gs_cv_objc_load_method_worked=yes
+cross_gs_cv_objc_compiler_supports_constant_string_class=yes
+cross_non_fragile=yes
+cross_have_unexpected=yes
+cross_safe_initialize=yes
+cross_objc2_runtime=1
+cross_utf8literal_ok=yes
+cross_gs_cv_program_invocation_name_worked=no
+cross_found_iconv_libc=no
+cross_found_iconv_liconv=yes
+cross_found_iconv_lgiconv=no

--- a/.github/scripts/android/back.sh
+++ b/.github/scripts/android/back.sh
@@ -1,0 +1,190 @@
+#!/bin/bash
+#
+# Cross-build tools-make, libs-base, libs-gui and libs-back for Android,
+# with libs-back configured for the android server and cairo graphics.
+#
+# libs-base and libs-gui are built only so that libs-back has something to link
+# against: Source/GNUmakefile.preamble links -lgnustep-gui, so the chain is
+# base, then gui, then back.  The backend itself is the android server over
+# cairo graphics, drawing into an offscreen image surface.
+#
+set -eu
+
+: "${ANDROID_NDK_HOME:?}"
+: "${GS_PREFIX:?}"
+: "${GS_BASE:?}"                     # the libs-base checkout
+: "${GS_GUI:?}"                      # the libs-gui checkout
+: "${GS_BACK:?}"                     # the libs-back checkout (this repository)
+: "${GS_API:=31}"
+: "${GS_TRIPLE:=x86_64-linux-android}"
+GS_SRC="${GS_SRC:-$HOME/gs-src}"
+GS_DISPATCH_PREFIX="${GS_DISPATCH_PREFIX:-$GS_PREFIX/../dispatch-prefix}"
+GS_DISPATCH_PREFIX=$(cd "$GS_DISPATCH_PREFIX" && pwd)
+GSROOT="$GS_PREFIX/gnustep"
+
+TOOLCHAIN="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64"
+CCPREFIX="$TOOLCHAIN/bin/${GS_TRIPLE}${GS_API}"
+JOBS=$(nproc)
+say() { echo "== $*"; }
+
+# ------------------------------------------------------------- tools-make
+find_gnustep_sh() { find "$GSROOT" -name GNUstep.sh -path '*Makefiles*' 2>/dev/null | head -1; }
+
+if [ -z "$(find_gnustep_sh)" ]; then
+  say "tools-make (cross)"
+  [ -d "$GS_SRC/tools-make" ] || git clone -q --depth 1 \
+    https://github.com/gnustep/tools-make.git "$GS_SRC/tools-make"
+  cd "$GS_SRC/tools-make"
+  ./configure --prefix="$GSROOT" \
+    --host="$GS_TRIPLE" --target="$GS_TRIPLE" \
+    --with-library-combo=ng-gnu-gnu \
+    CC="$CCPREFIX-clang" \
+    CPPFLAGS="-I$GS_PREFIX/include" \
+    LDFLAGS="-L$GS_PREFIX/lib -fuse-ld=lld" \
+    LIBS="-lobjc" > "$GS_SRC/tools-make-configure.log" 2>&1 || {
+      echo "tools-make configure failed"
+      tail -25 "$GS_SRC/tools-make-configure.log"; exit 1; }
+  make -j"$JOBS" >/dev/null && make install >/dev/null
+fi
+
+GSMAKE_SH=$(find_gnustep_sh)
+[ -n "$GSMAKE_SH" ] || { echo "tools-make installed no GNUstep.sh"; exit 1; }
+echo "   GNUstep.sh: $GSMAKE_SH"
+
+# ------------------------------------------------------- host tool wrappers
+# plmerge, pl2link and defaults run on the BUILD machine.  Sourcing the Android
+# GNUstep.sh puts the cross-built copies in $GSROOT/Local/Tools on PATH and
+# points LD_LIBRARY_PATH at Android libraries, so the host binaries exit 127
+# with "invalid ELF header".  Wrap the host ones and put them first.
+HOSTTOOLS="$GS_SRC/hosttools"
+mkdir -p "$HOSTTOOLS"
+for t in plmerge pl2link defaults; do
+  real=$(command -v "$t" || true)
+  [ -n "$real" ] || { echo "missing host tool: $t"; exit 1; }
+  rm -f "$HOSTTOOLS/$t"
+  printf '#!/bin/sh\nexec env -u LD_LIBRARY_PATH %s "$@"\n' "$real" > "$HOSTTOOLS/$t"
+  chmod +x "$HOSTTOOLS/$t"
+done
+
+CROSS="${GS_CROSS_CONFIG:-$GS_BACK/.github/scripts/android/android.cross.config}"
+[ -f "$CROSS" ] || { echo "missing cross config: $CROSS"; exit 1; }
+
+# GNUstep.sh reads variables that are not set, which `set -u` treats as fatal.
+set +u
+# shellcheck disable=SC1091
+. "$GSMAKE_SH"
+set -u
+export PATH="$HOSTTOOLS:$PATH"
+export CC="$CCPREFIX-clang" CXX="$CCPREFIX-clang++"
+export PKG_CONFIG_PATH="$GS_PREFIX/lib/pkgconfig"
+export PKG_CONFIG_LIBDIR="$GS_PREFIX/lib/pkgconfig"
+GNUTLS_LIBS=$(pkg-config --static --libs gnutls)
+# libobjc2's Block.h must win over libdispatch's, so its include comes first.
+export CPPFLAGS="-I$GS_PREFIX/include -I$GS_DISPATCH_PREFIX/include"
+export LDFLAGS="-L$GS_PREFIX/lib -L$GS_DISPATCH_PREFIX/lib -fuse-ld=lld"
+export LIBS="-liconv $GNUTLS_LIBS"
+export XML2_CONFIG="$GS_PREFIX/bin/xml2-config"
+
+# gnustep-make does not put the environment's CPPFLAGS on its own compile
+# lines. ADDITIONAL_INCLUDE_DIRS is the variable it honours, and base's
+# NSOperation.h includes dispatch/dispatch.h whenever GS_USE_LIBDISPATCH is 1,
+# so libs-gui does not compile without the dispatch include reaching it.
+export ADDITIONAL_INCLUDE_DIRS="-I$GS_PREFIX/include -I$GS_DISPATCH_PREFIX/include"
+
+# tools-make installs either layout depending on how it was configured:
+# $GSROOT/System/Library/Libraries and friends, or the FHS $GSROOT/lib and
+# $GSROOT/share. Ask where the library actually is rather than assuming, or the
+# already-built check silently misses and every path printed after it is wrong.
+find_baselib() { find "$GSROOT" -name 'libgnustep-base.so' 2>/dev/null | head -1; }
+
+# ---------------------------------------------------------------- libs-base
+if [ -z "$(find_baselib)" ]; then
+  say "libs-base configure"
+  cd "$GS_BASE"
+  ./configure --host="$GS_TRIPLE" --prefix="$GSROOT" \
+    --with-cross-compilation-info="$CROSS" \
+    --with-xml-prefix="$GS_PREFIX" --with-curl="$GS_PREFIX" \
+    --with-dispatch-include="$GS_DISPATCH_PREFIX/include" \
+    --with-dispatch-library="$GS_DISPATCH_PREFIX/lib" \
+    > "$GS_BASE/android-configure.log" 2>&1 || {
+      echo "configure failed"; tail -40 "$GS_BASE/android-configure.log"; exit 1; }
+  say "libs-base build"
+  make -j"$JOBS" > "$GS_BASE/android-build.log" 2>&1 || {
+    echo "build failed"; grep -E "error:" "$GS_BASE/android-build.log" | head -20; exit 1; }
+  say "libs-base install"
+  make install > "$GS_BASE/android-install.log" 2>&1 || {
+    echo "install failed"; tail -25 "$GS_BASE/android-install.log"; exit 1; }
+fi
+BASELIB=$(find_baselib)
+[ -n "$BASELIB" ] || { echo "libs-base installed no libgnustep-base.so under $GSROOT"; exit 1; }
+echo "    base: $BASELIB"
+
+# ----------------------------------------------------------------- libs-gui
+say "libs-gui configure"
+cd "$GS_GUI"
+./configure --host="$GS_TRIPLE" --prefix="$GSROOT" \
+  > "$GS_GUI/android-configure.log" 2>&1 || {
+    echo "configure failed"; tail -40 "$GS_GUI/android-configure.log"; exit 1; }
+
+# The image libraries are built on purpose: code behind #if HAVE_LIBJPEG and
+# friends is compiled away otherwise and gets no coverage at all.
+say "image libraries picked up by configure"
+grep -E '^ac_cv_lib_(jpeg|tiff|png|gif)' config.log | sort -u | sed 's/^/    /'
+for v in ac_cv_lib_png_png_sig_cmp ac_cv_lib_jpeg_jpeg_destroy_decompress \
+         ac_cv_lib_tiff_TIFFReadScanline ac_cv_lib_gif_DGifOpen; do
+  grep -q "^$v=yes" config.log || { echo "$v is not yes; the image paths would be compiled out"; exit 1; }
+done
+
+say "libs-gui build"
+make -j"$JOBS" > "$GS_GUI/android-build.log" 2>&1 || {
+  echo "build failed"; grep -E "error:" "$GS_GUI/android-build.log" | head -20; exit 1; }
+ls -l Source/obj/libgnustep-gui.so.* | sed 's/^/    /'
+
+say "libs-gui install"
+make install > "$GS_GUI/android-install.log" 2>&1 || {
+  echo "install failed"; tail -25 "$GS_GUI/android-install.log"; exit 1; }
+
+# ---------------------------------------------------------------- libs-back
+# This repository's own checkout, built with the android server and cairo
+# graphics.  That is what this workflow exists to exercise.
+say "libs-back configure (android server, cairo graphics)"
+cd "$GS_BACK"
+./configure --host="$GS_TRIPLE" --prefix="$GSROOT" \
+  --enable-server=android --enable-graphics=cairo \
+  > "$GS_BACK/android-configure.log" 2>&1 || {
+    echo "configure failed"; tail -30 "$GS_BACK/android-configure.log"; exit 1; }
+# configure switches the graphics to xlib or art when it cannot find freetype
+# or cairo, for every server except win32, wayland and android.  android errors
+# instead, but the choice is checked here rather than trusted: an x11 graphics
+# backend on Android would build and then fail to draw anything.
+grep -E '^BUILD_SERVER|^BUILD_GRAPHICS' config.make | sed 's/^/    /'
+for v in "BUILD_SERVER=android" "BUILD_GRAPHICS=cairo"; do
+  grep -q "^$v\$" config.make || { echo "expected $v"; exit 1; }
+done
+
+say "libs-back build and install"
+make -j"$JOBS" > "$GS_BACK/android-build.log" 2>&1 || {
+  echo "build failed"; grep -E "error:" "$GS_BACK/android-build.log" | head -20
+  echo "--- last 25 lines of the build log"
+  tail -25 "$GS_BACK/android-build.log"; exit 1; }
+make install > "$GS_BACK/android-install.log" 2>&1 || {
+  echo "install failed"; tail -25 "$GS_BACK/android-install.log"; exit 1; }
+BUNDLE=$(find "$GSROOT" -maxdepth 6 -name 'libgnustep-back*.bundle' | head -1)
+[ -n "$BUNDLE" ] || { echo "libs-back installed no bundle under $GSROOT"; exit 1; }
+echo "    bundle: $BUNDLE"
+
+# The bundle must carry the android classes and none of the x11 or win32 ones.
+# Listing Source/cairo/obj says nothing: objects from an earlier configuration
+# stay behind there and are simply not linked.
+BIN=$(find "$BUNDLE" -maxdepth 1 -type f -name 'libgnustep-back*' | head -1)
+for c in AndroidServer AndroidCairoSurface; do
+  "$TOOLCHAIN/bin/llvm-nm" --defined-only "$BIN" 2>/dev/null | grep -q "$c\$" \
+    || { echo "$c is not in the bundle"; exit 1; }
+done
+for c in XGServer XGCairoSurface Win32CairoSurface; do
+  "$TOOLCHAIN/bin/llvm-nm" --defined-only "$BIN" 2>/dev/null | grep -q "$c\$" \
+    && { echo "$c should not be in an android bundle"; exit 1; }
+done
+echo "    bundle defines the android classes and no x11 or win32 ones"
+
+say "cross build complete"

--- a/.github/scripts/android/deps.sh
+++ b/.github/scripts/android/deps.sh
@@ -1,0 +1,436 @@
+#!/bin/bash
+#
+# Cross-build everything libs-gui needs on Android, into $GS_PREFIX.
+#
+# This is libs-base's dependency script with the four image libraries AppKit
+# uses added to it: libs-gui builds against libs-base, so both sets are needed.
+#
+# Every component is skipped if its output is already present, so a restored
+# cache short-circuits the whole script.  Versions are pinned: a CI that
+# follows upstream releases fails for reasons unrelated to libs-gui.
+#
+set -eu
+
+: "${ANDROID_NDK_HOME:?}"
+: "${GS_PREFIX:?}"
+: "${GS_API:=31}"
+: "${GS_ABI:=x86_64}"
+: "${GS_TRIPLE:=x86_64-linux-android}"
+GS_SRC="${GS_SRC:-$HOME/gs-src}"
+GS_DISPATCH_PREFIX="${GS_DISPATCH_PREFIX:-$GS_PREFIX/../dispatch-prefix}"
+
+TOOLCHAIN="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64"
+CCPREFIX="$TOOLCHAIN/bin/${GS_TRIPLE}${GS_API}"
+export PATH="$TOOLCHAIN/bin:$PATH"
+mkdir -p "$GS_SRC" "$GS_PREFIX" "$GS_DISPATCH_PREFIX"
+GS_DISPATCH_PREFIX=$(cd "$GS_DISPATCH_PREFIX" && pwd)
+
+JOBS=$(nproc)
+say() { echo "== $*"; }
+
+# fetch <url> [mirror ...] -> echoes the extracted source directory.
+#
+# A download that fails must fail HERE, naming the URL.  Letting it fall through
+# leaves tar reading a file that is not there and then ./configure missing,
+# which reports as exit 127 and says nothing about the real cause.  Mirrors are
+# tried in order: gmplib.org refuses connections from hosted runners often
+# enough to break an otherwise good run.
+fetch() {
+  local f d url got
+  f=$(basename "$1")
+  cd "$GS_SRC"
+  if [ ! -s "$f" ]; then
+    got=""
+    for url in "$@"; do
+      if curl -fsSL --connect-timeout 30 --retry 3 --retry-delay 5 \
+              -o "$f.part" "$url"; then
+        mv "$f.part" "$f"; got=$url; break
+      fi
+      echo "   download failed, trying the next source: $url" >&2
+      rm -f "$f.part"
+    done
+    [ -n "$got" ] || { echo "could not download $f from any source" >&2; return 1; }
+  fi
+  [ -s "$f" ] || { echo "$f downloaded empty" >&2; return 1; }
+  case "$f" in
+    *.tar.gz|*.tgz) d=$(tar tzf "$f" | head -1 | cut -d/ -f1) ;;
+    *)              d=$(tar tf  "$f" | head -1 | cut -d/ -f1) ;;
+  esac
+  [ -n "$d" ] || { echo "$f is not readable as an archive" >&2; return 1; }
+  [ -d "$d" ] || tar xf "$f"
+  echo "$GS_SRC/$d"
+}
+
+# ---------------------------------------------------------------- libobjc2
+if [ ! -f "$GS_PREFIX/lib/libobjc.so" ]; then
+  say "libobjc2"
+  [ -d "$GS_SRC/libobjc2" ] || git clone -q --depth 1 --recurse-submodules \
+    https://github.com/gnustep/libobjc2.git "$GS_SRC/libobjc2"
+  cmake -B "$GS_SRC/libobjc2/build" -S "$GS_SRC/libobjc2" -G Ninja \
+    -DCMAKE_TOOLCHAIN_FILE="$ANDROID_NDK_HOME/build/cmake/android.toolchain.cmake" \
+    -DANDROID_ABI="$GS_ABI" -DANDROID_PLATFORM="android-$GS_API" \
+    -DANDROID_STL=c++_shared -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX="$GS_PREFIX" \
+    -DGNUSTEP_INSTALL_TYPE=NONE \
+    -DTESTS=OFF -DCMAKE_FIND_USE_CMAKE_PATH=false \
+    -DCMAKE_C_COMPILER="$CCPREFIX-clang" \
+    -DCMAKE_CXX_COMPILER="$CCPREFIX-clang++" \
+    -DCMAKE_OBJC_COMPILER="$CCPREFIX-clang" \
+    -DCMAKE_OBJCXX_COMPILER="$CCPREFIX-clang++" >/dev/null
+  cmake --build "$GS_SRC/libobjc2/build" -j "$JOBS" >/dev/null
+  cmake --install "$GS_SRC/libobjc2/build" >/dev/null
+fi
+
+# ------------------------------------------------------------------ libffi
+if [ ! -f "$GS_PREFIX/lib/libffi.a" ] && [ ! -f "$GS_PREFIX/lib64/libffi.a" ]; then
+  say "libffi"
+  d=$(fetch https://github.com/libffi/libffi/releases/download/v3.5.2/libffi-3.5.2.tar.gz)
+  cd "$d" && ./configure --host="$GS_TRIPLE" --prefix="$GS_PREFIX" \
+    --disable-shared --enable-static --with-pic \
+    CC="$CCPREFIX-clang" >/dev/null
+  make -j"$JOBS" >/dev/null && make install >/dev/null
+fi
+
+# ----------------------------------------------------------------- libxml2
+if [ ! -f "$GS_PREFIX/lib/libxml2.a" ]; then
+  say "libxml2"
+  d=$(fetch https://download.gnome.org/sources/libxml2/2.15/libxml2-2.15.3.tar.xz)
+  cd "$d" && ./configure --host="$GS_TRIPLE" --prefix="$GS_PREFIX" \
+    --without-python --without-icu --without-lzma --without-zlib \
+    --disable-shared --enable-static --with-pic \
+    CC="$CCPREFIX-clang" >/dev/null
+  make -j"$JOBS" >/dev/null && make install >/dev/null
+fi
+
+# ---------------------------------------------------------------- libiconv
+# bionic's iconv is in libc but thin: 16 encodings against glibc's 68.
+if [ ! -f "$GS_PREFIX/lib/libiconv.so" ]; then
+  say "GNU libiconv"
+  d=$(fetch https://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.17.tar.gz)
+  cd "$d" && ./configure --host="$GS_TRIPLE" --prefix="$GS_PREFIX" \
+    --with-pic CC="$CCPREFIX-clang" >/dev/null
+  make -j"$JOBS" >/dev/null && make install >/dev/null
+fi
+
+# --------------------------------------------------------------------- ICU
+# The cross build runs the host's own data tools, so a native build first.
+if [ ! -f "$GS_PREFIX/lib/libicuuc.so" ]; then
+  say "ICU (native, for the cross build's tools)"
+  d=$(fetch https://github.com/unicode-org/icu/releases/download/release-74-2/icu4c-74_2-src.tgz)
+  ICUSRC="$d/source"
+  if [ ! -d "$GS_SRC/icu-native" ]; then
+    mkdir -p "$GS_SRC/icu-native"
+    cd "$GS_SRC/icu-native" && "$ICUSRC/runConfigureICU" Linux >/dev/null
+    make -j"$JOBS" >/dev/null
+  fi
+  say "ICU (cross)"
+  mkdir -p "$GS_SRC/icu-android"
+  cd "$GS_SRC/icu-android"
+  "$ICUSRC/configure" --host="$GS_TRIPLE" --prefix="$GS_PREFIX" \
+    --with-cross-build="$GS_SRC/icu-native" \
+    --disable-tests --disable-samples --disable-extras \
+    CC="$CCPREFIX-clang" CXX="$CCPREFIX-clang++" >/dev/null
+  make -j"$JOBS" >/dev/null && make install >/dev/null
+fi
+
+# ----------------------------------------------------------------- libcurl
+if [ ! -f "$GS_PREFIX/lib/libcurl.a" ]; then
+  say "libcurl"
+  d=$(fetch https://curl.se/download/curl-8.11.1.tar.xz)
+  cd "$d" && ./configure --host="$GS_TRIPLE" --prefix="$GS_PREFIX" \
+    --with-pic --disable-shared --enable-static \
+    --without-ssl --without-libpsl --without-brotli --without-zstd \
+    --without-nghttp2 --without-libidn2 --disable-ldap --disable-ldaps \
+    CC="$CCPREFIX-clang" AR="$TOOLCHAIN/bin/llvm-ar" \
+    RANLIB="$TOOLCHAIN/bin/llvm-ranlib" >/dev/null
+  make -j"$JOBS" >/dev/null && make install >/dev/null
+fi
+
+# ------------------------------------------------- shared flags from here on
+export CFLAGS="-fPIC -O2"
+export CPPFLAGS="-I$GS_PREFIX/include"
+export LDFLAGS="-L$GS_PREFIX/lib"
+export PKG_CONFIG_PATH="$GS_PREFIX/lib/pkgconfig"
+export PKG_CONFIG_LIBDIR="$GS_PREFIX/lib/pkgconfig"
+export CC="$CCPREFIX-clang" CXX="$CCPREFIX-clang++"
+export AR="$TOOLCHAIN/bin/llvm-ar" RANLIB="$TOOLCHAIN/bin/llvm-ranlib" \
+       NM="$TOOLCHAIN/bin/llvm-nm"
+
+# ------------------------------------------------- GMP, nettle, tasn1, TLS
+if [ ! -f "$GS_PREFIX/lib/libgmp.a" ]; then
+  say "GMP"
+  d=$(fetch https://ftp.gnu.org/gnu/gmp/gmp-6.3.0.tar.xz \
+            https://gmplib.org/download/gmp/gmp-6.3.0.tar.xz)
+  cd "$d" && ./configure --host="$GS_TRIPLE" --prefix="$GS_PREFIX" \
+    --disable-shared --enable-static --with-pic >/dev/null
+  make -j"$JOBS" >/dev/null && make install >/dev/null
+fi
+if [ ! -f "$GS_PREFIX/lib/libhogweed.a" ]; then
+  say "nettle"
+  d=$(fetch https://ftp.gnu.org/gnu/nettle/nettle-3.10.tar.gz)
+  cd "$d" && ./configure --host="$GS_TRIPLE" --prefix="$GS_PREFIX" \
+    --disable-shared --enable-static --disable-openssl --disable-documentation \
+    --with-include-path="$GS_PREFIX/include" --with-lib-path="$GS_PREFIX/lib" >/dev/null
+  make -j"$JOBS" >/dev/null && make install >/dev/null
+fi
+if [ ! -f "$GS_PREFIX/lib/libtasn1.a" ]; then
+  say "libtasn1"
+  d=$(fetch https://ftp.gnu.org/gnu/libtasn1/libtasn1-4.19.0.tar.gz)
+  cd "$d" && ./configure --host="$GS_TRIPLE" --prefix="$GS_PREFIX" \
+    --disable-shared --enable-static --with-pic --disable-doc >/dev/null
+  make -j"$JOBS" >/dev/null && make install >/dev/null
+fi
+if [ ! -f "$GS_PREFIX/lib/libgnutls.a" ]; then
+  say "GnuTLS"
+  d=$(fetch https://www.gnupg.org/ftp/gcrypt/gnutls/v3.8/gnutls-3.8.13.tar.xz)
+  cd "$d" && ./configure --host="$GS_TRIPLE" --prefix="$GS_PREFIX" \
+    --disable-shared --enable-static --with-pic \
+    --with-included-unistring --without-p11-kit --without-idn \
+    --without-tpm --without-tpm2 --disable-doc --disable-cxx \
+    --disable-tests --disable-guile --disable-libdane --disable-nls \
+    --with-default-trust-store-dir=/system/etc/security/cacerts/ >/dev/null
+  make -j"$JOBS" >/dev/null && make install >/dev/null
+fi
+
+# ---------------------------------------------------------------- libxslt
+if [ ! -f "$GS_PREFIX/lib/libxslt.a" ]; then
+  say "libxslt"
+  d=$(fetch https://download.gnome.org/sources/libxslt/1.1/libxslt-1.1.43.tar.xz)
+  cd "$d" && ./configure --host="$GS_TRIPLE" --prefix="$GS_PREFIX" \
+    --with-libxml-prefix="$GS_PREFIX" --without-python --without-crypto \
+    --without-debug --disable-shared --enable-static --with-pic >/dev/null
+  make -j"$JOBS" >/dev/null && make install >/dev/null
+fi
+
+# ======================= the image libraries AppKit uses =====================
+# zlib comes from the NDK sysroot and is not built here.
+
+# ------------------------------------------------------------------- libpng
+if [ ! -f "$GS_PREFIX/lib/libpng16.a" ]; then
+  say "libpng"
+  d=$(fetch https://download.sourceforge.net/libpng/libpng-1.6.44.tar.gz \
+            https://ftp-osl.osuosl.org/pub/libpng/src/libpng16/libpng-1.6.44.tar.gz)
+  cd "$d" && ./configure --host="$GS_TRIPLE" --prefix="$GS_PREFIX" \
+    --disable-shared --enable-static --with-pic >/dev/null
+  make -j"$JOBS" >/dev/null && make install >/dev/null
+fi
+
+# ------------------------------------------------------------ libjpeg-turbo
+# Built through its CMake path; the autotools path is not maintained upstream.
+if [ ! -f "$GS_PREFIX/lib/libjpeg.a" ]; then
+  say "libjpeg-turbo"
+  d=$(fetch https://github.com/libjpeg-turbo/libjpeg-turbo/releases/download/3.0.4/libjpeg-turbo-3.0.4.tar.gz)
+  cmake -B "$d/build" -S "$d" -G Ninja \
+    -DCMAKE_TOOLCHAIN_FILE="$ANDROID_NDK_HOME/build/cmake/android.toolchain.cmake" \
+    -DANDROID_ABI="$GS_ABI" -DANDROID_PLATFORM="android-$GS_API" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX="$GS_PREFIX" \
+    -DENABLE_SHARED=FALSE -DENABLE_STATIC=TRUE \
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON >/dev/null
+  cmake --build "$d/build" -j "$JOBS" >/dev/null
+  cmake --install "$d/build" >/dev/null
+fi
+
+# ------------------------------------------------------------------ libtiff
+# NSBitmapImageRep reads TIFF, so this is not optional in practice.  webp,
+# zstd and lzma are off: further cross builds for formats the tests do not
+# exercise.
+if [ ! -f "$GS_PREFIX/lib/libtiff.a" ]; then
+  say "libtiff"
+  d=$(fetch https://download.osgeo.org/libtiff/tiff-4.7.0.tar.gz)
+  cd "$d" && ./configure --host="$GS_TRIPLE" --prefix="$GS_PREFIX" \
+    --disable-shared --enable-static --with-pic \
+    --disable-webp --disable-zstd --disable-lzma \
+    --disable-tests --disable-tools --disable-docs >/dev/null
+  make -j"$JOBS" >/dev/null && make install >/dev/null
+fi
+
+# ------------------------------------------------------------------ giflib
+# No configure script upstream; drive the Makefile and install only the static
+# library and its header.  The `all` target builds utilities needing a host
+# compiler, which are not wanted here.
+if [ ! -f "$GS_PREFIX/lib/libgif.a" ]; then
+  say "giflib"
+  d=$(fetch https://download.sourceforge.net/giflib/giflib-5.2.2.tar.gz)
+  cd "$d"
+  make -j"$JOBS" libgif.a CC="$CC" CFLAGS="$CFLAGS -std=gnu99" >/dev/null
+  install -d "$GS_PREFIX/lib" "$GS_PREFIX/include"
+  install -m 644 libgif.a "$GS_PREFIX/lib/libgif.a"
+  install -m 644 gif_lib.h "$GS_PREFIX/include/gif_lib.h"
+fi
+
+# -------------------------------------------------------------- libdispatch
+# Its own prefix: it installs a Block.h that collides with libobjc2's.
+if [ ! -f "$GS_DISPATCH_PREFIX/lib/libdispatch.so" ]; then
+  say "libdispatch"
+  [ -d "$GS_SRC/libdispatch" ] || git clone -q --depth 1 \
+    https://github.com/swiftlang/swift-corelibs-libdispatch.git "$GS_SRC/libdispatch"
+  cmake -B "$GS_SRC/libdispatch/build" -S "$GS_SRC/libdispatch" -G Ninja \
+    -DCMAKE_TOOLCHAIN_FILE="$ANDROID_NDK_HOME/build/cmake/android.toolchain.cmake" \
+    -DANDROID_ABI="$GS_ABI" -DANDROID_PLATFORM="android-$GS_API" \
+    -DANDROID_STL=c++_shared -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX="$GS_DISPATCH_PREFIX" \
+    -DBUILD_SHARED_LIBS=YES -DENABLE_SWIFT=NO -DBUILD_TESTING=NO \
+    -DINSTALL_PRIVATE_HEADERS=YES -DCMAKE_FIND_USE_CMAKE_PATH=false >/dev/null
+  cmake --build "$GS_SRC/libdispatch/build" -j "$JOBS" >/dev/null
+  cmake --install "$GS_SRC/libdispatch/build" >/dev/null
+  # It leaves _Block_copy and friends undefined but still links its own
+  # BlocksRuntime, which duplicates libobjc2's.  Point it at libobjc2 instead.
+  patchelf --replace-needed libBlocksRuntime.so libobjc.so \
+    "$GS_DISPATCH_PREFIX/lib/libdispatch.so"
+fi
+
+# --------------------------------------------------------------------- zlib
+# zlib comes from the NDK sysroot and is not cross-built, but the NDK ships no
+# pkg-config file for it.  libpng16.pc says "Requires.private: zlib", so
+# without this every "pkg-config --exists libpng16" fails and freetype reports
+# "libpng support requested but library not found" while libpng16.a is present.
+if [ ! -f "$GS_PREFIX/lib/pkgconfig/zlib.pc" ]; then
+  say "zlib.pc for the NDK's zlib"
+  SYSROOT="$TOOLCHAIN/sysroot"
+  ZVER=$(sed -n 's/^#define ZLIB_VERSION "\([^"]*\)".*/\1/p' \
+           "$SYSROOT/usr/include/zlib.h" | head -1)
+  [ -n "$ZVER" ] || { echo "could not read ZLIB_VERSION from the NDK sysroot" >&2; exit 1; }
+  mkdir -p "$GS_PREFIX/lib/pkgconfig"
+  cat > "$GS_PREFIX/lib/pkgconfig/zlib.pc" <<EOF
+prefix=$SYSROOT/usr
+includedir=\${prefix}/include
+libdir=\${prefix}/lib/$GS_TRIPLE/$GS_API
+
+Name: zlib
+Description: zlib compression library, from the Android NDK sysroot
+Version: $ZVER
+Libs: -lz
+Cflags: -I\${includedir}
+EOF
+fi
+
+# -------------------------------------------------------------------- expat
+if [ ! -f "$GS_PREFIX/lib/libexpat.a" ]; then
+  say "expat"
+  d=$(fetch https://github.com/libexpat/libexpat/releases/download/R_2_6_4/expat-2.6.4.tar.xz)
+  cd "$d" && ./configure --host="$GS_TRIPLE" --prefix="$GS_PREFIX" \
+    --disable-shared --enable-static --with-pic \
+    --without-docbook --without-examples --without-tests \
+    CC="$CCPREFIX-clang" >/dev/null
+  make -j"$JOBS" >/dev/null && make install >/dev/null
+fi
+
+# ----------------------------------------------------------------- freetype
+# png is taken from the cross prefix on purpose: FT_Open_Face on an embedded
+# PNG bitmap is compiled out otherwise.  harfbuzz would drag in a C++ cross
+# build for no benefit here, and brotli only decodes WOFF2.
+if [ ! -f "$GS_PREFIX/lib/libfreetype.a" ]; then
+  say "freetype"
+  d=$(fetch https://download.savannah.gnu.org/releases/freetype/freetype-2.13.3.tar.xz)
+  cd "$d" && ./configure --host="$GS_TRIPLE" --prefix="$GS_PREFIX" \
+    --disable-shared --enable-static --with-pic \
+    --with-zlib=yes --with-png=yes \
+    --with-harfbuzz=no --with-brotli=no --with-bzip2=no \
+    CC="$CCPREFIX-clang" >/dev/null
+  make -j"$JOBS" >/dev/null && make install >/dev/null
+fi
+
+# --------------------------------------------------------------- fontconfig
+# --disable-cache-build: the install hook runs the freshly built fc-cache,
+# which is a TARGET binary here.  The config and cache directories compiled in
+# are the DEVICE's, so the install tries to create /data on the build host and
+# dies AFTER installing the library, leaving no fontconfig.pc; DESTDIR puts
+# that directory inside a staging tree instead.  The guard is on the .pc for
+# the same reason.
+if [ ! -f "$GS_PREFIX/lib/pkgconfig/fontconfig.pc" ]; then
+  say "fontconfig"
+  command -v gperf >/dev/null || { echo "gperf is required by fontconfig's configure" >&2; exit 1; }
+  d=$(fetch https://www.freedesktop.org/software/fontconfig/release/fontconfig-2.15.0.tar.xz)
+  cd "$d"
+  [ -f config.status ] || ./configure --host="$GS_TRIPLE" --prefix="$GS_PREFIX" \
+    --disable-shared --enable-static --with-pic \
+    --disable-docs --disable-cache-build --disable-nls \
+    --with-expat="$GS_PREFIX" \
+    --with-default-fonts=/system/fonts \
+    --with-cache-dir=/data/local/tests/fontconfig/cache \
+    --with-baseconfigdir=/data/local/tests/fontconfig \
+    CC="$CCPREFIX-clang" >/dev/null
+  make -j"$JOBS" >/dev/null
+  rm -rf "$GS_SRC/fc-stage"
+  make install DESTDIR="$GS_SRC/fc-stage" >/dev/null
+  cp -a "$GS_SRC/fc-stage$GS_PREFIX/." "$GS_PREFIX/"
+  [ -f "$GS_PREFIX/lib/pkgconfig/fontconfig.pc" ] \
+    || { echo "fontconfig installed no fontconfig.pc" >&2; exit 1; }
+fi
+
+# ------------------------------------------------------------------- pixman
+# 0.42.2 still ships autotools; 0.44 is meson-only.
+if [ ! -f "$GS_PREFIX/lib/libpixman-1.a" ]; then
+  say "pixman"
+  d=$(fetch https://www.x.org/releases/individual/lib/pixman-0.42.2.tar.xz)
+  cd "$d" && ./configure --host="$GS_TRIPLE" --prefix="$GS_PREFIX" \
+    --disable-shared --enable-static --with-pic \
+    --disable-gtk --disable-libpng \
+    CC="$CCPREFIX-clang" >/dev/null
+  make -j"$JOBS" >/dev/null && make install >/dev/null
+fi
+
+# -------------------------------------------------------------------- cairo
+# cairo 1.18.2 is meson-only; the last autotools cairo is 1.16.0, from 2018.
+# Every window-system backend is off: this build rasterises into an image
+# surface, and xlib or xcb would look for X headers Android does not have.
+# --wrap-mode=nofallback stops meson quietly building a bundled copy of a
+# dependency it cannot find.
+if [ ! -f "$GS_PREFIX/lib/libcairo.a" ]; then
+  say "cairo"
+  command -v meson >/dev/null || { echo "meson is required to build cairo" >&2; exit 1; }
+  # meson does not expand environment variables inside a cross file, so it is
+  # written here with the paths already substituted.  -lexpat is needed because
+  # fontconfig is static and meson resolves it with the non-static pkg-config
+  # line, which omits Libs.private; cairo's script utilities fail without it.
+  cat > "$GS_SRC/android.cross" <<EOF
+[binaries]
+c = '$CCPREFIX-clang'
+cpp = '$CCPREFIX-clang++'
+ar = '$TOOLCHAIN/bin/llvm-ar'
+strip = '$TOOLCHAIN/bin/llvm-strip'
+pkg-config = 'pkg-config'
+
+[built-in options]
+c_args = ['-fPIC', '-O2', '-I$GS_PREFIX/include']
+c_link_args = ['-L$GS_PREFIX/lib', '-lexpat']
+
+[properties]
+pkg_config_libdir = '$GS_PREFIX/lib/pkgconfig'
+needs_exe_wrapper = true
+
+[host_machine]
+system = 'android'
+cpu_family = 'x86_64'
+cpu = 'x86_64'
+endian = 'little'
+EOF
+  d=$(fetch https://www.cairographics.org/releases/cairo-1.18.2.tar.xz)
+  cd "$d"
+  rm -rf build-android
+  meson setup build-android \
+    --cross-file "$GS_SRC/android.cross" \
+    --prefix="$GS_PREFIX" \
+    --default-library=static \
+    --wrap-mode=nofallback \
+    -Dxlib=disabled -Dxcb=disabled -Dquartz=disabled -Dtee=disabled \
+    -Dglib=disabled -Dspectre=disabled -Dsymbol-lookup=disabled \
+    -Dgtk_doc=false -Dtests=disabled \
+    -Dfreetype=enabled -Dfontconfig=enabled -Dpng=enabled -Dzlib=enabled \
+    >/dev/null
+  ninja -C build-android >/dev/null
+  ninja -C build-android install >/dev/null
+fi
+
+# The cairo font path is not optional: CairoFaceInfo.m calls
+# cairo_ft_font_face_create_for_pattern, so a cairo built without FT_FONT
+# compiles the whole font layer out and the backend draws no text at all.
+for f in CAIRO_HAS_FT_FONT CAIRO_HAS_FC_FONT CAIRO_HAS_PNG_FUNCTIONS CAIRO_HAS_IMAGE_SURFACE; do
+  grep -q "^#define $f 1" "$GS_PREFIX/include/cairo/cairo-features.h" \
+    || { echo "$f is not set; the cairo build is not usable"; exit 1; }
+done
+say "cairo features checked"
+
+say "dependency prefix ready"
+ls "$GS_PREFIX/lib" | sed 's/^/    /'

--- a/.github/scripts/android/expected-failures.txt
+++ b/.github/scripts/android/expected-failures.txt
@@ -1,0 +1,16 @@
+# Tests that are known to fail on Android, one "directory/name" per line.
+#
+# An entry here is a claim that the failure is NOT the android backend's, and
+# it has to be justified by the x11+cairo result: a test that x11+cairo passes
+# and android+cairo fails is a defect to fix, not a line to add here.
+#
+# Two things belong in this file and nothing else does:
+#   - a failure x11+cairo also produces, with its counts quoted as evidence
+#   - a divergence that has been read and accepted
+#
+# In particular, do NOT regenerate this file from a red run. An executable that
+# prints nothing may be crashing, and listing a crash as expected is how a
+# suite goes green while proving less than it did before.
+#
+# The file is empty on purpose: the first Android run of libs-back's suite has
+# not been triaged yet, so nothing has earned a place in it.

--- a/.github/scripts/android/mkfontsconf.py
+++ b/.github/scripts/android/mkfontsconf.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""Generate a fonts.conf for Android from /system/etc/fonts.xml.
+
+Android ships the font files but not fontconfig, so nothing on the device maps
+a family name to a file.  fonts.xml carries exactly the two things fontconfig
+needs and cannot discover: which family is the default for a generic name
+(sans-serif, serif, monospace), and the alias set that maps the names
+applications actually ask for -- Helvetica, Arial, Times -- onto them.
+
+The font files themselves are left to fontconfig's own scan of /system/fonts.
+Writing them out here would freeze a list that changes with the platform.
+
+Usage: mkfontsconf.py <fonts.xml> <output fonts.conf> [font dir] [cache dir]
+"""
+import sys
+import xml.etree.ElementTree as ET
+
+HEADER = """<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
+<!-- Generated from Android's /system/etc/fonts.xml.  Do not edit by hand. -->
+<fontconfig>
+  <dir>{fontdir}</dir>
+  <cachedir>{cachedir}</cachedir>
+"""
+
+FOOTER = """  <config>
+    <rescan><int>30</int></rescan>
+  </config>
+</fontconfig>
+"""
+
+
+def escape(s):
+    return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def alias_element(name, target, indent="  "):
+    """A fontconfig alias: asking for `name` prefers `target`."""
+    return (
+        '{i}<alias binding="same">\n'
+        '{i}  <family>{n}</family>\n'
+        '{i}  <prefer><family>{t}</family></prefer>\n'
+        '{i}</alias>\n'.format(i=indent, n=escape(name), t=escape(target))
+    )
+
+
+# fontconfig's weight and slant scales are not OpenType's, and a scan match can
+# only name a const.  These are the values fontconfig's scanner assigns, so a
+# match keyed on them selects exactly one named instance of a variable font.
+FC_WEIGHT = {
+    "100": "thin", "200": "extralight", "300": "light", "400": "regular",
+    "500": "medium", "600": "demibold", "700": "bold", "800": "extrabold",
+    "900": "black",
+}
+FC_SLANT = {"normal": "roman", "italic": "italic"}
+
+# FC_WIDTH_NORMAL.  It is written as an integer rather than <const>normal</const>
+# because fontconfig's constant table is keyed by NAME alone: "normal" is also
+# the name of a weight, resolves to FC_WEIGHT_NORMAL (80), and a width test
+# against it matches nothing at all.  Measured on fontconfig 2.15: the const
+# form silently never fires, the integer form does.
+FC_WIDTH_NORMAL = 100
+
+
+def face_match(psname, families, filename, weight, style, width, indent="  "):
+    """Name one FACE: its PostScript name, and the families it belongs to.
+
+    The match cannot be keyed on the file alone.  Android's sans-serif keeps
+    weight 400 in RobotoStatic-Regular.ttf and every other weight and slant in
+    named instances of the ONE variable file Roboto-Regular.ttf, and a scan
+    match that tests only the file fires for all 37 of them -- so every
+    instance is given the same PostScript name, of which FCFontEnumerator keeps
+    the first it meets, and the face called Helvetica-Bold ends up being the
+    regular weight.  weight, slant and width are what tell the instances apart;
+    width has to be tested too, or the Condensed instances are named as well.
+
+    FCFontEnumerator names a FACE from FC_POSTSCRIPT_NAME (FCFontEnumerator.m:320)
+    and takes its FAMILY from element 0 of FC_FAMILY (FCFontEnumerator.m:371),
+    which is what a prepend supplies.  -availableFonts is built from the face
+    names and NSFont looks its defaults up there by name, so the name has to
+    reach the right face; the family has to be the AppKit family, or asking
+    fontconfig for that family's bold face finds nothing and falls back to the
+    regular one.
+    """
+    out = ['{i}<match target="scan">\n'
+           '{i}  <test name="file" compare="eq"><string>{f}</string></test>\n'
+           '{i}  <test name="weight" compare="eq"><const>{w}</const></test>\n'
+           '{i}  <test name="slant" compare="eq"><const>{s}</const></test>\n'
+           '{i}  <test name="width" compare="eq"><int>{d}</int></test>\n'
+           .format(i=indent, f=escape(filename), d=width,
+                   w=FC_WEIGHT[weight], s=FC_SLANT[style])]
+    if psname is not None:
+        out.append('{i}  <edit name="postscriptname" mode="assign">'
+                   '<string>{n}</string></edit>\n'
+                   .format(i=indent, n=escape(psname)))
+    for fam in families:
+        out.append('{i}  <edit name="family" mode="prepend">'
+                   '<string>{n}</string></edit>\n'
+                   .format(i=indent, n=escape(fam)))
+    out.append('{i}</match>\n'.format(i=indent))
+    return "".join(out)
+
+
+def face_width(font):
+    """The fontconfig width of a fonts.xml <font>, from its wdth axis.
+
+    A named instance of a variable font carries the axis value as its width;
+    everything else is normal.  Testing the wrong width means the match never
+    fires and the face silently keeps its own name.
+    """
+    for a in font.findall("axis"):
+        if a.get("tag") == "wdth":
+            try:
+                return int(float(a.get("stylevalue")))
+            except (TypeError, ValueError):
+                return FC_WIDTH_NORMAL
+    return FC_WIDTH_NORMAL
+
+
+# The PostScript names AppKit asks for by default, and the Android family and
+# face each should resolve to.  GNUstep's font roles default to Helvetica,
+# Helvetica-Bold and Courier (libs-gui Source/NSFont.m), and NSFont looks a
+# family up BY NAME in the enumerator's list -- an alias is not enough, because
+# no font file on the device carries any of these names.
+#
+# The AppKit family is carried as well as the PostScript name: the three roles
+# of a family have to sit in ONE family, or -defaultBoldSystemFontName, which
+# asks fontconfig for the bold face of the system font's family, finds only the
+# regular face and answers the system name back.
+#
+# (postscript name, AppKit family, android family, weight, style)
+APPKIT_NAMES = [
+    ("Helvetica",          "Helvetica", "sans-serif", "400", "normal"),
+    ("Helvetica-Bold",     "Helvetica", "sans-serif", "700", "normal"),
+    ("Helvetica-Oblique",  "Helvetica", "sans-serif", "400", "italic"),
+    ("Times-Roman",        "Times",     "serif",      "400", "normal"),
+    ("Times-Bold",         "Times",     "serif",      "700", "normal"),
+    ("Times-Italic",       "Times",     "serif",      "400", "italic"),
+    ("Courier",            "Courier",   "monospace",  "400", "normal"),
+    ("Courier-Bold",       "Courier",   "monospace",  "700", "normal"),
+]
+
+
+def faces_of(family, fontdir):
+    """Every face fonts.xml declares for a family, as (path, weight, style,
+    width) in declaration order.  Faces whose weight or style this script
+    cannot express as a fontconfig constant are dropped and reported, never
+    written out with a guessed value."""
+    out = []
+    skipped = []
+    for f in family.findall("font"):
+        name = (f.text or "").strip()
+        if not name:
+            continue
+        fw = f.get("weight")
+        fs = f.get("style", "normal")
+        if fw not in FC_WEIGHT or fs not in FC_SLANT:
+            skipped.append("%s %s/%s" % (name, fw, fs))
+            continue
+        out.append(("%s/%s" % (fontdir, name), fw, fs, face_width(f)))
+    return out, skipped
+
+
+def font_for(faces, weight, style):
+    """The face for a (weight, style), falling back to the regular one.
+
+    Returns (face, exact).  The face returned is the one that actually exists,
+    which is what a scan match has to test: asking for the 700 face of a family
+    that has none and then testing for weight 700 would match nothing at all.
+    """
+    fallback = None
+    for face in faces:
+        _, fw, fs, fd = face
+        if fw == weight and fs == style and fd == FC_WIDTH_NORMAL:
+            return face, True
+        if fw == "400" and fs == "normal" and fd == FC_WIDTH_NORMAL \
+                and fallback is None:
+            fallback = face
+    return fallback, False
+
+
+def main():
+    if len(sys.argv) < 3:
+        sys.stderr.write(__doc__)
+        return 2
+    src, dst = sys.argv[1], sys.argv[2]
+    fontdir = sys.argv[3] if len(sys.argv) > 3 else "/system/fonts"
+    cachedir = sys.argv[4] if len(sys.argv) > 4 else "/data/local/tests/fontconfig/cache"
+
+    root = ET.parse(src).getroot()
+
+    named = [f for f in root.findall("family") if f.get("name")]
+    if not named:
+        sys.stderr.write("%s declares no named family; refusing to write a "
+                         "configuration that would match nothing\n" % src)
+        return 1
+
+    aliases = []
+    for a in root.findall("alias"):
+        name, to = a.get("name"), a.get("to")
+        if name and to:
+            aliases.append((name, to))
+
+    default = named[0].get("name")
+
+    out = [HEADER.format(fontdir=escape(fontdir), cachedir=escape(cachedir))]
+
+    # Everything is written per FACE -- (file, weight, style, width) -- not per
+    # file.  Android's sans-serif keeps weight 400 in RobotoStatic-Regular.ttf
+    # and every other weight and slant in named instances of the ONE variable
+    # file Roboto-Regular.ttf, so a rule keyed on the file alone applies to all
+    # 37 of them at once.
+    faces = {}            # (path, weight, style, width) -> {ps, families}
+    order = []
+    inexact = []
+    unnamed = []
+    dropped = []
+
+    def face_entry(key):
+        if key not in faces:
+            faces[key] = {"ps": None, "families": []}
+            order.append(key)
+        return faces[key]
+
+    # A family name has to reach EVERY face fonts.xml declares for it, not just
+    # the regular one.  fontconfig scores the family before the weight, so a
+    # family carried by the regular face alone answers that face for a bold
+    # request -- which is how -defaultBoldSystemFontName came back with the
+    # system font's own name.
+    out.append("  <!-- the families fonts.xml names, over all their faces -->\n")
+    byfaces = {}
+    bound = 0
+    for fam in named:
+        fl, skipped = faces_of(fam, fontdir)
+        byfaces[fam.get("name")] = fl
+        dropped.extend(skipped)
+        for face in fl:
+            e = face_entry(face)
+            if fam.get("name") not in e["families"]:
+                e["families"].append(fam.get("name"))
+        if fl:
+            bound += 1
+
+    # The names AppKit asks for by default, bound onto real faces.  These are
+    # appended last so that the AppKit family, not the Android one, ends up as
+    # element 0 of the family list: prepends are emitted in order and the last
+    # one wins, and FCFontEnumerator takes the family from element 0.
+    appkit = 0
+    for ps, appfam, fam, weight, style in APPKIT_NAMES:
+        fl = byfaces.get(fam)
+        if not fl:
+            continue
+        face, exact = font_for(fl, weight, style)
+        if face is None:
+            continue
+        e = face_entry(face)
+        appkit += 1
+
+        # A face has exactly ONE PostScript name, so the first claimant keeps
+        # it.  Letting a later one overwrite would silently take the name away
+        # from the earlier, more important role.
+        if e["ps"] is None:
+            e["ps"] = ps
+        else:
+            unnamed.append("%s (%s %s/%s already carries the name %s)"
+                           % (ps, face[0].rsplit("/", 1)[-1], face[1], face[2],
+                              e["ps"]))
+
+        # The family list is multi-valued, so every name can be prepended.
+        if appfam not in e["families"]:
+            e["families"].append(appfam)
+
+        if not exact:
+            inexact.append("%s (no %s/%s face in %s)" % (ps, weight, style, fam))
+
+    for key in order:
+        path, fw, fs, fd = key
+        e = faces[key]
+        out.append(face_match(e["ps"], e["families"], path, fw, fs, fd))
+
+    out.append("  <!-- %d aliases from fonts.xml -->\n" % len(aliases))
+    for name, to in aliases:
+        out.append(alias_element(name, to))
+
+    generics = ("sans-serif", "sans", "serif", "monospace", "system-ui")
+    names = [f.get("name") for f in named]
+    missing = [g for g in generics if g not in names]
+    out.append("  <!-- generic families not named in fonts.xml, defaulting to "
+               "%s -->\n" % default)
+    for g in missing:
+        out.append(alias_element(g, default))
+
+    out.append(FOOTER)
+
+    with open(dst, "w") as fh:
+        fh.write("".join(out))
+
+    sys.stderr.write("%s: %d named families (%d with faces, %d faces in all), "
+                     "%d AppKit names, %d aliases, %d generic fallbacks -> %s\n"
+                     % (src, len(named), bound, len(order), appkit,
+                        len(aliases), len(missing), dst))
+    # Substitutions are reported rather than hidden: a name bound to the
+    # regular face when a bold one was asked for will render at the wrong
+    # weight, and that is a real limitation of the device's font set.
+    for line in inexact:
+        sys.stderr.write("  substituted the regular face for %s\n" % line)
+    for line in unnamed:
+        sys.stderr.write("  no PostScript name for %s\n" % line)
+    for line in dropped:
+        sys.stderr.write("  no fontconfig constant for %s; face left alone\n"
+                         % line)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/android/tests.sh
+++ b/.github/scripts/android/tests.sh
@@ -1,0 +1,237 @@
+#!/bin/bash
+#
+# Build and run libs-back's tests on the Android emulator.
+#
+# Each test .m is compiled directly with clang rather than through
+# gnustep-make: the test directories carry no GNUmakefile of their own,
+# gnustep-tests instantiates one from a template at run time, and driving
+# gnustep-make per set does not cross compile.  This mirrors what libs-base's
+# Android runner does.
+#
+# Everything runs under /data/local/tests.  Its shell_test_data_file label is
+# what lets the shell domain create files and sockets, and it is writable
+# without disabling SELinux.
+#
+set -u
+
+: "${ANDROID_NDK_HOME:?}"
+: "${GS_PREFIX:?}"
+: "${GS_BACK:?}"
+: "${GS_API:=31}"
+: "${GS_TRIPLE:=x86_64-linux-android}"
+GS_DISPATCH_PREFIX="${GS_DISPATCH_PREFIX:-$GS_PREFIX/../dispatch-prefix}"
+GS_DISPATCH_PREFIX=$(cd "$GS_DISPATCH_PREFIX" && pwd)
+GSROOT="$GS_PREFIX/gnustep"
+GS_WORK="${GS_WORK:-$HOME/gs-run}"
+GS_TIMEOUT="${GS_TIMEOUT:-120}"
+
+TOOLCHAIN="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64"
+CCPREFIX="$TOOLCHAIN/bin/${GS_TRIPLE}${GS_API}"
+
+# The cairo a test compiles against is the cross-built one, so pkg-config is
+# pointed at its .pc files, as back.sh points it.  LIBDIR replaces the default
+# search path rather than adding to it, which stops a host cairo answering for
+# the target.  Unset, pkg-config answers nothing at all here: cairo.h is then
+# absent from the include path and every test that includes it fails to build
+# while the rest of the suite compiles and runs.
+export PKG_CONFIG_PATH="$GS_PREFIX/lib/pkgconfig"
+export PKG_CONFIG_LIBDIR="$GS_PREFIX/lib/pkgconfig"
+
+TF=$(find "$GSROOT" -type d -name TestFramework | head -1)
+[ -n "$TF" ] || { echo "no TestFramework under $GSROOT"; exit 1; }
+
+EXPECTED="$GS_BACK/.github/scripts/android/expected-failures.txt"
+
+DEV=/data/local/tests/gsback
+ROOT=/data/local/tests/gsroot
+UHOME=/data/local/tests/gshome
+TMP=/data/local/tests/gstmp
+CONF=$ROOT/etc/GNUstep/GNUstep.conf
+W="$GS_WORK"
+
+say() { echo "== $*"; }
+
+# tools-make installs either the GNUstep layout ($GSROOT/Local/Library/...) or
+# the FHS one ($GSROOT/lib, $GSROOT/include), depending on how it was
+# configured.  Find what was installed rather than assuming a path.
+BASELIB=$(find "$GSROOT" -name 'libgnustep-base.so' 2>/dev/null | head -1)
+[ -n "$BASELIB" ] || { echo "no libgnustep-base.so under $GSROOT"; exit 1; }
+BASELIBDIR=$(dirname "$BASELIB")
+FOUNDATION_H=$(find "$GSROOT" -path '*/Foundation/NSObject.h' 2>/dev/null | head -1)
+[ -n "$FOUNDATION_H" ] || { echo "no Foundation headers under $GSROOT"; exit 1; }
+BASEINC=$(dirname "$(dirname "$FOUNDATION_H")")
+GUILIB=$(find "$GSROOT" -name 'libgnustep-gui.so' 2>/dev/null | head -1)
+[ -n "$GUILIB" ] || { echo "no libgnustep-gui.so under $GSROOT"; exit 1; }
+GUILIBDIR=$(dirname "$GUILIB")
+echo "  gui library:  $GUILIBDIR"
+echo "  base library: $BASELIBDIR"
+echo "  base headers: $BASEINC"
+
+INC="-I$GS_BACK/Headers -I$GS_BACK/Source -I$TF -I$GS_PREFIX/include \
+ -I$BASEINC -I$GS_DISPATCH_PREFIX/include \
+ -I$GS_BACK/Tests $(pkg-config --cflags cairo)"
+LIBS="-L$GUILIBDIR -lgnustep-gui \
+ -L$BASELIBDIR -lgnustep-base \
+ -L$GS_PREFIX/lib $(pkg-config --static --libs cairo) \
+ -lobjc -licuuc -licui18n -licudata -liconv \
+ -L$GS_DISPATCH_PREFIX/lib -ldispatch -lm"
+FLAGS="-fobjc-runtime=gnustep-2.2 -fblocks -fexceptions -DGNUSTEP \
+ -DGNUSTEP_BASE_LIBRARY=1 -Wno-deprecated-declarations -Wno-objc-method-access"
+
+adb wait-for-device
+adb shell 'echo device ready; id' </dev/null
+
+say "the device screen"
+SCREEN=$(adb shell wm size | sed -n 's/.*: *\([0-9]*x[0-9]*\).*/\1/p' | tr -d '\r')
+[ -n "$SCREEN" ] || { echo "wm size reported no screen size"; exit 1; }
+echo "  screen: $SCREEN"
+
+say "fonts.conf from the device's own fonts.xml"
+FCDIR=/data/local/tests/fontconfig
+mkdir -p "$W"
+adb pull /system/etc/fonts.xml "$W/fonts.xml" >/dev/null 2>&1 </dev/null
+[ -s "$W/fonts.xml" ] || { echo "could not read /system/etc/fonts.xml"; exit 1; }
+python3 "$GS_BACK/.github/scripts/android/mkfontsconf.py" \
+  "$W/fonts.xml" "$W/fonts.conf" || exit 1
+# The cache is discarded, not reused: scan rules are not re-applied to a cache
+# built before them, so a stale one silently keeps the old bindings.
+adb shell "rm -rf $FCDIR/cache; mkdir -p $FCDIR/cache; chmod 777 $FCDIR/cache" \
+  >/dev/null 2>&1 </dev/null
+adb push "$W/fonts.conf" "$FCDIR/fonts.conf" >/dev/null 2>&1 </dev/null
+
+say "preparing the device"
+adb shell "rm -rf $DEV" >/dev/null 2>&1 </dev/null
+adb shell "mkdir -p $DEV $UHOME/GNUstep/Defaults $TMP && chmod 777 $TMP" \
+  >/dev/null 2>&1 </dev/null
+
+rm -rf "$W"; mkdir -p "$W"
+cp "$GUILIBDIR"/libgnustep-gui.so.*.* "$W/" 2>/dev/null
+cp "$BASELIBDIR"/libgnustep-base.so.* "$W/" 2>/dev/null
+cp "$GS_PREFIX/lib/libobjc.so" "$W/"
+cp "$TOOLCHAIN/sysroot/usr/lib/$GS_TRIPLE/libc++_shared.so" "$W/" 2>/dev/null
+cp "$GS_PREFIX"/lib/libicu*.so* "$W/" 2>/dev/null
+cp "$GS_PREFIX"/lib/libiconv*.so* "$W/" 2>/dev/null
+cp "$GS_DISPATCH_PREFIX/lib/libdispatch.so" "$W/" 2>/dev/null
+
+say "compiling the tests"
+NB=0; OK=0
+: > "$W/nobuild.txt"
+for d in "$GS_BACK"/Tests/*/; do
+  n=$(basename "$d")
+  ls "$d"*.m >/dev/null 2>&1 || continue
+  mkdir -p "$W/$n"
+  find "$d" -maxdepth 1 -type f -exec cp {} "$W/$n/" \; 2>/dev/null
+  sed -e 's/@TESTNAMES@//; s^@TESTOPTS@^^; s/@TESTRULES@//' \
+    "$TF/GNUmakefile.in" > "$W/$n/GNUmakefile" 2>/dev/null
+  for sub in "$d"*/; do
+    [ -d "$sub" ] || continue
+    case "$(basename "$sub")" in obj|derived_src) continue ;; esac
+    cp -rL "$sub" "$W/$n/" 2>/dev/null
+  done
+  for f in "$d"*.m; do
+    b=$(basename "$f" .m)
+    if $CCPREFIX-clang $FLAGS $INC -I"$d" -o "$W/$n/$b" "$f" $LIBS \
+         > "$W/cc-$n-$b.log" 2>&1; then
+      OK=$((OK+1))
+    else
+      NB=$((NB+1)); echo "$n/$b" >> "$W/nobuild.txt"; rm -f "$W/$n/$b"
+    fi
+  done
+done
+say "compiled $OK executables, $NB did not build"
+[ "$NB" -eq 0 ] || sed 's/^/    /' "$W/nobuild.txt"
+
+say "deploying"
+adb push "$W"/. $DEV >/dev/null 2>&1 </dev/null
+SO=$(basename "$(ls "$GUILIBDIR"/libgnustep-gui.so.*.* 2>/dev/null | head -1)")
+BSO=$(basename "$(ls "$BASELIBDIR"/libgnustep-base.so.*.* 2>/dev/null | head -1)")
+adb shell "cd $DEV && ln -sf $SO libgnustep-gui.so && ln -sf $SO ${SO%.*} && \
+  ln -sf $BSO libgnustep-base.so && ln -sf $BSO ${BSO%.*}" >/dev/null 2>&1 </dev/null
+
+# A real GNUstep tree, so the backend bundle and the plist DTD resolve.
+GT="$W/gsroot"; cp -rL "$GSROOT" "$GT" 2>/dev/null
+sed "s|$GSROOT|$ROOT|g" "$GSROOT/etc/GNUstep/GNUstep.conf" \
+  > "$GT/etc/GNUstep/GNUstep.conf" 2>/dev/null
+adb shell "mkdir -p $ROOT" >/dev/null 2>&1 </dev/null
+adb push "$GT"/. $ROOT >/dev/null 2>&1 </dev/null
+# base discards a config file that is group or world writable, and adb push
+# creates 0666.
+# GSAndroidScreenSize travels in GNUstep.conf: NSUserDefaults reads it
+# into GSConfigDomain, which is in the search list and works on Android,
+# unlike NSArgumentDomain, which is empty there.  GNUSTEP_EXTRA declares
+# the key, or base reports "Configuration contains unknown keys".
+adb shell "printf '\\nGNUSTEP_EXTRA=GSAndroidScreenSize\\nGSAndroidScreenSize=%s\\n' $SCREEN >> $CONF"
+adb shell "chmod 644 $CONF" >/dev/null 2>&1 </dev/null
+adb shell "chmod -R 755 $ROOT/bin $ROOT/Local/Tools 2>/dev/null; true" \
+  >/dev/null 2>&1 </dev/null
+
+say "running"
+RES="$W/results.txt"; : > "$RES"
+: > "$W/noresult.txt"; : > "$W/unexpected.txt"
+EMPTY=0
+for d in "$GS_BACK"/Tests/*/; do
+  n=$(basename "$d")
+  [ -d "$W/$n" ] || continue
+  for f in "$W/$n"/*; do
+    b=$(basename "$f")
+    # a directory passes [ -x ]: .gorm, .nib and dummy are bundle-style DATA
+    [ -f "$f" ] && [ -x "$f" ] || continue
+    case "$b" in *.m|*.h|GNUmakefile*|obj) continue ;; esac
+    out=$(adb shell "cd $DEV/$n && LD_LIBRARY_PATH=$DEV \
+      GNUSTEP_CONFIG_FILE=$CONF HOME=$UHOME TMPDIR=$TMP FONTCONFIG_FILE=$FCDIR/fonts.conf \
+      timeout -s KILL $GS_TIMEOUT ./$b 2>&1; echo RC=\$?" </dev/null | tr -d '\r')
+    p=$(printf '%s\n' "$out" | grep -c '^Passed test')
+    fl=$(printf '%s\n' "$out" | grep -c '^Failed test')
+    h=$(printf '%s\n' "$out" | grep -c '^Dashed hope')
+    # a guarded set that skips is a RESULT, not a silent gap
+    sk=$(printf '%s\n' "$out" | grep -c '^Skipped set')
+    echo "$n/$b passed=$p failed=$fl hopes=$h skipped=$sk" >> "$RES"
+    if [ "$p" -eq 0 ] && [ "$fl" -eq 0 ] && [ "$sk" -eq 0 ]; then
+      EMPTY=$((EMPTY+1))
+      # Record WHY. An executable that says nothing may have been killed by the
+      # timeout, aborted, or died before its first assertion, and those need
+      # different fixes. Naming it without its exit status and last output
+      # gives nobody enough to act on.
+      rc=$(printf '%s\n' "$out" | sed -n 's/^RC=//p' | tail -1)
+      case "$rc" in
+        137) why="killed by the ${GS_TIMEOUT}s timeout" ;;
+        139) why="segmentation fault" ;;
+        134) why="aborted" ;;
+        0)   why="exited 0 without running an assertion" ;;
+        *)   why="exit ${rc:-unknown}" ;;
+      esac
+      {
+        echo "$n/$b: $why"
+        printf '%s\n' "$out" | grep -v '^RC=' | tail -4 | sed 's/^/      /'
+      } >> "$W/noresult.txt"
+    fi
+    if [ "$fl" -gt 0 ] && ! grep -qx "$n/$b" "$EXPECTED" 2>/dev/null; then
+      echo "$n/$b" >> "$W/unexpected.txt"
+    fi
+  done
+done
+
+say "totals"
+awk '{for(i=1;i<=NF;i++){if($i~/^passed=/){split($i,a,"=");P+=a[2]}
+                         if($i~/^failed=/){split($i,b,"=");F+=b[2]}
+                         if($i~/^hopes=/){split($i,c,"=");H+=c[2]}
+                         if($i~/^skipped=/){split($i,d,"=");K+=d[2]}}}
+     END{printf "  %d passed, %d failed, %d dashed hopes, %d skipped sets\n",P,F,H,K}' "$RES"
+echo "  $NB did not build, $EMPTY produced no result"
+
+RC=0
+if [ -s "$W/unexpected.txt" ]; then
+  echo "== failures that are NOT in expected-failures.txt"
+  sed 's/^/    /' "$W/unexpected.txt"
+  RC=1
+fi
+if [ "$EMPTY" -gt 0 ]; then
+  echo "== executables that produced no result at all"
+  sed 's/^/    /' "$W/noresult.txt"
+  RC=1
+fi
+if [ "$NB" -gt 0 ]; then
+  echo "== executables that did not build"
+  RC=1
+fi
+exit $RC

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,167 @@
+name: Android
+
+on:
+  push:
+    branches: [ master, 'ci/**' ]
+  pull_request:
+  workflow_dispatch:
+
+# A newer push on the same ref supersedes the run already going for it, and
+# nothing cancels that run without this. An Android run is ten minutes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  android:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - api-level: 31
+            abi: x86_64
+            triple: x86_64-linux-android
+    runs-on: ubuntu-24.04
+    name: Android ${{ matrix.abi }} API-${{ matrix.api-level }}
+    env:
+      GS_PREFIX: ${{ github.workspace }}/android-prefix
+      GS_DISPATCH_PREFIX: ${{ github.workspace }}/dispatch-prefix
+      GS_SRC: ${{ github.workspace }}/gs-src
+      GS_BASE: ${{ github.workspace }}/libs-base
+      GS_GUI: ${{ github.workspace }}/libs-gui
+      GS_BACK: ${{ github.workspace }}/libs-back
+      GS_WORK: ${{ github.workspace }}/gs-run
+      GS_API: ${{ matrix.api-level }}
+      GS_ABI: ${{ matrix.abi }}
+      GS_TRIPLE: ${{ matrix.triple }}
+    steps:
+    - uses: actions/checkout@v5
+      with:
+        path: libs-back
+
+    # Source/GNUmakefile.preamble links -lgnustep-gui, so the build order is
+    # base, then gui, then back. Both are checked out at master rather than
+    # cloned in the script, so the run records exactly what was built against.
+    - uses: actions/checkout@v5
+      with:
+        repository: gnustep/libs-base
+        path: libs-base
+
+    - uses: actions/checkout@v5
+      with:
+        repository: gnustep/libs-gui
+        path: libs-gui
+
+    - name: Install host packages
+      run: |
+        sudo apt-get update -y
+        # gnustep-base-runtime supplies plmerge, pl2link and defaults, which
+        # run on the build machine while everything else is cross compiled.
+        # gperf is required by fontconfig's configure, and meson by cairo
+        # 1.18, which ships no autotools build at all.
+        sudo apt-get install -y ninja-build meson gperf patchelf \
+          gnustep-base-runtime autoconf automake libtool pkg-config
+
+    - name: Enable KVM
+      run: |
+        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+          | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+        sudo udevadm control --reload-rules
+        sudo udevadm trigger --name-match=kvm
+
+    - name: Restore the dependency cache
+      id: deps-cache
+      uses: actions/cache/restore@v5
+      with:
+        path: |
+          ${{ github.workspace }}/android-prefix
+          ${{ github.workspace }}/dispatch-prefix
+        key: android-deps-${{ matrix.abi }}-${{ matrix.api-level }}-${{ hashFiles('libs-back/.github/scripts/android/deps.sh') }}
+
+    - name: Cross-build the dependencies
+      if: steps.deps-cache.outputs.cache-hit != 'true'
+      run: libs-back/.github/scripts/android/deps.sh
+
+    # Saved even when a later step fails, so a broken test run does not cost
+    # a full dependency rebuild on the next attempt.
+    - name: Save the dependency cache
+      if: always() && steps.deps-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v5
+      with:
+        path: |
+          ${{ github.workspace }}/android-prefix
+          ${{ github.workspace }}/dispatch-prefix
+        key: ${{ steps.deps-cache.outputs.cache-primary-key }}
+
+    - name: Cross-build base, gui and the android backend
+      run: libs-back/.github/scripts/android/back.sh
+
+    # Creating the AVD costs 83 to 90 seconds; restoring it costs 19 to 33.
+    # It depends on the image, not on anything in this repository, so the key
+    # is the ABI and the API level alone.
+    - name: Restore the AVD cache
+      id: avd-cache
+      uses: actions/cache/restore@v5
+      with:
+        path: |
+          ~/.android/avd/*
+          ~/.android/adb*
+        key: avd-${{ matrix.abi }}-${{ matrix.api-level }}
+
+    - name: Create the AVD snapshot
+      if: steps.avd-cache.outputs.cache-hit != 'true'
+      uses: reactivecircus/android-emulator-runner@v2
+      with:
+        api-level: ${{ matrix.api-level }}
+        arch: ${{ matrix.abi }}
+        target: default
+        force-avd-creation: false
+        emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+        disable-animations: true
+        script: echo "AVD snapshot created."
+
+    # Saved as its own step, for the reason the dependency cache above is:
+    # actions/cache writes nothing from a post step when the job has failed, so
+    # a red suite would leave the AVD to be created again on every later run.
+    # The image is saved as created, before the suite has run against it.
+    - name: Save the AVD cache
+      if: steps.avd-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v5
+      with:
+        path: |
+          ~/.android/avd/*
+          ~/.android/adb*
+        key: ${{ steps.avd-cache.outputs.cache-primary-key }}
+
+    # -no-snapshot-save keeps the emulator from writing a snapshot as it shuts
+    # down, which would both cost time and rewrite the AVD the cache holds.
+    - name: Run the test suite
+      uses: reactivecircus/android-emulator-runner@v2
+      with:
+        api-level: ${{ matrix.api-level }}
+        arch: ${{ matrix.abi }}
+        target: default
+        force-avd-creation: false
+        emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+        disable-animations: true
+        script: libs-back/.github/scripts/android/tests.sh
+
+    # The counts and the build logs, kept whatever the run concluded: a red run
+    # is the one whose logs are wanted, and the step that fails prints a tail
+    # rather than the whole of the log it was reading.
+    - name: Upload the run log
+      if: always()
+      uses: actions/upload-artifact@v6
+      with:
+        name: android-test-log-api${{ matrix.api-level }}
+        path: |
+          gs-run/results.txt
+          gs-run/unexpected.txt
+          gs-run/noresult.txt
+          gs-run/nobuild.txt
+          gs-run/cc-*.log
+          gs-src/tools-make-configure.log
+          libs-base/android-*.log
+          libs-gui/android-*.log
+          libs-back/android-*.log
+        if-no-files-found: warn


### PR DESCRIPTION
libs-back is built and tested only on the systems it already runs on. This workflow cross-compiles the dependencies, tools-make, libs-base, libs-gui and libs-back for x86_64-linux-android at API 31 and runs Tests on an emulator.

The dependencies are cached on the hash of deps.sh, so the 9 minutes they take are paid only when it changes. tests.sh compiles each test, stages every library under the soname the loader asks for, deploys a GNUstep tree the bundle can be found in, and reads the result against expected-failures.txt.

The emulator image is cached on the ABI and the API level: creating it costs 86 to 116 seconds and restoring it 15. It is saved by a step of its own, since actions/cache writes nothing when the job has failed. A concurrency block cancels a run a newer push has superseded.

pkg-config is pointed at the cross prefix. Unset, it answers nothing on a runner with no host cairo, and every test including cairo.h fails to build while the rest reports healthy counts.

Measured against a branch carrying the android server: 286 assertions passed, 0 failed, nothing unbuilt, in about 4 minutes.
