### PR TITLE
CI: cancel a run that a newer push has superseded

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,12 @@ on:
         default: "master"
         required: true
 
+# A run whose ref has been pushed again is answering a question about a tree
+# nobody is waiting on, and nothing cancels it without this.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ########### Linux ###########
   linux:


### PR DESCRIPTION
main.yml runs on push and on pull_request and has no concurrency block, so a second push to a branch leaves the first run going. It answers a question about a tree nobody is waiting on, and nothing cancels it.

Over the last 90 days 49 of libs-back's 357 workflow runs were superseded while still running, 229 of 1736 wall-clock minutes. Taken from the Actions API over that window, counting a run as superseded when a later run for the same workflow and ref started before it finished.

The group is the workflow and the ref, so a run on one branch never cancels a run on another, and a push to master never cancels a pull request. A superseded run reports as cancelled rather than as a failure.

libs-base carries the same block, added in gnustep/libs-base#746.
